### PR TITLE
Align practice link icons with their titles

### DIFF
--- a/src/components/common/DashedNavLink.tsx
+++ b/src/components/common/DashedNavLink.tsx
@@ -42,9 +42,9 @@ export const DashedNavLink = forwardRef<HTMLAnchorElement, DashedNavLinkProps>(
         )}
         {...rest}
       >
-        <div className="flex items-start text-sm font-semibold text-left">
+        <div className="flex items-center text-sm font-semibold text-left">
           {Icon && (
-            <Icon className={cn("mt-1 mr-2 size-4 shrink-0", iconClassName)} />
+            <Icon className={cn("mr-2 size-4 shrink-0", iconClassName)} />
           )}
           {title}
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the top margin on `DashedNavLink` icons and vertically center them with the title text.
- Fixes the Kanji Recognition / Speed Katakana practice menu links looking shifted down relative to their labels.

## Test plan
- [ ] Open the practice FAB on `/` and confirm the Eye and Keyboard icons sit level with “Kanji Recognition” and “Speed Katakana”.
- [ ] Spot-check header nav links that also use `DashedNavLink` still look aligned.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f61e7-80eb-766a-9fc3-caad865d0066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f61e7-80eb-766a-9fc3-caad865d0066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

