### PR TITLE
Polish search UX, similar kanji, stroke animation, and Speed Katakana

### DIFF
--- a/src/components/error/NoSearchResults.tsx
+++ b/src/components/error/NoSearchResults.tsx
@@ -18,14 +18,18 @@ export const NonIdealResultText = () => {
 export const NoSearchResults = () => {
   return (
     <Wrapper>
-      <Sumimasen />
-      <div className="my-2 font-bold">
-        <span>No Kanji match your search.</span>
-        <br />
-        <ClearFiltersCTA />
-      </div>
 
-      <NonIdealResultText />
+      <div className="my-6 animate-fade-in">
+
+        <Sumimasen />
+        <div className="my-2 font-bold">
+          <span>No Kanji match your search.</span>
+          <br />
+          <ClearFiltersCTA />
+        </div>
+
+        <NonIdealResultText />
+      </div>
     </Wrapper>
   );
 };

--- a/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
@@ -3,7 +3,6 @@ import { useLocalStorage } from "@/hooks/use-local-storage";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { DualRangeSlider } from "@/components/ui/dual-range-slider";
 import { FreqCategory, freqCategoryCn } from "@/lib/freq/freq-category";
 import { SoundMode, SpeedKatakanaSettings, WordCount } from "./types";
 import { readSetStats } from "./storage";
@@ -58,6 +57,8 @@ const RadioRow = ({
 
 const SetStats = ({ challengeSet }: { challengeSet: number }) => {
   const currentStats = useMemo(() => readSetStats(challengeSet), [challengeSet]);
+  const level = levelOf(challengeSet);
+  const pos = positionInLevel(challengeSet);
   const stats = currentStats ?
     {
       timesTaken: currentStats.timesTaken,
@@ -76,7 +77,9 @@ const SetStats = ({ challengeSet }: { challengeSet: number }) => {
 
   return (
     <div className="flex flex-wrap gap-2 text-xs font-bold text-left min-h-10">
-      <div>Challenge # {challengeSet}:</div>
+      <div>
+        Challenge {level}-{pos} (#{challengeSet}):
+      </div>
       <div>
         {stats.timesTaken}{" "}
         {stats.timesTaken === 1 ? "attempt" : "attempts"}
@@ -177,7 +180,7 @@ export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
 
           <div className="flex flex-col">
             <div className="flex items-center justify-between gap-4">
-              <Label className="text-sm">Long Session (48 words)</Label>
+              <Label className="text-sm">Full Session (48 words)</Label>
               <Switch
                 aria-label="Words per round"
                 checked={settings.wordCount === 48}
@@ -188,7 +191,7 @@ export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
             </div>
             {settings.wordCount !== 48 && (
               <p className="w-full text-xs text-left animate-fade-in-fast">
-                ⚠️ Short sessions will not be recorded.
+                ⚠️ Practice sessions (24 words) will not be recorded.
               </p>
             )}
           </div>
@@ -263,15 +266,31 @@ export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
             </div>
             <Label className="text-sm text-left">Select a Challenge</Label>
 
-            <DualRangeSlider
-              value={[currentPos]}
-              min={1}
-              max={CHALLENGES_PER_LEVEL}
-              step={1}
-              onValueChange={(value) =>
-                setSetting("challengeSet", setFromLevelAndPos(currentLevel, value[0]))
-              }
-            />
+            <div className="grid grid-cols-10 gap-1">
+              {Array.from({ length: CHALLENGES_PER_LEVEL }, (_, i) => i + 1).map(
+                (pos) => {
+                  const setNum = setFromLevelAndPos(currentLevel, pos);
+                  const completed = !!readSetStats(setNum);
+                  const bgCn = completed
+                    ? freqCategoryCn[4]
+                    : freqCategoryCn[0];
+                  const textCn = completed
+                    ? "text-white"
+                    : "text-foreground";
+                  return (
+                    <button
+                      key={pos}
+                      onClick={() => setSetting("challengeSet", setNum)}
+                      className={`py-1 ${bgCn} ${textCn} hover:opacity-80 text-xs rounded font-bold transition-colors border-2 ${
+                        currentPos === pos ? "border-primary" : ""
+                      }`}
+                    >
+                      {pos}
+                    </button>
+                  );
+                }
+              )}
+            </div>
 
             <p className="text-xs text-left">
               Lower challenges contain more common words.

--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -22,6 +22,7 @@ import { DebugInfo } from "@/components/common/DebugInfo";
 import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
 import { useKanjiRepresentativeWord } from "@/providers/kanji-representative-word-provider";
 import { KanjiWordStatusActions } from "./KanjiWordStatusActions";
+import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
 
 
 export const RirikkuCTABadge = () => {
@@ -82,11 +83,35 @@ const StrokeAnimationLoadingScreen = () => {
           <div className="w-24 h-3 rounded-lg bg-muted animate-pulse" />
         </div>
       </div>
-      <div className="flex justify-center w-full my-4">
-        <div className="relative overflow-hidden rounded-3xl bg-muted animate-pulse" style={{ width: 280, height: 280 }}>
-          <svg width="280" height="280" className="absolute inset-0 text-foreground opacity-10" aria-hidden>
-            <line x1="140" y1="0" x2="140" y2="280" stroke="currentColor" strokeWidth="1" strokeDasharray="5 5" />
-            <line x1="0" y1="140" x2="280" y2="140" stroke="currentColor" strokeWidth="1" strokeDasharray="5 5" />
+      <div className={CONTAINER_CN} style={{ height: SVG_SIZE }}>
+        <div
+          className="relative overflow-hidden rounded-3xl bg-muted animate-pulse"
+          style={{ width: SVG_SIZE, height: SVG_SIZE }}
+        >
+          <svg
+            width={SVG_SIZE}
+            height={SVG_SIZE}
+            className="absolute inset-0 text-foreground opacity-10"
+            aria-hidden
+          >
+            <line
+              x1={SVG_SIZE / 2}
+              y1={0}
+              x2={SVG_SIZE / 2}
+              y2={SVG_SIZE}
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeDasharray="5 5"
+            />
+            <line
+              x1={0}
+              y1={SVG_SIZE / 2}
+              x2={SVG_SIZE}
+              y2={SVG_SIZE / 2}
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeDasharray="5 5"
+            />
           </svg>
         </div>
       </div>

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -8,6 +8,7 @@ import assetsPaths from "@/lib/assets-paths";
 import { installSafeDmakLoader } from "@/lib/dmak-safe-loader";
 import { PlayCircle, Snail } from "@/components/icons";
 import { DrawingPad } from "@/components/dependent/DrawingPad";
+import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
 
 // Stock dmak crashes on null kvg: root — install our guarded loader once.
 installSafeDmakLoader();
@@ -18,9 +19,6 @@ const SPEEDS: Record<AnimationSpeed, { rate: number }> = {
   fast: { rate: 0.0095 },
   slow: { rate: 0.022 },
 };
-
-const SVG_SIZE = 280;
-const CONTAINER_CN = `flex w-full justify-center my-4 h-[${SVG_SIZE}px]`;
 
 const KanjiDMAK = ({
   kanji,

--- a/src/components/sections/KanjiDetails/StructureInfo.tsx
+++ b/src/components/sections/KanjiDetails/StructureInfo.tsx
@@ -11,10 +11,8 @@ import { ReactNode } from "react";
 import { PrimaryDataSources } from "@/components/common/PrimaryDataSources";
 import { OriginalKanjiComponentBreakdown } from "./OriginalComponentBreakdown";
 import {
-    useGetKanjiInfoFn,
     useSimilarKanjis,
 } from "@/kanji-worker/kanji-worker-hooks";
-import { GlobalKanjiLink } from "@/components/dependent/routing";
 
 const TableCellFixed = ({
     children,
@@ -34,7 +32,6 @@ const TableCellGrow = ({ children }: { children: ReactNode }) => (
 
 const SimilarKanjis = ({ kanji }: { kanji: string }) => {
     const similar = useSimilarKanjis(kanji);
-    const getKanjiInfo = useGetKanjiInfoFn();
     const similars = similar.data ?? [];
     const showEmpty = similar.status !== "loading" && similars.length === 0;
 
@@ -46,11 +43,7 @@ const SimilarKanjis = ({ kanji }: { kanji: string }) => {
                 <div className="flex items-center min-w-0 space-x-2 overflow-x-auto overflow-y-hidden">
                     {similars.map((similarKanji) => (
                         <div key={similarKanji} className="shrink-0">
-                            <GlobalKanjiLink
-                                fontSize="text-6xl"
-                                kanji={similarKanji}
-                                keyword={getKanjiInfo?.(similarKanji)?.keyword ?? "..."}
-                            />
+                            <OriginalKanjiComponentBreakdown kanji={similarKanji} />
                         </div>
                     ))}
                 </div>

--- a/src/components/sections/KanjiDetails/stroke-animation-constants.ts
+++ b/src/components/sections/KanjiDetails/stroke-animation-constants.ts
@@ -1,0 +1,2 @@
+export const SVG_SIZE = 310;
+export const CONTAINER_CN = `flex w-full justify-center my-4 h-[${SVG_SIZE}px]`;

--- a/src/lib/search-input-maps.ts
+++ b/src/lib/search-input-maps.ts
@@ -15,14 +15,14 @@ export const translateMap: Record<SearchType, TranslateType> = {
 };
 
 export const placeholderMap: Record<SearchType, string> = {
-  keyword: "Keyword Search",
-  onyomi: "オンヨミ 検索",
-  kunyomi: "くんよみ 検索",
-  meanings: `e.g. "world" or "person"`,
-  readings: "Any Kun or On Reading",
-  "multi-kanji": "e.g paste 鼻詰まり ",
-  similar: "paste a single kanji here",
-  radicals: "Click to open radical selection",
+  keyword: "Enter an English keyword...",
+  onyomi: "音読みを入力... (例: シン)", // Standardized to Kanji + localized helper text
+  kunyomi: "訓読みを入力... (例: こころ)", // Standardized to Kanji + localized helper text
+  meanings: "Enter meanings (e.g., world, person)...",
+  readings: "Enter any On or Kun reading...",
+  "multi-kanji": "Paste multiple kanji (e.g., 鼻詰まり)...",
+  similar: "Paste a single kanji to find similar shapes...",
+  radicals: "Click to select one or more radicals",
   handwriting: "Click to draw a kanji",
   "handwriting-alt": "Click to draw a kanji (offline)",
 };
@@ -40,5 +40,5 @@ export const SEARCH_TYPE_OPTIONS: {
   { value: "readings", label: "Readings" },
   { value: "onyomi", label: "音読み" },
   { value: "kunyomi", label: "訓読み" },
-  { value: "similar", label: "Similar" },
+  { value: "similar", label: "Similar Shapes" },
 ];


### PR DESCRIPTION
## Summary
- Clarify search placeholders/labels and polish empty-results spacing; show similar kanji via component breakdown cards
- Keep stroke animation loading skeleton sized in sync with the rendered SVG
- Improve Speed Katakana challenge picking with completion-aware buttons, clearer session labels, and level-position challenge IDs

## Test plan
- [ ] Try each search type and confirm placeholders read clearly; verify Similar Shapes works and empty results look spaced correctly
- [ ] Open a kanji’s Structure section and confirm similar kanji render as component breakdown cards
- [ ] Open Stroke Animation and confirm the loading skeleton matches the final animation size (no layout jump)
- [ ] On Speed Katakana initial screen: pick challenges via the 1–10 buttons, confirm completed ones are highlighted, stats show `Challenge L-P (#N)`, and Full/Practice session copy is clear


Made with [Cursor](https://cursor.com)