### PR TITLE
Copy: Remove ko-fi. Add X/Twitter, Instagram, or email

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,5 @@ rm kanji-heatmap-data.tar.gz
 ## Talk to Us
 
 - [Discord](https://discord.gg/Ash8ZrGb4s)
-- [Ko-Fi](https://ko-fi.com/minimithi")
+- [X/Twitter](https://x.com/pikapikagemsjp)
+- [Instagram](https://www.instagram.com/pikapikagems)

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,8 +1,8 @@
 # Privacy Policy
 
-_Last Updated: March 24, 2025_
+_Last Updated: December 12, 2025_
 
-[PikaPikaGems](https://github.com/PikaPikaGems) operates kanjiheatmap.com (the “Site”). This Privacy Policy explains how we handle information related to your use of the Site.
+[PikaPikaGems Pte Ltd](https://github.com/PikaPikaGems) operates kanjiheatmap.com (the “Site”). This Privacy Policy explains how we handle information related to your use of the Site.
 
 ## Information We Collect
 
@@ -38,6 +38,6 @@ We may update this Privacy Policy from time to time. If we do, the updated versi
 
 If you have questions about this Privacy Policy, feel free to reach out:
 
-- [KoFi](https://ko-fi.com/minimithi)
+- privacy@pikapikagems.com
 - [Discord](https://discord.gg/Ash8ZrGb4s)
 - [GitHub](https://github.com/PikaPikaGems/kanji-heatmap/issues)

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -1,6 +1,6 @@
 # Terms of Use
 
-_Last Updated: March 24, 2025_
+_Last Updated: December 12, 2025_
 
 By using kanjiheatmap.com (the “Site”), you agree to these Terms of Use and our [Privacy Policy](#).
 
@@ -28,6 +28,6 @@ We may update these Terms of Use at any time. Changes will be posted here with a
 
 Questions? Reach out at:
 
-- [KoFi](https://ko-fi.com/minimithi)
+- admin@pikapikagems.com
 - [Discord](https://discord.gg/Ash8ZrGb4s)
 - [GitHub](https://github.com/PikaPikaGems/kanji-heatmap/issues)

--- a/src/components/common/docs/CustomLink.tsx
+++ b/src/components/common/docs/CustomLink.tsx
@@ -17,3 +17,14 @@ export function CustomLink({ href, children }: CustomLinkProps) {
     </a>
   );
 }
+
+export function CustomMailLink({ email }: { email: string }) {
+  return (
+    <a
+      href={`mailto:${email}`}
+      className="underline font-bold hover:bg-[#2effff] hover:text-black rounded-md p-1"
+    >
+      {email}
+    </a>
+  );
+}

--- a/src/components/error/common.tsx
+++ b/src/components/error/common.tsx
@@ -42,8 +42,8 @@ export const ReachOutToUs = ({
       {SHOW_TWITTER && (
         <ExternalTextLink href={outLinks.twitter} text="Twitter," />
       )}
-      <ExternalTextLink href={outLinks.githubIssue} text="GitHub," /> or
-      <ExternalTextLink href={outLinks.koFi} text="Ko-Fi." />
+      or
+      <ExternalTextLink href={outLinks.githubIssue} text="GitHub." />
     </>
   );
 };

--- a/src/components/items/links-out-items.tsx
+++ b/src/components/items/links-out-items.tsx
@@ -1,5 +1,5 @@
 import { outLinks } from "@/lib/external-links";
-import { BugIcon, KoFiIcon, DiscordIcon } from "../icons";
+import { BugIcon, DiscordIcon } from "../icons";
 import { BirdIcon } from "lucide-react";
 
 const bugItem = {
@@ -14,12 +14,6 @@ const discordItem = {
   icon: <DiscordIcon />,
 };
 
-const kofiItem = {
-  href: outLinks.koFi,
-  text: "Motivate us with a Ko-Fi ☕🧋🍵",
-  icon: <KoFiIcon />,
-};
-
 export const twitterItem = {
   href: outLinks.twitter,
   text: "Follow us on X/Twitter",
@@ -29,7 +23,6 @@ export const twitterItem = {
 const linksOutItems = {
   bugItem,
   discordItem,
-  kofiItem,
   twitterItem,
 };
 

--- a/src/components/screens/DocsScreen/PrivacySection.tsx
+++ b/src/components/screens/DocsScreen/PrivacySection.tsx
@@ -1,4 +1,4 @@
-import { CustomLink } from "@/components/common/docs/CustomLink";
+import { CustomLink, CustomMailLink } from "@/components/common/docs/CustomLink";
 
 export const PrivacyPolicySection = ({ title }: { title: string }) => {
   return (
@@ -7,12 +7,12 @@ export const PrivacyPolicySection = ({ title }: { title: string }) => {
         {title}
       </h1>
       <p className="text-sm text-muted-foreground italic mb-6">
-        <em>Last Updated: March 24, 2025</em>
+        <em>Last Updated: December 12, 2025</em>
       </p>
 
       <p className="leading-7 mb-4">
         <CustomLink href="https://github.com/PikaPikaGems">
-          PikaPikaGems
+          PikaPikaGems Pte Ltd
         </CustomLink>{" "}
         operates kanjiheatmap.com (the {`"Site"`}). This Privacy Policy explains
         how we handle information related to your use of the Site.
@@ -115,7 +115,7 @@ export const PrivacyPolicySection = ({ title }: { title: string }) => {
 
       <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
         <li>
-          <CustomLink href="https://ko-fi.com/minimithi">KoFi</CustomLink>
+          <CustomMailLink email="privacy@pikapikagems.com"/>
         </li>
         <li>
           <CustomLink href="https://discord.gg/Ash8ZrGb4s">Discord</CustomLink>

--- a/src/components/screens/DocsScreen/TermsOfUseSection.tsx
+++ b/src/components/screens/DocsScreen/TermsOfUseSection.tsx
@@ -1,4 +1,4 @@
-import { CustomLink } from "@/components/common/docs/CustomLink";
+import { CustomLink, CustomMailLink } from "@/components/common/docs/CustomLink";
 
 export const TermsOfUseSection = ({ title }: { title: string }) => {
   return (
@@ -8,7 +8,7 @@ export const TermsOfUseSection = ({ title }: { title: string }) => {
       </h1>
       <div>
         <p className="text-sm text-muted-foreground italic mb-6">
-          <em>Last Updated: March 24, 2025</em>
+          <em>Last Updated: December 12, 2025</em>
         </p>
 
         <p className="leading-7 mb-4">
@@ -73,7 +73,7 @@ export const TermsOfUseSection = ({ title }: { title: string }) => {
 
         <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
           <li>
-            <CustomLink href="https://ko-fi.com/minimithi">KoFi</CustomLink>
+            <CustomMailLink email="admin@pikapikagems.com"/>
           </li>
           <li>
             <CustomLink href="https://discord.gg/Ash8ZrGb4s">

--- a/src/components/site-layout/BottomBanner.tsx
+++ b/src/components/site-layout/BottomBanner.tsx
@@ -30,8 +30,8 @@ export const SocialLinksCTA = () => {
   return (
     <>
       {"(◠_◠)"} Say hi on
-      <ExternalTextLink href={outLinks.koFi} text={"Ko-Fi,"} />
       <ExternalTextLink href={outLinks.discord} text="Discord," />
+      <ExternalTextLink href={outLinks.twitter} text="X/Twitter," />
       or
       <ExternalTextLink href={outLinks.githubIssue} text={"GitHub"} />
       {"👋"}

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -164,7 +164,6 @@ export const outLinks = {
   githubIssue: "https://github.com/PikaPikaGems/kanji-heatmap/issues/63",
   githubContentIssue:
     "https://github.com/PikaPikaGems/kanji-heatmap-data/issues/5",
-  koFi: "https://ko-fi.com/minimithi",
   discord: "https://discord.gg/Ash8ZrGb4s",
   ririkku: `https://ririkku.com/?utm_source=kanjiheatmap`,
   twitter: "https://x.com/pikapikagemsJP",


### PR DESCRIPTION
Remove Ko-fi link, but add other links:
* README - add X, Instagram
* Privacy - add privacy email
* Terms of Use - add admin email
* Common - just remove ko-fi, no replacement
* links-out-items (icon links) - just remove ko-fi, no replacement

Also, update company name in privacy and TOS.
