### PR TITLE
Tighten recognition layout and stop keyboard viewport bob

### DIFF
--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -143,25 +143,24 @@ export const Game = ({
   };
 
   return (
-    <div className="flex flex-col w-full h-full gap-5 animate-fade-in [@media(pointer:fine)]:justify-center [@media(pointer:fine)]:gap-8 md:justify-center md:gap-8 [@media(min-height:900px)]:justify-center [@media(min-height:900px)]:gap-8">
+    <div className="relative flex flex-col w-full h-full gap-5 [@media(pointer:fine)]:justify-center [@media(pointer:fine)]:gap-8 md:justify-center md:gap-8 [@media(min-height:900px)]:justify-center [@media(min-height:900px)]:gap-8">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute z-10 top-0 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
+        tabIndex={-1}
+        onClick={onEnd}
+        aria-label="End session"
+      >
+        <CircleArrowLeft />
+      </Button>
+
       {/*
         Touch layout: keep the prompt + input as a top-anchored cluster with a
         fixed gap. A bottom spacer absorbs visual-viewport height changes so
         the keyboard opening/closing does not shove content around.
       */}
-      <div className="flex flex-col items-center shrink-0 gap-3 px-4 pt-2 text-center [@media(pointer:fine)]:pt-8 md:pt-8 [@media(min-height:900px)]:pt-8">
-        <div className="flex items-center justify-center [@media(pointer:fine)]:translate-y-4 md:translate-y-4">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
-            tabIndex={-1}
-            onClick={onEnd}
-            aria-label="End session"
-          >
-            <CircleArrowLeft />
-          </Button>
-        </div>
+      <div className="flex flex-col items-center shrink-0 gap-3 px-4 pt-3 text-center [@media(pointer:fine)]:pt-8 md:pt-8 [@media(min-height:900px)]:pt-8">
         <div
           className={current.fontIndex === null ? "kanji-font" : undefined}
           style={
@@ -206,7 +205,7 @@ export const Game = ({
               spellCheck={false}
               aria-label='Type the reading or type "forgot"'
               placeholder='Type the reading or type "forgot"'
-              className="relative w-full text-center border-2 rounded-2xl h-14 kanji-font"
+              className="relative w-full text-center border-2 rounded-2xl h-14 kanji-font focus-visible:ring-offset-0"
               onKeyDown={handleKeyDown}
               onCompositionStart={() => {
                 isComposingRef.current = true;

--- a/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
+++ b/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
@@ -44,6 +44,26 @@ const RecognitionPracticeV1 = () => {
     }
   }, [phase, setOpenedKanji]);
 
+  // Keep the play shell pinned to the layout top. Chasing visualViewport.offsetTop
+  // while iOS animates the keyboard makes the whole UI bob; "/" doesn't do that
+  // because ListScreen isn't viewport-pinned at all.
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const lockScroll = () => {
+      if (window.scrollY !== 0) window.scrollTo(0, 0);
+    };
+
+    vv.addEventListener("scroll", lockScroll);
+    vv.addEventListener("resize", lockScroll);
+    lockScroll();
+    return () => {
+      vv.removeEventListener("scroll", lockScroll);
+      vv.removeEventListener("resize", lockScroll);
+    };
+  }, []);
+
   const beginPlaying = (items: PracticeItem[], nextCursor: number) => {
     setSessionItems(items);
     setCursor(nextCursor);
@@ -126,11 +146,15 @@ const RecognitionPracticeV1 = () => {
         autoComplete="off"
       />
       <div
-        className="fixed inset-x-0 flex flex-col overflow-hidden bg-background"
-        style={{ top: viewport.offsetTop, height: viewport.height }}
+        className="fixed inset-x-0 top-0 flex flex-col overflow-hidden bg-background"
+        style={{ height: viewport.height }}
       >
         <PracticeHeader progress={progress} />
-        <main className="flex-1 min-h-0 py-2 overflow-hidden">
+        <main
+          className={`flex-1 min-h-0 overflow-hidden ${
+            phase === "playing" ? "pt-0 pb-2" : "py-2"
+          }`}
+        >
           {phase === "initial" && (
             <div key="initial" className="h-full animate-fade-in">
               <InitialScreen onStart={startGame} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Absolutely position the end-session control at the top-left under the header so it no longer consumes vertical space.
- Reduce the Japanese word’s top padding to `12px` (`pt-3`) during play.
- Stop chasing `visualViewport.offsetTop` when the keyboard opens (keep the shell at `top: 0`, lock scroll, drop input ring-offset). That chase is what made the UI bob; `/` doesn’t do it because ListScreen isn’t viewport-pinned.

## Why `/` doesn’t bob
The home search field lives in normal document flow. Recognition pins its whole play shell to the visual viewport height/`offsetTop`, so focusing the input made React re-layout through the keyboard animation. This PR keeps height tracking (so the input stays above the keyboard) but stops the vertical offset chase.

## Test plan
- [ ] Start Kanji Recognition on a phone: end-session icon sits top-left under the header and does not push the word down.
- [ ] Word sits close under the header (~12px).
- [ ] Tap the answer input to open the keyboard: content should stay put instead of bouncing.
- [ ] Confirm the input still remains usable above the keyboard.
- [ ] Spot-check desktop layout still centers cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f61e7-80eb-766a-9fc3-caad865d0066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f61e7-80eb-766a-9fc3-caad865d0066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

