### PR TITLE
Nudge home practice FAB 5px left

### DIFF
--- a/src/components/screens/ListScreen/PracticeFab.tsx
+++ b/src/components/screens/ListScreen/PracticeFab.tsx
@@ -100,7 +100,7 @@ export const PracticeFab = () => {
           size="icon"
           variant={hasBgMeaning ? "secondary" : "primary"}
           className={cn(
-            "fixed z-40 rounded-full h-[5rem] w-[5rem] p-6 border-b-[8px] active:translate-y-[5px] active:border-b-[3px] [&_svg]:size-10 right-[0.35rem] bottom-[calc(1rem+env(safe-area-inset-bottom))]",
+            "fixed z-40 rounded-full h-[5rem] w-[5rem] p-6 border-b-[8px] active:translate-y-[5px] active:border-b-[3px] [&_svg]:size-10 right-[calc(0.35rem+5px)] bottom-[calc(1rem+env(safe-area-inset-bottom))]",
             hasBgMeaning && "border-foreground/40"
           )}
           aria-label="Open practice menu"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move the bottom-right practice FAB on `/` about 5px left by increasing its right offset from `0.35rem` to `calc(0.35rem + 5px)`.

## Test plan
- [ ] Open `/` and confirm the practice button in the bottom-right sits slightly farther from the right edge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f61e7-80eb-766a-9fc3-caad865d0066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f61e7-80eb-766a-9fc3-caad865d0066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

