### PR TITLE
Polish practice UX, search IME switching, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,41 @@ If you have both [Kanji Heatmap Data](https://github.com/PikaPikaGems/kanji-heat
 cp ../kanji-heatmap-data/output/*.json ./public/json
 ```
 
-### Regenerating structure and reading files
+### Regenerating derived JSON
 
-The following files in `public/json/` are generated from raw sources in `raw-data/` and filtered to the kanji in `public/json/filtered_kanji.json`:
+`pnpm run build` regenerates derived JSON before compiling and bundling:
 
-- `kanji-structure-filtered-hlorenzi.json`
-- `kanji-readings-details-filtered.json`
-- `kanji-structure-kanjium.json`
-- `scott-components.json`
-- `yagays-components.json`
+```
+node scripts/generate-more-info.mjs && node scripts/generate-speed-katakana.mjs && tsc -b && vite build
+```
 
-To regenerate them:
+You can also run the generators on their own:
 
 ```
 pnpm run generate-more-info
+pnpm run generate-speed-katakana
+```
+
+#### Structure and reading files
+
+These files in `public/json/` are generated from raw sources in `raw-data/` and filtered to the kanji in `public/json/filtered_kanji.json`:
+
+- `kanji-structure-hlorenzi.json`
+- `kanji-readings-details.json`
+- `kanji-structure-kanjium.json`
+- `kanji-structure-scott.json`
+- `kanji-structure-yagays.json`
+
+```
+pnpm run generate-more-info
+```
+
+#### Speed Katakana challenge sets
+
+The `/speed-katakana` game loads word lists from `public/json/katakana/challenge-set-<N>.json`, generated from `raw-data/katakana-kore.txt` (48 words per set, ordered by frequency).
+
+```
+pnpm run generate-speed-katakana
 ```
 
 ## Build Analysis
@@ -96,19 +117,25 @@ Uncompress and store the json files in `./public/json`
 tar -xzf ./kanji-heatmap-data.tar.gz -C ./public/json/
 ```
 
-You should have the following files updated
+You should have the following files updated (among others from the release)
 
 ```
 ls -la public/json
 
-    1759 component_keyword.json
-    2118 cum_use.json
-  369264 kanji_extended.json
-  284376 kanji_main.json
-    2187 phonetic.json
-  200687 vocab_furigana.json
-  191712 vocab_meaning.json
+    component_keyword.json
+    cum_use.json
+    extra_kanji_keyword.json
+    filtered_kanji.json
+    kanji_extended.json
+    kanji_main.json
+    kanji_representative_words.json
+    phonetic.json
+    similar-kanjis.json
+    vocab_furigana.json
+    vocab_meaning.json
 ```
+
+Derived files (`kanji-structure-*.json`, `kanji-readings-details.json`, `katakana/`) are produced by the generators above, not by this tarball.
 
 Delete the `tar.gz` file since it's not needed anymore
 

--- a/src/components/dependent/DrawingPad.tsx
+++ b/src/components/dependent/DrawingPad.tsx
@@ -192,6 +192,7 @@ export const DrawingPad = ({
             <div className="flex justify-center mt-2 space-x-2">
                 <PracticeButton
                     size="icon"
+                    variant="secondary"
                     onClick={() => setStrokes((s) => s.slice(0, -1))}
                     disabled={strokes.length === 0}
                 >

--- a/src/components/dependent/routing/global-links.tsx
+++ b/src/components/dependent/routing/global-links.tsx
@@ -4,6 +4,31 @@ import { useKanjiFromUrl, useUrlLocation } from "./routing-hooks";
 import { Link } from "./router-adapter";
 import { radicalFalseFriends } from "@/lib/radicals";
 
+export const ComponentLink = ({
+  component,
+  keyword,
+  title,
+  type
+}: {
+  component: string;
+  keyword: string;
+  title?: string;
+  type: 'kanji' | 'radical' | 'unknown'
+}) => {
+
+  return (
+    <div className="flex flex-col text-center w-fit ">
+      {type === 'kanji' ?
+        <GlobalKanjiLink kanji={component} keyword={keyword} /> : type === "radical" ?
+          <GlobalRadicalLink radical={component} keyword={keyword} /> : <FakeComponentLink radical={component} keyword={keyword} />
+      }
+      {title && <div className="text-[10px] uppercase opacity-70">{title}</div>}
+    </div>
+  )
+
+
+};
+
 type FontSize = 'text-xl' | 'text-2xl' | 'text-3xl' | 'text-4xl' | 'text-5xl' | 'text-6xl' | 'text-7xl' | 'text-8xl' | 'text-9xl' | 'text-10xl';
 
 const cnJPCard = "flex flex-col m-1 p-1 text-xl rounded-md";

--- a/src/components/recognition-practice-v1/AnswerFeedback.tsx
+++ b/src/components/recognition-practice-v1/AnswerFeedback.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { RomajiBadge } from "@/components/dependent/kana/RomajiBadge";
 import { SpeakButton } from "@/components/common/SpeakButton";
-import { pickCorrectCheer, pickForgotCheer } from "@/lib/practice-cheers";
 
 /** Inline answer reveal shown in place of the input controls. */
 export const AnswerFeedback = ({
   correct,
   reading,
   word,
-  englishGloss,
   onNext,
 }: {
   correct: boolean;
@@ -22,10 +20,6 @@ export const AnswerFeedback = ({
     .split("・")
     .map((r) => r.trim())
     .filter(Boolean);
-
-  const [cheer] = useState(() =>
-    correct ? pickCorrectCheer() : pickForgotCheer()
-  );
 
   useEffect(() => {
     // Don't treat the Enter that opened feedback as "Continue".
@@ -59,26 +53,13 @@ export const AnswerFeedback = ({
       aria-live="polite"
       aria-label={correct ? "Correct" : "Forgot"}
     >
-      <p
-        key={cheer}
-        className={`animate-practice-bounce-soft text-lg font-bold tracking-wide kanji-font animate-practice-pop ${
-          correct ? "text-green-500" : "text-muted-foreground"
-        }`}
-      >
-        {correct ? "🥳" : ""} {cheer}
-      </p>
       <div className="flex flex-wrap items-center justify-center gap-1">
+        <p >{correct ? "🎉 ·" : ""}</p>
         <SpeakButton word={word} iconType="volume-2" />
         {readings.map((r) => (
           <RomajiBadge key={r} kana={r} />
         ))}
-        <p className="text-xl font-bold kanji-font">· {word}</p>
       </div>
-      {englishGloss && englishGloss.length > 0 ? (
-        <p className="max-w-sm text-sm text-center text-muted-foreground">
-          {englishGloss}
-        </p>
-      ) : null}
       <PracticeButton size="lg" className="max-w-xs" onClick={onNext}>
         Continue
       </PracticeButton>

--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -147,49 +147,45 @@ export const Game = ({
       <Button
         variant="ghost"
         size="icon"
-        className="absolute z-10 top-0 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
+        className="absolute z-10 top-1 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
         tabIndex={-1}
         onClick={onEnd}
         aria-label="End session"
       >
         <CircleArrowLeft />
       </Button>
-
       {/*
         Touch layout: keep the prompt + input as a top-anchored cluster with a
         fixed gap. A bottom spacer absorbs visual-viewport height changes so
         the keyboard opening/closing does not shove content around.
       */}
-      <div className="flex flex-col items-center shrink-0 gap-3 px-4 pt-3 text-center [@media(pointer:fine)]:pt-8 md:pt-8 [@media(min-height:900px)]:pt-8">
+      <div className="flex flex-col items-center shrink-0 px-4 pt-8 text-center [@media(pointer:fine)]:pt-8 md:pt-8 [@media(min-height:900px)]:pt-8">
         <div
           className={current.fontIndex === null ? "kanji-font" : undefined}
           style={
             current.fontIndex === null
               ? undefined
               : {
-                  fontFamily: `var(--jap-font-${current.fontIndex}), "Noto Sans JP", system-ui`,
-                }
+                fontFamily: `var(--jap-font-${current.fontIndex}), "Noto Sans JP", system-ui`,
+              }
           }
         >
-          <p className="text-6xl leading-tight break-all md:text-8xl whitespace-nowrap">
+          <p className={`${current.word.length > 4 ? "text-6xl" : current.word.length < 2 ? "text-8xl" : "text-7xl"} leading-tight break-all md:text-8xl whitespace-nowrap`}>
             {current.word}
           </p>
         </div>
 
-        {feedback == null ? (
-          <button
-            type="button"
-            className={`max-w-sm px-2 py-1 text-xs font-bold tracking-wide transition-all outline-none focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0 ${
-              glossBlurred ? "blur-[5px] hover:blur-none" : ""
+        <button
+          type="button"
+          className={`max-w-sm px-2 text-xs font-bold tracking-wide transition-all outline-none focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0 ${glossBlurred && feedback == null ? "blur-[5px] hover:blur-none" : ""
             }`}
-            onClick={() => setGlossBlurred((v) => !v)}
-            aria-label={
-              glossBlurred ? "Reveal English gloss" : "Blur English gloss"
-            }
-          >
-            {current.englishGloss || "—"}
-          </button>
-        ) : null}
+          onClick={() => setGlossBlurred((v) => !v)}
+          aria-label={
+            glossBlurred && feedback == null ? "Reveal English gloss" : "Blur English gloss"
+          }
+        >
+          {current.englishGloss || "—"}
+        </button>
       </div>
 
       <div className="flex flex-col gap-3 shrink-0 px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] [@media(pointer:fine)]:pb-0 md:pb-0">
@@ -205,7 +201,7 @@ export const Game = ({
               spellCheck={false}
               aria-label='Type the reading or type "forgot"'
               placeholder='Type the reading or type "forgot"'
-              className="relative w-full text-center border-2 rounded-2xl h-14 kanji-font focus-visible:ring-offset-0"
+              className="relative w-full mt-2 text-center border-2 rounded-2xl h-14 focus-visible:ring-offset-0 animate-fade-in"
               onKeyDown={handleKeyDown}
               onCompositionStart={() => {
                 isComposingRef.current = true;

--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -16,14 +16,12 @@ import { AnswerFeedback } from "./AnswerFeedback";
 
 export const Game = ({
   sessionItems,
-  blurEnglishGloss,
   sound,
   onProgress,
   onComplete,
   onEnd,
 }: {
   sessionItems: PracticeItem[];
-  blurEnglishGloss: boolean;
   sound: { enabled: true; type: SoundMode } | { enabled: false };
   onProgress: (progress: number) => void;
   onComplete: (results: SessionResult[]) => void;
@@ -31,7 +29,7 @@ export const Game = ({
 }) => {
   const [index, setIndex] = useState(0);
   const [inputValue, setInputValue] = useState("");
-  const [glossBlurred, setGlossBlurred] = useState(blurEnglishGloss);
+  const [glossBlurred, setGlossBlurred] = useState(true);
   const [feedback, setFeedback] = useState<"correct" | "forgot" | null>(null);
   const resultsRef = useRef<SessionResult[]>([]);
 
@@ -49,8 +47,8 @@ export const Game = ({
   const speak = useSpeak(current?.word ?? "");
 
   useEffect(() => {
-    setGlossBlurred(blurEnglishGloss);
-  }, [blurEnglishGloss, index]);
+    setGlossBlurred(true);
+  }, [index]);
 
   useEffect(() => {
     if (feedback == null) {

--- a/src/components/recognition-practice-v1/InitialScreen.tsx
+++ b/src/components/recognition-practice-v1/InitialScreen.tsx
@@ -155,12 +155,6 @@ export const InitialScreen = ({
               checked={settings.randomizeFont}
               onChange={(v) => setSetting("randomizeFont", v)}
             />
-            <ToggleRow
-              id="blur-gloss"
-              label="Blur English gloss"
-              checked={settings.blurEnglishGloss}
-              onChange={(v) => setSetting("blurEnglishGloss", v)}
-            />
 
             <div className="flex flex-col">
               <ToggleRow

--- a/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
+++ b/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
@@ -165,7 +165,6 @@ const RecognitionPracticeV1 = () => {
             <div key={`playing-${sessionKey}`} className="h-full animate-fade-in">
               <Game
                 sessionItems={sessionItems}
-                blurEnglishGloss={settings.blurEnglishGloss}
                 sound={settings.sound ?? { enabled: true, type: "correct" }}
                 onProgress={setProgress}
                 onComplete={finishSession}

--- a/src/components/recognition-practice-v1/constants.ts
+++ b/src/components/recognition-practice-v1/constants.ts
@@ -9,6 +9,5 @@ export const DEFAULT_SETTINGS: RecognitionPracticeSettings = {
   bookmarkedOnly: false,
   randomizeOrder: true,
   randomizeFont: false,
-  blurEnglishGloss: true,
   sound: { enabled: true, type: "correct" },
 };

--- a/src/components/recognition-practice-v1/types.ts
+++ b/src/components/recognition-practice-v1/types.ts
@@ -7,7 +7,6 @@ export type RecognitionPracticeSettings = {
   bookmarkedOnly: boolean;
   randomizeOrder: boolean;
   randomizeFont: boolean;
-  blurEnglishGloss: boolean;
   sound: { enabled: true; type: SoundMode } | { enabled: false };
 };
 

--- a/src/components/screens/ListScreen/ControlBar/ItemCountBadge.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemCountBadge.tsx
@@ -50,7 +50,7 @@ const ItemsCountLayout = ({ count }: { count: number }) => {
   return <>
     <div className="absolute top-[50px] flex flex-wrap gap-1">
       <div className="px-2 text-xs font-extrabold bg-opacity-75 border rounded-lg bg-background">
-        {count} {count !== 1 ? "Items Matched" : "Item Matched"}
+        {count} {count !== 1 ? "Items" : "Item"}
       </div>
       <KnownBadge />
     </div>

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
@@ -56,9 +56,9 @@ export const SearchInput = ({
   const [parsedValue, setValue] = useState(
     translateValue(initialText, translateMap[searchType])
   );
-  // Ephemeral "Switched to Readings" chip after paste auto-picks a type.
+  // Ephemeral "Switched to Readings" chip after paste/IME auto-picks a type.
   // Same idea as CopyButton's brief feedback — local state, no toast lib.
-  // typeHintKey remounts the span so the CSS animation restarts on rapid pastes.
+  // typeHintKey remounts the span so the CSS animation restarts on rapid switches.
   const [typeHint, setTypeHint] = useState<string | null>(null);
   const [typeHintKey, setTypeHintKey] = useState(0);
 
@@ -101,14 +101,33 @@ export const SearchInput = ({
     setSearchType(finalSearchType);
   };
 
-  // Paste-driven sync: same as onSyncAll, but briefly announce when the search
-  // type was auto-changed (e.g. kana paste → Readings).
-  const syncFromPaste = (text: string, nextType: SearchType) => {
+  // Same as onSyncAll, but briefly announce when the search type was
+  // auto-changed (e.g. kana paste/Enter → Readings).
+  const syncAndAnnounceType = (text: string, nextType: SearchType) => {
     if (nextType !== searchType) {
       setTypeHint(searchTypeLabel(nextType));
       setTypeHintKey((key) => key + 1);
     }
     onSyncAll(text, nextType);
+  };
+
+  // Infer a search type from Japanese IME / typed input. Returns null when
+  // the script is ambiguous or already matches the current type.
+  const inferSearchTypeFromText = (text: string): SearchType | null => {
+    if (text.length === 0) {
+      return null;
+    }
+    if (hasKanji(text)) {
+      return "multi-kanji";
+    }
+    if (wanakana.isKana(text)) {
+      return "readings";
+    }
+    // Multi-kanji expects Japanese characters — a roman word belongs in meanings.
+    if (searchType === "multi-kanji" && wanakana.isRomaji(text)) {
+      return "meanings";
+    }
+    return null;
   };
 
   // Immediately apply the current field value if a debounce is still waiting
@@ -199,11 +218,19 @@ export const SearchInput = ({
           }, INPUT_DEBOUNCE_TIME);
         }}
         onCompositionEnd={(e) => {
-          // Composition just finished — now it's safe to translate and settle.
-          const updatedValue = translateValue(
-            e.currentTarget.value,
-            translateMap[searchType]
-          );
+          // Composition just finished (IME confirm — often via Enter).
+          // Infer from the raw committed text before translateValue: if the
+          // current type maps to romaji, toRomaji would turn かんじ → kanji
+          // and we'd miss the readings switch.
+          const raw = e.currentTarget.value;
+          const text = raw.trim();
+          const inferred = inferSearchTypeFromText(text);
+          if (inferred != null && inferred !== searchType) {
+            syncAndAnnounceType(text, inferred);
+            return;
+          }
+
+          const updatedValue = translateValue(raw, translateMap[searchType]);
           setValue(updatedValue);
           clearTimeout(timeoutRef.current);
           hasPendingSettleRef.current = true;
@@ -213,6 +240,8 @@ export const SearchInput = ({
           }, INPUT_DEBOUNCE_TIME);
         }}
         onKeyDown={(e) => {
+          // IME is still composing (first Enter confirms a candidate) — don't
+          // treat it as a search submit; compositionend handles the switch.
           if (e.nativeEvent.isComposing) {
             return;
           }
@@ -224,8 +253,17 @@ export const SearchInput = ({
             return;
           }
 
-          // Don't flush mid-IME; wait for compositionend.
+          // Fallback when composition already ended (e.g. second Enter, or
+          // text entered without IME). Same script → type rules as paste.
           if (e.key === "Enter") {
+            const text = (
+              inputRef.current?.value ?? parsedValue
+            ).trim();
+            const inferred = inferSearchTypeFromText(text);
+            if (inferred != null && inferred !== searchType) {
+              syncAndAnnounceType(text, inferred);
+              return;
+            }
             flushPendingSettle();
           }
         }}
@@ -257,7 +295,7 @@ export const SearchInput = ({
             const newValue = `${parsedValue.slice(0, start)}${insertion}${parsedValue.slice(end)}`;
             const caret = start + insertion.length;
             if (announceSwitch) {
-              syncFromPaste(newValue, nextType);
+              syncAndAnnounceType(newValue, nextType);
             } else {
               onSyncAll(newValue, nextType);
             }

--- a/src/components/screens/ListScreen/PracticeFab.tsx
+++ b/src/components/screens/ListScreen/PracticeFab.tsx
@@ -34,7 +34,7 @@ const isBodyScrollLocked = () => {
     body.style.paddingRight !== "" ||
     body.hasAttribute("data-scroll-locked") ||
     getComputedStyle(body).getPropertyValue("--removed-body-scroll-bar-size").trim() !==
-      ""
+    ""
   );
 };
 
@@ -118,7 +118,7 @@ export const PracticeFab = () => {
         className="z-50 w-[min(100vw-1.5rem,28rem)] p-3"
       >
         <p className="px-1 mb-2 text-sm font-semibold text-left">
-          Choose a Practice Mode
+          What do you want to do?
         </p>
         <div className="flex flex-row gap-2">
           {practiceLinks.map((item) => (

--- a/src/components/screens/SpeedKatakanaScreen/Game.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/Game.tsx
@@ -18,7 +18,7 @@ import {
 } from "./types";
 import { NUMBER_OF_FONTS } from "@/hooks/use-change-font";
 import { shuffle } from "@/lib/utils";
-import { ArrowRightFromLine, CircleArrowLeft } from "lucide-react";
+import { CircleArrowLeft } from "lucide-react";
 
 type GameWord = {
   katakana: string;
@@ -243,7 +243,7 @@ export const Game = ({
   };
 
   return (
-    <div className="relative flex flex-col w-full h-full max-w-lg gap-4 mx-auto [@media(min-height:900px)]:justify-center animate-fade-in-fast">
+    <div className="flex flex-col w-full h-full gap-4 mx-auto [@media(min-height:900px)]:justify-center animate-fade-in-fast">
       <Button
         variant="ghost"
         size="icon"
@@ -260,16 +260,13 @@ export const Game = ({
           <span className="px-2 text-xs font-bold tabular-nums">
             {index + 1} / {words.length}
           </span>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-red-500 opacity-70 hover:opacity-100 hover:text-red-500 hover:bg-opacity-0"
+          <button
+            className="text-xs font-bold tracking-wide text-red-500 transition-opacity -translate-y-[0.5px] hover:opacity-70"
             tabIndex={-1}
             onClick={handleSkip}
-            aria-label="Skip this word"
           >
-            <ArrowRightFromLine />
-          </Button>
+            {`>>`}
+          </button>
         </div>
         <div
           className={current.fontIndex === null ? "kanji-font" : undefined}

--- a/src/components/screens/SpeedKatakanaScreen/Game.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/Game.tsx
@@ -18,7 +18,7 @@ import {
 } from "./types";
 import { NUMBER_OF_FONTS } from "@/hooks/use-change-font";
 import { shuffle } from "@/lib/utils";
-import { CircleArrowLeft, DeleteIcon } from "lucide-react";
+import { ArrowRightFromLine, CircleArrowLeft } from "lucide-react";
 
 type GameWord = {
   katakana: string;
@@ -243,20 +243,20 @@ export const Game = ({
   };
 
   return (
-    <div className="flex flex-col w-full h-full max-w-lg gap-4 mx-auto [@media(min-height:900px)]:justify-center  animate-fade-in-fast">
+    <div className="relative flex flex-col w-full h-full max-w-lg gap-4 mx-auto [@media(min-height:900px)]:justify-center animate-fade-in-fast">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute z-10 top-1 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
+        tabIndex={-1}
+        onClick={onEnd}
+        aria-label="End session"
+      >
+        <CircleArrowLeft />
+      </Button>
+
       <div className="flex flex-col items-center justify-center flex-1 min-h-0 [@media(min-height:900px)]:flex-none gap-3 text-center">
         <div className="flex items-center justify-center gap-1 pt-4">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
-            tabIndex={-1}
-            onClick={onEnd}
-            aria-label="End session"
-          >
-            <CircleArrowLeft />
-          </Button>
-
           <span className="px-2 text-xs font-bold tabular-nums">
             {index + 1} / {words.length}
           </span>
@@ -268,7 +268,7 @@ export const Game = ({
             onClick={handleSkip}
             aria-label="Skip this word"
           >
-            <DeleteIcon className="rotate-180" />
+            <ArrowRightFromLine />
           </Button>
         </div>
         <div
@@ -316,7 +316,7 @@ export const Game = ({
           spellCheck={false}
           aria-label='Type romaji or type "skip"'
           placeholder='Type romaji or "skip"'
-          className="w-full text-2xl text-center border-2 z-1000 rounded-2xl h-14 kanji-font"
+          className="w-full text-2xl text-center border-2 z-1000 rounded-2xl h-14"
           onKeyDown={handleKeyDown}
           onCompositionStart={() => {
             isComposingRef.current = true;

--- a/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
@@ -97,7 +97,7 @@ const SpeedKatakanaScreen = () => {
         style={{ top: viewport.offsetTop, height: viewport.height }}
       >
         <SpeedKatakanaHeader progress={headerProgress} />
-        <main className="flex-1 min-h-0 py-4 overflow-hidden">
+        <main className="relative flex-1 min-h-0 py-4 overflow-hidden">
           {phase === "initial" && (
             <div key="initial" className="h-full animate-fade-in">
               <InitialScreen onStart={startGame} />

--- a/src/components/sections/KanjiDetails/PartComponentLink.tsx
+++ b/src/components/sections/KanjiDetails/PartComponentLink.tsx
@@ -1,0 +1,41 @@
+import { useGetKanjiInfoFn } from "@/kanji-worker/kanji-worker-hooks";
+import { ComponentLink } from "@/components/dependent/routing/global-links";
+import {
+  moreRadicalKeywords,
+  nonRadicalVariantKeywords,
+  radicalFalseFriends,
+} from "@/lib/radicals";
+
+const getRadicalKeyword = (component: string): string | undefined => {
+  if (moreRadicalKeywords[component]) return moreRadicalKeywords[component];
+  const canonical = radicalFalseFriends[component]?.trim();
+  if (canonical && moreRadicalKeywords[canonical]) return moreRadicalKeywords[canonical];
+  return undefined;
+};
+
+export const useResolvedComponent = (component: string | null | undefined) => {
+  const getKanjiInfo = useGetKanjiInfoFn();
+  if (!component) return null;
+  const info = getKanjiInfo?.(component ?? radicalFalseFriends[component]) ?? null;
+  const isKanji = !!info && "on" in info;
+  const keyword = info?.keyword ?? getRadicalKeyword(component);
+  const nonRadicalKeyword = nonRadicalVariantKeywords[component] ?? "...";
+  return {
+    component,
+    keyword: keyword ?? nonRadicalKeyword ?? "...",
+    type: (isKanji ? "kanji" : keyword ? "radical" : "unknown") as
+      | "kanji"
+      | "radical"
+      | "unknown",
+  };
+};
+
+export const PartComponentLink = ({ part }: { part: string }) => {
+  const props = useResolvedComponent(part);
+
+  if (!props) {
+    return null;
+  }
+
+  return <ComponentLink {...props} />;
+};

--- a/src/components/sections/KanjiDetails/SampleVocabulary.tsx
+++ b/src/components/sections/KanjiDetails/SampleVocabulary.tsx
@@ -198,7 +198,7 @@ const PaginatedVocabulary = ({ data, shortcuts }: { data: CommonWordEntry[]; sho
 
   return (
     <div className="px-2 mt-4 -mx-2 overflow-x-auto" key={`${start}-${end}`}>
-      <p className="w-full px-4 text-left">{data.length} total item(s) found.</p>
+      <p className="w-full px-4 text-left">{data.length} total {data.length === 1 ? "item" : "items"}</p>
       {pagination}
       <Table className="w-full min-w-[400px] mt-4 animate-fade-in">
         <TableHeader>

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -226,7 +226,7 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
         onClickClear={onClear}
       />
 
-      <div className="w-full max-w-[310px] min-h-10 px-2 text-xs font-bold text-center">
+      <div className="w-full max-w-[310px] min-h-10 px-2 text-base font-bold text-center">
         {status === "loading" && (
           <div className="animate-fade-in opacity-80">採点中 · Grading…</div>
         )}
@@ -240,7 +240,7 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
         )}
         {status === "idle" && (
           <div className="font-bold">
-            Draw the kanji, then tap 🚀 to Grade.
+            Draw the kanji, then tap 🚀 to grade.
           </div>
         )}
       </div>

--- a/src/components/sections/KanjiDetails/StructuralCategory.tsx
+++ b/src/components/sections/KanjiDetails/StructuralCategory.tsx
@@ -1,10 +1,7 @@
-import { useGetKanjiInfoFn } from "@/kanji-worker/kanji-worker-hooks";
-
 import { useMultiKanjiStructure } from "@/providers/multiple-kanji-structure-provider";
 import { StructuralType, structuralTypeInfo, structuralTypeInfoB } from "@/lib/kanji-section-constants";
-import { GlobalKanjiLink } from "@/components/dependent/routing";
-import { FakeComponentLink, GlobalRadicalLink } from "@/components/dependent/routing/global-links";
-import { moreRadicalKeywords, nonRadicalVariantKeywords, radicalFalseFriends } from "@/lib/radicals";
+
+import { ComponentLink } from "@/components/dependent/routing/global-links";
 import { ReactNode } from "react";
 import { BadgeWithPopover } from "@/components/common/BadgeWithPopover";
 import {
@@ -12,6 +9,7 @@ import {
   CircleHelp, GitBranch, Mic, Sparkles, Minimize2,
   Lightbulb,
 } from "lucide-react";
+import { PartComponentLink, useResolvedComponent } from "./PartComponentLink";
 
 const ICON_SIZE = 15;
 
@@ -41,74 +39,12 @@ const formatStructuralTypeName = (type: StructuralType): string => {
   return `${info.name ?? "unknown"}`;
 };
 
-const ComponentLink = ({
-  component,
-  keyword,
-  title,
-  type
-}: {
-  component: string;
-  keyword: string;
-  title?: string;
-  type: 'kanji' | 'radical' | 'unknown'
-}) => {
-
-  return (
-    <div className="flex flex-col text-center w-fit ">
-      {type === 'kanji' ?
-        <GlobalKanjiLink kanji={component} keyword={keyword} /> : type === "radical" ?
-          <GlobalRadicalLink radical={component} keyword={keyword} /> : <FakeComponentLink radical={component} keyword={keyword} />
-      }
-      {title && <div className="text-[10px] uppercase opacity-70">{title}</div>}
-    </div>
-  )
-
-
-};
 
 const Wrapper = ({ children }: { children: ReactNode }) => {
   return <div className="flex items-center gap-4 overflow-x-auto justify-left w-fit">{children}</div>
 }
 
 const NoInfo = () => { return <span className="text-[10px] uppercase">Not available</span>; }
-
-const getRadicalKeyword = (component: string): string | undefined => {
-  if (moreRadicalKeywords[component]) return moreRadicalKeywords[component];
-  const canonical = radicalFalseFriends[component]?.trim();
-  if (canonical && moreRadicalKeywords[canonical]) return moreRadicalKeywords[canonical];
-  return undefined;
-};
-
-
-// --- Helper to resolve component type and keyword ---
-
-
-const useResolvedComponent = (component: string | null | undefined) => {
-  const getKanjiInfo = useGetKanjiInfoFn();
-  if (!component) return null;
-  const info = getKanjiInfo?.(component ?? radicalFalseFriends[component]) ?? null;
-  const isKanji = !!info && "on" in info;
-  const keyword = info?.keyword ?? getRadicalKeyword(component);
-  const nonRadicalKeyword = nonRadicalVariantKeywords[component] ?? "..."
-  return {
-    component,
-    keyword: keyword ?? nonRadicalKeyword ?? "...",
-    type: (isKanji ? "kanji" : keyword ? "radical" : "unknown") as "kanji" | "radical" | "unknown",
-  };
-};
-
-const PartComponentLink = ({ part }: { part: string }) => {
-  const props = useResolvedComponent(part)
-
-  if (!props) {
-    return null
-  }
-
-  return (
-    <ComponentLink {...props} />
-  );
-}
-
 
 // --- TASK 2A: Lorenzi (same pattern as KanjiStructuralData, uses multi provider) ---
 const KanjiStructuralDataLorenzi = ({ kanji }: { kanji: string }) => {

--- a/src/components/sections/KanjiDetails/StructureInfo.tsx
+++ b/src/components/sections/KanjiDetails/StructureInfo.tsx
@@ -1,4 +1,3 @@
-
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 
 import {
@@ -14,6 +13,8 @@ import {
     useSimilarKanjis,
 } from "@/kanji-worker/kanji-worker-hooks";
 import { dedupe } from "@/lib/utils";
+import { GenericPopover } from "@/components/common/GenericPopover";
+import { PartComponentLink } from "./PartComponentLink";
 
 const TableCellFixed = ({
     children,
@@ -44,7 +45,14 @@ const SimilarKanjis = ({ kanji }: { kanji: string }) => {
                 <div className="flex items-center min-w-0 space-x-2 overflow-x-auto overflow-y-hidden">
                     {dedupe(similars).map((similarKanji) => (
                         <div key={similarKanji} className="shrink-0">
-                            <OriginalKanjiComponentBreakdown kanji={similarKanji} />
+                            <GenericPopover
+                                trigger={
+                                    <button className="flex flex-col my-1 kanji-font text-3xl border-2 rounded-2xl p-2 border-dotted hover:border-solid hover:border-[#2effff]">
+                                        {similarKanji}
+                                    </button>
+                                }
+                                content={<PartComponentLink part={similarKanji} />}
+                            />
                         </div>
                     ))}
                 </div>
@@ -54,7 +62,6 @@ const SimilarKanjis = ({ kanji }: { kanji: string }) => {
                     {
                         text: "lennart-finke/kanjidist-visualiser",
                         url: "https://github.com/lennart-finke/kanjidist-visualiser/blob/master/data/dkanjistat.json"
-
                     },
                     {
                         text: "Yencken, Lars (2010) Orthographic support for passing the reading hurdle in Japanese. PhD Thesis, University of Melbourne, Melbourne, Australia",
@@ -62,14 +69,11 @@ const SimilarKanjis = ({ kanji }: { kanji: string }) => {
                     },
                 ]}
             />
-
         </>
     );
 };
 
 export const StructureInfo = ({ kanji }: { kanji: string }) => {
-
-
     return (
         <>
             <h3 className="pt-3 pb-1 pl-3 text-sm font-bold text-left uppercase border-b border-dashed text-foreground/50">Component Breakdown</h3>


### PR DESCRIPTION
## Summary
- Polish recognition and writing practice: always-blurred English gloss, simpler answer feedback, secondary undo button, larger writing-status text
- Improve Speed Katakana session controls (anchored end button, clearer skip) and soften the practice FAB prompt
- Auto-switch list search type from IME/typed script on Enter, and update README data/generator docs
- Extract `PartComponentLink` helpers and show visually similar kanji as popovers instead of full component breakdowns

## Test plan
- [ ] Recognition practice: gloss stays blurred until revealed; feedback shows reading + Continue only
- [ ] Writing practice: status text is readable; idle prompt wording looks right; undo button uses secondary style
- [ ] Speed Katakana: end control stays top-left; skip control is clear and works
- [ ] List search: confirm kana/kanji/romaji with IME Enter switches search type and announces the change
- [ ] Practice FAB opens with “What do you want to do?” and links still work
- [ ] Kanji details: Visually Similar Kanji shows character buttons; popover opens with PartComponentLink content