### PR TITLE
Add Kanji Writing (production) practice with shared practice UI.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,9 +24,11 @@ const {
   privacyPage,
   speedKatakanaPage,
   recognitionPracticeV1Page,
+  productionPracticeV1Page,
 } = pageItems;
 
 const RecognitionPracticeV1 = recognitionPracticeV1Page.Component;
+const ProductionPracticeV1 = productionPracticeV1Page.Component;
 
 const App = () => {
   return (
@@ -51,6 +53,12 @@ const App = () => {
             <Route path={recognitionPracticeV1Page.href}>
               <KanjiFunctionalityProvider>
                 <RecognitionPracticeV1 />
+              </KanjiFunctionalityProvider>
+            </Route>
+            {/* Production (writing) practice needs kanji data, drawer, and ONNX. */}
+            <Route path={productionPracticeV1Page.href}>
+              <KanjiFunctionalityProvider>
+                <ProductionPracticeV1 />
               </KanjiFunctionalityProvider>
             </Route>
             <Route>

--- a/src/components/common/DashedNavLinkList.tsx
+++ b/src/components/common/DashedNavLinkList.tsx
@@ -1,0 +1,49 @@
+import { Fragment, type ReactNode } from "react";
+import { DashedNavLink } from "@/components/common/DashedNavLink";
+import type { NavLinkItem } from "@/components/items/nav-links";
+import { cn } from "@/lib/utils";
+
+type DashedNavLinkListProps = {
+  items: NavLinkItem[];
+  className?: string;
+  itemClassName?: string;
+  iconClassName?: string;
+  onItemClick?: () => void;
+  onItemPointerDown?: (e: React.PointerEvent) => void;
+  wrapItem?: (link: ReactNode, item: NavLinkItem) => ReactNode;
+};
+
+export const DashedNavLinkList = ({
+  items,
+  className,
+  itemClassName,
+  iconClassName,
+  onItemClick,
+  onItemPointerDown,
+  wrapItem,
+}: DashedNavLinkListProps) => {
+  return (
+    <div className={cn(className)}>
+      {items.map((item) => {
+        const link = (
+          <DashedNavLink
+            href={item.href}
+            title={item.title}
+            description={item.description}
+            Icon={item.Icon}
+            onClick={onItemClick}
+            onPointerDown={onItemPointerDown}
+            className={itemClassName}
+            iconClassName={iconClassName}
+          />
+        );
+
+        return (
+          <Fragment key={item.href}>
+            {wrapItem ? wrapItem(link, item) : link}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/dependent/DrawingPad.tsx
+++ b/src/components/dependent/DrawingPad.tsx
@@ -2,6 +2,7 @@
 import { Dispatch, ReactNode, SetStateAction, useEffect, useId, useRef, useState } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { Undo2, Trash2, Search } from "@/components/icons";
+import { HelpCircle } from "lucide-react";
 
 export type Stroke = [number, number][];
 
@@ -33,6 +34,9 @@ export const DrawingPad = ({
     submitDisabled = false,
     onClickSubmit,
     onClickClear,
+    showForgotBtn = false,
+    onClickForgot,
+    forgotDisabled = false,
 }: {
     svgSize: number;
     // Optional controlled strokes. When provided, the parent owns the strokes
@@ -47,6 +51,9 @@ export const DrawingPad = ({
     submitDisabled?: boolean;
     onClickSubmit?: (payload: DrawingSubmitPayload) => void;
     onClickClear?: () => void;
+    showForgotBtn?: boolean;
+    onClickForgot?: () => void;
+    forgotDisabled?: boolean;
 }) => {
     const [internalStrokes, setInternalStrokes] = useState<Stroke[]>([]);
     const strokes = controlledStrokes ?? internalStrokes;
@@ -129,7 +136,7 @@ export const DrawingPad = ({
     };
 
     return (
-        <div className="flex flex-col items-center gap-2 m-4">
+        <div className="flex flex-col items-center gap-2 my-2 mx-auto sm:m-4">
             <div
                 ref={wrapperRef}
                 style={{ touchAction: "none", lineHeight: 0 }}
@@ -190,6 +197,17 @@ export const DrawingPad = ({
                 </svg>
             </div>
             <div className="flex justify-center mt-2 space-x-2">
+                {showForgotBtn && (
+                    <PracticeButton
+                        size="icon"
+                        variant="danger"
+                        onClick={() => onClickForgot?.()}
+                        disabled={forgotDisabled}
+                    >
+                        <HelpCircle />
+                        <span className="sr-only">Forgot</span>
+                    </PracticeButton>
+                )}
                 <PracticeButton
                     size="icon"
                     variant="secondary"

--- a/src/components/items/nav-links.ts
+++ b/src/components/items/nav-links.ts
@@ -1,0 +1,46 @@
+import { ChartLine, Eye, Keyboard, PenLine, SearchIcon } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+import {
+  productionPracticePageMeta,
+  recognitionPracticePageMeta,
+  speedKatakanaPageMeta,
+} from "@/components/items/practice-pages";
+
+export type NavLinkIcon = ComponentType<
+  SVGProps<SVGSVGElement> & { className?: string }
+>;
+
+export type NavLinkItem = {
+  href: string;
+  title: string;
+  description: string;
+  Icon: NavLinkIcon;
+};
+
+export const exploreKanjiPageMeta = {
+  href: "/",
+  title: "Explore Kanji",
+  description: "Advanced search, sort, filter, and usage visualization tool",
+} as const;
+
+export const cumUseGraphPageMeta = {
+  href: "/cumulative-use-graph",
+  title: "Cumulative Use Graph",
+  description: "Inspect kanji usage vs rank trends",
+} as const;
+
+/** Practice destinations shown in the FAB menu. */
+export const practiceNavLinks: NavLinkItem[] = [
+  { ...recognitionPracticePageMeta, Icon: Eye },
+  { ...productionPracticePageMeta, Icon: PenLine },
+  { ...speedKatakanaPageMeta, Icon: Keyboard },
+];
+
+/** Primary destinations in the header drawer. */
+export const headerNavLinks: NavLinkItem[] = [
+  { ...exploreKanjiPageMeta, Icon: SearchIcon },
+  { ...recognitionPracticePageMeta, Icon: Eye },
+  { ...productionPracticePageMeta, Icon: PenLine },
+  { ...speedKatakanaPageMeta, Icon: Keyboard },
+  { ...cumUseGraphPageMeta, Icon: ChartLine },
+];

--- a/src/components/items/page-items.tsx
+++ b/src/components/items/page-items.tsx
@@ -7,22 +7,24 @@ import {
   SpeedKatakanaScreen,
 } from "@/components/screens";
 import { RecognitionPracticeV1Screen } from "@/components/recognition-practice-v1";
+import { ProductionPracticeV1Screen } from "@/components/production-practice-v1";
 import {
   recognitionPracticePageMeta,
+  productionPracticePageMeta,
   speedKatakanaPageMeta,
 } from "@/components/items/practice-pages";
+import {
+  cumUseGraphPageMeta,
+  exploreKanjiPageMeta,
+} from "@/components/items/nav-links";
 
 const kanjiPage = {
-  href: "/",
-  title: "Explore Kanji",
+  ...exploreKanjiPageMeta,
   Component: ListScreen,
-  description: "Advanced search, sort, filter, and usage visualization tool",
 };
 
 const cumUseGraphPage = {
-  href: "/cumulative-use-graph",
-  title: "Cumulative Use Graph",
-  description: "Inspect kanji usage vs rank trends",
+  ...cumUseGraphPageMeta,
   Component: CumUseScreen,
 };
 
@@ -54,6 +56,11 @@ const recognitionPracticeV1Page = {
   Component: RecognitionPracticeV1Screen,
 };
 
+const productionPracticeV1Page = {
+  ...productionPracticePageMeta,
+  Component: ProductionPracticeV1Screen,
+};
+
 const pageItems = {
   kanjiPage,
   cumUseGraphPage,
@@ -62,6 +69,7 @@ const pageItems = {
   privacyPage,
   speedKatakanaPage,
   recognitionPracticeV1Page,
+  productionPracticeV1Page,
 };
 
 export default pageItems;

--- a/src/components/items/practice-pages.ts
+++ b/src/components/items/practice-pages.ts
@@ -6,6 +6,12 @@ export const recognitionPracticePageMeta = {
   description: "Type the reading of kanji anchor words",
 } as const;
 
+export const productionPracticePageMeta = {
+  href: "/production-practice",
+  title: "Kanji Production",
+  description: "Draw the missing kanji in anchor words",
+} as const;
+
 export const speedKatakanaPageMeta = {
   href: "/speed-katakana",
   title: "Speed Katakana",
@@ -14,5 +20,6 @@ export const speedKatakanaPageMeta = {
 
 export const practicePageLinks = [
   recognitionPracticePageMeta,
+  productionPracticePageMeta,
   speedKatakanaPageMeta,
 ] as const;

--- a/src/components/production-practice-v1/ClozeWord.tsx
+++ b/src/components/production-practice-v1/ClozeWord.tsx
@@ -1,0 +1,53 @@
+/** Word with the target kanji blanked as "?", or revealed after feedback. */
+export const ClozeWord = ({
+  word,
+  kanji,
+  fontIndex,
+  revealed = false,
+}: {
+  word: string;
+  kanji: string;
+  fontIndex: number | null;
+  /** When true, show the real kanji instead of the "?" blank. */
+  revealed?: boolean;
+}) => {
+  const idx = word.indexOf(kanji);
+  const before = idx === -1 ? "" : word.slice(0, idx);
+  const after = idx === -1 ? word : word.slice(idx + kanji.length);
+  const displayLen = before.length + after.length + 1;
+
+  const sizeClass =
+    displayLen > 6
+      ? "text-4xl sm:text-5xl md:text-6xl"
+      : displayLen < 3
+        ? "text-6xl sm:text-7xl md:text-8xl"
+        : "text-5xl sm:text-6xl md:text-7xl";
+
+  return (
+    <p
+      className={`flex flex-wrap items-center justify-center max-w-full leading-tight ${sizeClass} ${
+        fontIndex === null ? "kanji-font" : ""
+      }`}
+      style={
+        fontIndex === null
+          ? undefined
+          : {
+              fontFamily: `var(--jap-font-${fontIndex}), "Noto Sans JP", system-ui`,
+            }
+      }
+    >
+      {before ? <span className="break-all">{before}</span> : null}
+      {revealed ? (
+        <span className="mx-0.5">{kanji}</span>
+      ) : (
+        <span
+          className="inline-flex items-center justify-center mx-1 min-w-[1.25em] px-2 pt-1 pb-4 border-2 border-dotted rounded-xl border-foreground/70 align-middle"
+          aria-label="missing kanji"
+        >
+          ?
+        </span>
+      )}
+      {after ? <span className="break-all">{after}</span> : null}
+    </p>
+  );
+};

--- a/src/components/production-practice-v1/Game.tsx
+++ b/src/components/production-practice-v1/Game.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useRef, useState } from "react";
+import { CircleArrowLeft, Rocket } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DrawingPad,
+  DrawingSubmitPayload,
+  Stroke,
+} from "@/components/dependent/DrawingPad";
+import { RomajiBadge } from "@/components/dependent/kana/RomajiBadge";
+import { SpeakButton } from "@/components/common/SpeakButton";
+import { useSpeak } from "@/hooks/use-jp-speak";
+import { useFitPadSize } from "@/hooks/use-fit-pad-size";
+import { useSimilarKanjis } from "@/kanji-worker/kanji-worker-hooks";
+import { recognizeWithDaKanji } from "@/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/recognizers";
+import assetsPaths from "@/lib/assets-paths";
+import { ClozeWord } from "./ClozeWord";
+import { buildCandidateGrid } from "./build-candidates";
+import { DRAW_SVG_SIZE } from "./constants";
+import { SelectSimilarKanjiDrawer } from "./drawers/SelectSimilarKanjiDrawer";
+import { FeedbackDrawer } from "./drawers/FeedbackDrawer";
+import {
+  DrawingSnapshot,
+  GradeRankInfo,
+  PracticeItem,
+  ProductionPracticeSettings,
+  SessionResult,
+} from "./types";
+
+type CardStep =
+  | { type: "draw" }
+  | { type: "recognizing" }
+  | {
+      type: "select";
+      grade: GradeRankInfo;
+      candidates: string[];
+    }
+  | {
+      type: "feedback";
+      kind: "noKanji" | "correct" | "incorrect";
+      grade: GradeRankInfo;
+    };
+
+export const Game = ({
+  sessionItems,
+  settings,
+  randomKanjiPool,
+  onProgress,
+  onComplete,
+  onEnd,
+}: {
+  sessionItems: PracticeItem[];
+  settings: ProductionPracticeSettings;
+  randomKanjiPool: string[];
+  onProgress: (progress: number) => void;
+  onComplete: (results: SessionResult[]) => void;
+  onEnd: () => void;
+}) => {
+  const [index, setIndex] = useState(0);
+  const [strokes, setStrokes] = useState<Stroke[]>([]);
+  const [drawing, setDrawing] = useState<DrawingSnapshot | null>(null);
+  const [glossBlurred, setGlossBlurred] = useState(settings.blurEnglishGloss);
+  const [step, setStep] = useState<CardStep>({ type: "draw" });
+  const [selected, setSelected] = useState<string | null>(null);
+  const resultsRef = useRef<SessionResult[]>([]);
+  const correctAudioRef = useRef<HTMLAudioElement | null>(null);
+  const padSize = useFitPadSize(DRAW_SVG_SIZE);
+
+  const current = sessionItems[index];
+  const similarState = useSimilarKanjis(current?.kanji ?? "");
+  const similars = similarState.data ?? [];
+  const speak = useSpeak(current?.word ?? "");
+
+  useEffect(() => {
+    setGlossBlurred(settings.blurEnglishGloss);
+    setStrokes([]);
+    setDrawing(null);
+    setStep({ type: "draw" });
+    setSelected(null);
+  }, [index, settings.blurEnglishGloss]);
+
+  useEffect(() => {
+    setStrokes([]);
+    setDrawing(null);
+  }, [padSize]);
+
+  useEffect(() => {
+    onProgress(
+      sessionItems.length === 0 ? 0 : (index / sessionItems.length) * 100
+    );
+  }, [index, onProgress, sessionItems.length]);
+
+  useEffect(() => {
+    if (!current || !settings.hearPronunciationOnLoad) return;
+    if (step.type !== "draw") return;
+    speak();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- speak on card load only
+  }, [index, settings.hearPronunciationOnLoad]);
+
+  if (!current) {
+    return null;
+  }
+
+  const playCorrectSound = () => {
+    if (!settings.celebratorySoundOnCorrect) return;
+    try {
+      if (!correctAudioRef.current) {
+        correctAudioRef.current = new Audio(
+          assetsPaths.SPEED_KATAKANA_CORRECT_SOUND
+        );
+      }
+      correctAudioRef.current.currentTime = 0;
+      void correctAudioRef.current.play();
+    } catch {
+      // ignore playback failures
+    }
+  };
+
+  const pushResult = (correct: boolean, gradeRank: number) => {
+    const result: SessionResult = { ...current, correct, gradeRank };
+    resultsRef.current = [...resultsRef.current, result];
+  };
+
+  const advance = () => {
+    const nextIndex = index + 1;
+    const allResults = resultsRef.current;
+    if (nextIndex >= sessionItems.length) {
+      onProgress(100);
+      onComplete(allResults);
+      return;
+    }
+    setIndex(nextIndex);
+  };
+
+  const onForgotFromDraw = () => {
+    if (step.type !== "draw") return;
+    pushResult(false, -1);
+    setStep({
+      type: "feedback",
+      kind: "noKanji",
+      grade: { rank: -1, topGuess: null, inTop10: false },
+    });
+  };
+
+  const onSubmit = async (payload: DrawingSubmitPayload) => {
+    if (step.type !== "draw" || payload.strokes.length === 0) return;
+    setDrawing(payload);
+    setStep({ type: "recognizing" });
+    try {
+      const candidates = await recognizeWithDaKanji(payload);
+      const rank = candidates.indexOf(current.kanji);
+      const inTop10 = rank >= 0;
+      const grade: GradeRankInfo = {
+        rank,
+        topGuess: candidates[0] ?? null,
+        inTop10,
+      };
+      const similarList = similarState.data ?? similars;
+      const grid = buildCandidateGrid({
+        target: current.kanji,
+        inTop10,
+        modelGuesses: candidates,
+        similars: similarList,
+        randomPool: randomKanjiPool,
+      });
+      setSelected(null);
+      setStep({ type: "select", grade, candidates: grid });
+    } catch {
+      setStep({ type: "draw" });
+    }
+  };
+
+  const onSelectForgot = () => {
+    if (step.type !== "select") return;
+    pushResult(false, step.grade.rank);
+    setStep({ type: "feedback", kind: "incorrect", grade: step.grade });
+  };
+
+  const onSelectNext = () => {
+    if (step.type !== "select" || selected == null) return;
+    const pickedCorrect = selected === current.kanji;
+    const sessionCorrect = pickedCorrect && step.grade.inTop10;
+    if (sessionCorrect) playCorrectSound();
+    pushResult(sessionCorrect, step.grade.rank);
+    setStep({
+      type: "feedback",
+      kind: pickedCorrect ? "correct" : "incorrect",
+      grade: step.grade,
+    });
+  };
+
+  const recognizing = step.type === "recognizing";
+  const selectOpen = step.type === "select";
+  const feedback = step.type === "feedback" ? step : null;
+
+  return (
+    <div className="relative flex flex-col w-full h-full overflow-hidden">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute z-10 top-1 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
+        tabIndex={-1}
+        onClick={onEnd}
+        aria-label="End session"
+      >
+        <CircleArrowLeft />
+      </Button>
+
+      <div className="flex flex-col items-center flex-1 min-h-0 px-3 pt-8 pb-2 overflow-y-auto sm:px-4">
+        <ClozeWord
+          word={current.word}
+          kanji={current.kanji}
+          fontIndex={current.fontIndex}
+          revealed={feedback != null}
+        />
+
+        <div className="flex flex-wrap items-center justify-center gap-1 mt-3">
+          {current.reading.split("・").map((r) => (
+            <RomajiBadge key={r} kana={r} />
+          ))}
+          <SpeakButton word={current.word} iconType="volume-2" />
+        </div>
+
+        {settings.blurEnglishGloss ? (
+          <button
+            type="button"
+            className={`max-w-sm px-2 text-xs mt-2 font-bold tracking-wide transition-all outline-none ${
+              glossBlurred ? "blur-[5px] hover:blur-none" : ""
+            }`}
+            onClick={() => setGlossBlurred((v) => !v)}
+            aria-label={
+              glossBlurred ? "Reveal English gloss" : "Blur English gloss"
+            }
+          >
+            {current.englishGloss || "—"}
+          </button>
+        ) : (
+          <p className="max-w-sm px-2 mt-1 text-xs font-bold tracking-wide">
+            {current.englishGloss || "—"}
+          </p>
+        )}
+
+        <div
+          className="relative mt-2 w-full mx-auto"
+          style={{ maxWidth: padSize + 32 }}
+        >
+          <DrawingPad
+            svgSize={padSize}
+            strokes={strokes}
+            setStrokes={setStrokes}
+            showForgotBtn
+            onClickForgot={onForgotFromDraw}
+            forgotDisabled={recognizing || step.type !== "draw"}
+            showSubmitBtn
+            submitIcon={<Rocket />}
+            submitLabel="Submit"
+            submitDisabled={recognizing || step.type !== "draw"}
+            onClickSubmit={onSubmit}
+          />
+          {recognizing && (
+            <div className="absolute inset-0 flex items-center justify-center rounded-3xl bg-background/70">
+              <p className="text-sm font-bold sm:text-base animate-pulse">
+                Recognizing…
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <SelectSimilarKanjiDrawer
+        open={selectOpen}
+        grade={
+          step.type === "select"
+            ? step.grade
+            : { rank: -1, topGuess: null, inTop10: false }
+        }
+        candidates={step.type === "select" ? step.candidates : []}
+        selected={selected}
+        onSelect={setSelected}
+        onForgot={onSelectForgot}
+        onNext={onSelectNext}
+      />
+
+      <FeedbackDrawer
+        open={feedback != null}
+        kind={feedback?.kind ?? "noKanji"}
+        item={current}
+        grade={
+          feedback?.grade ?? { rank: -1, topGuess: null, inTop10: false }
+        }
+        drawing={drawing}
+        onNext={advance}
+      />
+    </div>
+  );
+};

--- a/src/components/production-practice-v1/InitialScreen.tsx
+++ b/src/components/production-practice-v1/InitialScreen.tsx
@@ -12,46 +12,16 @@ import assetsPaths from "@/lib/assets-paths";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { buildPracticeDeck, ToggleRow } from "@/components/shared-practice";
 import { DEFAULT_SETTINGS, SETTINGS_KEY } from "./constants";
-import {
-  PracticeItem,
-  RecognitionPracticeSettings,
-  SoundMode,
-} from "./types";
+import { PracticeItem, ProductionPracticeSettings } from "./types";
 
 type RepEntry = [string, string, string, string];
-
-const RadioRow = ({
-  name,
-  value,
-  current,
-  label,
-  onChange,
-}: {
-  name: string;
-  value: SoundMode;
-  current: SoundMode;
-  label: string;
-  onChange: (value: SoundMode) => void;
-}) => (
-  <label className="flex items-center gap-2 pr-4 text-sm cursor-pointer">
-    <input
-      type="radio"
-      name={name}
-      value={value}
-      checked={current === value}
-      onChange={() => onChange(value)}
-      className="accent-primary"
-    />
-    {label}
-  </label>
-);
 
 export const InitialScreen = ({
   onStart,
 }: {
   onStart: (deck: PracticeItem[]) => void;
 }) => {
-  const [settings, setSetting] = useLocalStorage<RecognitionPracticeSettings>(
+  const [settings, setSetting] = useLocalStorage<ProductionPracticeSettings>(
     SETTINGS_KEY,
     DEFAULT_SETTINGS
   );
@@ -75,14 +45,7 @@ export const InitialScreen = ({
     !workerReady || repStatus === "pending" || repStatus === "idle";
   const canStart = !loading && deck.length > 0;
 
-  const soundEnabled = settings.sound?.enabled ?? true;
-  const soundType: SoundMode =
-    settings.sound?.enabled === true ? settings.sound.type : "correct";
-
-  useEnterAction(
-    canStart ? () => onStart(deck) : null,
-    canStart
-  );
+  useEnterAction(canStart ? () => onStart(deck) : null, canStart);
 
   return (
     <div className="flex flex-col h-full">
@@ -90,11 +53,10 @@ export const InitialScreen = ({
         <div className="flex flex-col max-w-md gap-6 px-4 py-6 mx-auto">
           <div className="text-left">
             <h1 className="pt-4 text-xl font-bold text-center">
-              👁️ Kanji Recognition
+              ✍️ Kanji Writing
             </h1>
-
             <p className="mt-1 text-sm text-center text-muted-foreground">
-              Type the reading of kanji anchor words
+              Draw the missing kanji in anchor words
             </p>
           </div>
 
@@ -134,49 +96,29 @@ export const InitialScreen = ({
               checked={settings.randomizeFont}
               onChange={(v) => setSetting("randomizeFont", v)}
             />
-
-            <div className="flex flex-col">
-              <ToggleRow
-                id="sound-on"
-                label="Sound On"
-                checked={soundEnabled}
-                onChange={(v) =>
-                  setSetting(
-                    "sound",
-                    v
-                      ? { enabled: true, type: soundType }
-                      : { enabled: false }
-                  )
-                }
-              />
-              {soundEnabled && (
-                <div className="flex flex-wrap pl-1 animate-fade-in-fast">
-                  <RadioRow
-                    name="sound-mode"
-                    value="speak"
-                    current={soundType}
-                    label="Say out loud"
-                    onChange={(v) =>
-                      setSetting("sound", { enabled: true, type: v })
-                    }
-                  />
-                  <RadioRow
-                    name="sound-mode"
-                    value="correct"
-                    current={soundType}
-                    label="Sound when correct"
-                    onChange={(v) =>
-                      setSetting("sound", { enabled: true, type: v })
-                    }
-                  />
-                </div>
-              )}
-              {soundEnabled && soundType === "speak" && (
-                <p className="w-full pt-1 text-xs text-left animate-fade-in-fast">
-                  ⚠️ text-to-speech might not work on all devices.
-                </p>
-              )}
-            </div>
+            <ToggleRow
+              id="blur-gloss"
+              label="Blur English gloss"
+              checked={settings.blurEnglishGloss}
+              onChange={(v) => setSetting("blurEnglishGloss", v)}
+            />
+            <ToggleRow
+              id="hear-on-load"
+              label="Hear pronunciation on load"
+              checked={settings.hearPronunciationOnLoad}
+              onChange={(v) => setSetting("hearPronunciationOnLoad", v)}
+            />
+            {settings.hearPronunciationOnLoad && (
+              <p className="w-full text-xs text-left animate-fade-in-fast">
+                ⚠️ Text-to-speech might not work on all devices.
+              </p>
+            )}
+            <ToggleRow
+              id="celebratory-sound"
+              label="Celebratory sound on correct"
+              checked={settings.celebratorySoundOnCorrect}
+              onChange={(v) => setSetting("celebratorySoundOnCorrect", v)}
+            />
           </section>
         </div>
       </div>

--- a/src/components/production-practice-v1/ModelLoadingScreen.tsx
+++ b/src/components/production-practice-v1/ModelLoadingScreen.tsx
@@ -1,0 +1,46 @@
+import { PracticeButton } from "@/components/ui/practice-button";
+
+export const ModelLoadingScreen = ({
+  status,
+  onRetry,
+  onCancel,
+}: {
+  status: "loading" | "error";
+  onRetry: () => void;
+  onCancel: () => void;
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center w-full h-full gap-6 px-6 text-center animate-fade-in">
+      {status === "loading" ? (
+        <>
+          <div className="text-4xl animate-pulse" aria-hidden>
+            ✍️
+          </div>
+          <div>
+            <h2 className="text-xl font-bold">Loading handwriting model…</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              This only happens once per visit. Hang tight.
+            </p>
+          </div>
+        </>
+      ) : (
+        <>
+          <div>
+            <h2 className="text-xl font-bold">Could not load the model</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Check your connection and try again.
+            </p>
+          </div>
+          <div className="flex flex-col w-full max-w-xs gap-2">
+            <PracticeButton size="lg" onClick={onRetry}>
+              Retry
+            </PracticeButton>
+            <PracticeButton size="md" variant="ghost" onClick={onCancel}>
+              Back
+            </PracticeButton>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/production-practice-v1/ProductionPracticeV1.tsx
+++ b/src/components/production-practice-v1/ProductionPracticeV1.tsx
@@ -1,76 +1,47 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
 import { useLocalStorage } from "@/hooks/use-local-storage";
-import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { useSetOpenedParam } from "@/components/dependent/routing/routing-hooks";
 import KanjiDrawerGlobal from "@/components/screens/ListScreen/Drawer/KanjiDrawerGlobal";
 import { EndSession, PracticeShell } from "@/components/shared-practice";
+import { warmupDaKanji } from "@/lib/dakanji-adapter";
 import { InitialScreen } from "./InitialScreen";
+import { ModelLoadingScreen } from "./ModelLoadingScreen";
 import { Game } from "./Game";
 import { DEFAULT_SETTINGS, SESSION_SIZE, SETTINGS_KEY } from "./constants";
 import {
   Phase,
   PracticeItem,
-  RecognitionPracticeSettings,
+  ProductionPracticeSettings,
   SessionResult,
 } from "./types";
 
-const RecognitionPracticeV1 = () => {
-  useHtmlDocumentTitle("Kanji Recognition");
+const ProductionPracticeV1 = () => {
+  useHtmlDocumentTitle("Kanji Production");
 
-  const [settings] = useLocalStorage<RecognitionPracticeSettings>(
+  const [settings] = useLocalStorage<ProductionPracticeSettings>(
     SETTINGS_KEY,
     DEFAULT_SETTINGS
   );
   const [phase, setPhase] = useState<Phase>("initial");
+  const [loadStatus, setLoadStatus] = useState<"loading" | "error">("loading");
   const [progress, setProgress] = useState(0);
   const [deck, setDeck] = useState<PracticeItem[]>([]);
+  const [randomKanjiPool, setRandomKanjiPool] = useState<string[]>([]);
   const [cursor, setCursor] = useState(0);
   const [sessionItems, setSessionItems] = useState<PracticeItem[]>([]);
   const [sessionKey, setSessionKey] = useState(0);
   const [results, setResults] = useState<SessionResult[] | null>(null);
   const [runResults, setRunResults] = useState<SessionResult[]>([]);
   const [hasMore, setHasMore] = useState(true);
+  const [modelReady, setModelReady] = useState(false);
   const setOpenedKanji = useSetOpenedParam();
 
-  const viewport = useVisualViewport();
-  const primerRef = useRef<HTMLInputElement | null>(null);
-
-  // Kanji details drawer only on end screen; clear open param when leaving ended
   useEffect(() => {
     if (phase !== "ended") {
       setOpenedKanji(null);
     }
   }, [phase, setOpenedKanji]);
-
-  // Keep the play shell pinned to the layout top. Chasing visualViewport.offsetTop
-  // while iOS animates the keyboard makes the whole UI bob; "/" doesn't do that
-  // because ListScreen isn't viewport-pinned at all.
-  useEffect(() => {
-    const vv = window.visualViewport;
-    if (!vv) return;
-
-    const lockScroll = () => {
-      if (window.scrollY !== 0) window.scrollTo(0, 0);
-    };
-
-    vv.addEventListener("scroll", lockScroll);
-    vv.addEventListener("resize", lockScroll);
-    lockScroll();
-    return () => {
-      vv.removeEventListener("scroll", lockScroll);
-      vv.removeEventListener("resize", lockScroll);
-    };
-  }, []);
-
-  const beginPlaying = (items: PracticeItem[], nextCursor: number) => {
-    setSessionItems(items);
-    setCursor(nextCursor);
-    setSessionKey((k) => k + 1);
-    setProgress(0);
-    setResults(null);
-    setPhase("playing");
-  };
 
   const goToInitial = () => {
     setProgress(0);
@@ -78,18 +49,58 @@ const RecognitionPracticeV1 = () => {
     setRunResults([]);
     setHasMore(true);
     setDeck([]);
+    setRandomKanjiPool([]);
     setCursor(0);
     setSessionItems([]);
+    setLoadStatus("loading");
     setPhase("initial");
   };
 
+  const warmAndPlay = async (
+    items: PracticeItem[],
+    nextCursor: number,
+    builtDeck?: PracticeItem[]
+  ) => {
+    if (builtDeck) {
+      setDeck(builtDeck);
+      setRandomKanjiPool(builtDeck.map((item) => item.kanji));
+    }
+    setSessionItems(items);
+    setCursor(nextCursor);
+    setSessionKey((k) => k + 1);
+    setProgress(0);
+    setResults(null);
+
+    if (modelReady) {
+      setPhase("playing");
+      return;
+    }
+
+    setLoadStatus("loading");
+    setPhase("loading");
+    try {
+      await warmupDaKanji();
+      setModelReady(true);
+      setPhase("playing");
+    } catch {
+      setLoadStatus("error");
+    }
+  };
+
   const startGame = (builtDeck: PracticeItem[]) => {
-    primerRef.current?.focus();
-    setDeck(builtDeck);
     setRunResults([]);
     setHasMore(true);
     const chunk = builtDeck.slice(0, SESSION_SIZE);
-    beginPlaying(chunk, chunk.length);
+    void warmAndPlay(chunk, chunk.length, builtDeck);
+  };
+
+  const retryWarmup = () => {
+    const items = sessionItems;
+    if (items.length === 0) {
+      goToInitial();
+      return;
+    }
+    void warmAndPlay(items, cursor);
   };
 
   const finishSession = (sessionResults: SessionResult[]) => {
@@ -105,7 +116,6 @@ const RecognitionPracticeV1 = () => {
 
   const startNextSession = () => {
     if (!hasMore) return;
-    primerRef.current?.focus();
 
     const forgottens = (results ?? [])
       .filter((r) => !r.correct)
@@ -124,7 +134,6 @@ const RecognitionPracticeV1 = () => {
     const remaining = deck.slice(cursor);
     const pool = [...forgottens, ...remaining];
     if (pool.length === 0) {
-      // Nothing left — treat as complete rather than looping forever.
       setHasMore(false);
       setPhase("ended");
       return;
@@ -132,26 +141,25 @@ const RecognitionPracticeV1 = () => {
 
     const chunk = pool.slice(0, SESSION_SIZE);
     const fromRemaining = Math.max(0, chunk.length - forgottens.length);
-    beginPlaying(chunk, cursor + fromRemaining);
+    void warmAndPlay(chunk, cursor + fromRemaining);
   };
 
   return (
     <>
-      <input
-        ref={primerRef}
-        className="sr-only"
-        aria-hidden="true"
-        tabIndex={-1}
-        autoComplete="off"
-      />
-      <PracticeShell
-        progress={progress}
-        playing={phase === "playing"}
-        height={viewport.height}
-      >
+      <PracticeShell progress={progress} playing={phase === "playing"}>
         {phase === "initial" && (
           <div key="initial" className="h-full animate-fade-in">
             <InitialScreen onStart={startGame} />
+          </div>
+        )}
+
+        {phase === "loading" && (
+          <div key="loading" className="h-full animate-fade-in">
+            <ModelLoadingScreen
+              status={loadStatus}
+              onRetry={retryWarmup}
+              onCancel={goToInitial}
+            />
           </div>
         )}
 
@@ -159,7 +167,8 @@ const RecognitionPracticeV1 = () => {
           <div key={`playing-${sessionKey}`} className="h-full animate-fade-in">
             <Game
               sessionItems={sessionItems}
-              sound={settings.sound ?? { enabled: true, type: "correct" }}
+              settings={settings}
+              randomKanjiPool={randomKanjiPool}
               onProgress={setProgress}
               onComplete={finishSession}
               onEnd={goToInitial}
@@ -188,4 +197,4 @@ const RecognitionPracticeV1 = () => {
   );
 };
 
-export default RecognitionPracticeV1;
+export default ProductionPracticeV1;

--- a/src/components/production-practice-v1/StrokeOrderPlayer.tsx
+++ b/src/components/production-practice-v1/StrokeOrderPlayer.tsx
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Raphael from "raphael";
+import "dmak";
+import { useEffect, useId, useRef, useState } from "react";
+import { PracticeButton } from "@/components/ui/practice-button";
+import { PlayCircle, Snail } from "@/components/icons";
+import assetsPaths from "@/lib/assets-paths";
+import { installSafeDmakLoader } from "@/lib/dmak-safe-loader";
+
+installSafeDmakLoader();
+
+type AnimationSpeed = "fast" | "slow";
+
+const SPEEDS: Record<AnimationSpeed, { rate: number }> = {
+  fast: { rate: 0.0095 },
+  slow: { rate: 0.022 },
+};
+
+const KanjiDMAK = ({
+  kanji,
+  step,
+  size,
+}: {
+  kanji: string;
+  step: number;
+  size: number;
+}) => {
+  const dmakInstanceRef = useRef<any>(null);
+  const id = useId();
+  const kanjiId = `${id}-${kanji}-draw`;
+
+  useEffect(() => {
+    (window as any).Raphael = Raphael;
+
+    if (dmakInstanceRef.current) {
+      return;
+    }
+
+    dmakInstanceRef.current = new (window as any).Dmak(kanji, {
+      element: kanjiId,
+      uri:
+        import.meta.env.MODE === "development" ||
+        window.location.protocol === "http:"
+          ? assetsPaths.dev.KANJI_SVGS
+          : assetsPaths.KANJI_SVGS,
+      height: size,
+      width: size,
+      step,
+      stroke: { attr: { stroke: "random" } },
+      grid: { show: true },
+    });
+
+    return () => {
+      (window as any).Raphael = null;
+    };
+  }, [kanji, kanjiId, step, size]);
+
+  return <div id={kanjiId} />;
+};
+
+export const StrokeOrderPlayer = ({
+  kanji,
+  size = 160,
+}: {
+  kanji: string;
+  size?: number;
+}) => {
+  const [key, setKey] = useState(1);
+  const [speed, setSpeed] = useState<AnimationSpeed>("fast");
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div style={{ height: size }} key={`${kanji}-${speed}-${key}`}>
+        <KanjiDMAK kanji={kanji} step={SPEEDS[speed].rate} size={size} />
+      </div>
+      <div className="flex justify-center space-x-1.5 sm:space-x-2">
+        <PracticeButton
+          size="icon"
+          className="h-10 w-10 sm:h-12 sm:w-12"
+          onClick={() => {
+            setSpeed("fast");
+            setKey((x) => x + 1);
+          }}
+        >
+          <PlayCircle />
+          <span className="sr-only">Animate</span>
+        </PracticeButton>
+        <PracticeButton
+          size="icon"
+          variant="secondary"
+          className="h-10 w-10 sm:h-12 sm:w-12"
+          onClick={() => {
+            setSpeed("slow");
+            setKey((x) => x + 1);
+          }}
+        >
+          <Snail />
+          <span className="sr-only">Animate Slowly</span>
+        </PracticeButton>
+      </div>
+    </div>
+  );
+};

--- a/src/components/production-practice-v1/StrokePreview.tsx
+++ b/src/components/production-practice-v1/StrokePreview.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useId, useState } from "react";
+import type { Stroke } from "@/components/dependent/DrawingPad";
+
+function getSvgPathFromStroke(stroke: number[][]): string {
+  if (!stroke.length) return "";
+  const d: (string | number)[] = ["M", ...stroke[0], "Q"];
+  for (let i = 0; i < stroke.length; i++) {
+    const [x0, y0] = stroke[i];
+    const [x1, y1] = stroke[(i + 1) % stroke.length];
+    d.push(x0, y0, (x0 + x1) / 2, (y0 + y1) / 2);
+  }
+  d.push("Z");
+  return d.join(" ");
+}
+
+/**
+ * Read-only replay of a DrawingPad stroke snapshot.
+ * `sourceSize` must match the pad the strokes were drawn on (viewBox);
+ * `displaySize` is the on-screen square size.
+ */
+export const StrokePreview = ({
+  strokes,
+  sourceSize,
+  displaySize,
+}: {
+  strokes: Stroke[];
+  sourceSize: number;
+  displaySize: number;
+}) => {
+  const patternId = useId();
+  const [getStrokeFn, setGetStrokeFn] = useState<
+    ((points: number[][], options: object) => number[][]) | null
+  >(null);
+
+  useEffect(() => {
+    void import("perfect-freehand").then((m) => {
+      setGetStrokeFn(() => m.getStroke);
+    });
+  }, []);
+
+  const renderPath = (points: Stroke) => {
+    if (!getStrokeFn || !points.length) return null;
+    const outline = getStrokeFn(points, {
+      size: 16,
+      thinning: 0.7,
+      smoothing: 0.7,
+      streamline: 0.5,
+      easing: (t: number) => t,
+      simulatePressure: true,
+      last: true,
+      start: { cap: true, taper: 0, easing: (t: number) => t },
+      end: { cap: true, taper: 0, easing: (t: number) => t },
+    });
+    return getSvgPathFromStroke(outline);
+  };
+
+  return (
+    <svg
+      width={displaySize}
+      height={displaySize}
+      viewBox={`0 0 ${sourceSize} ${sourceSize}`}
+      className="border-2 border-dotted select-none border-foreground rounded-3xl"
+      style={{ background: "hsl(var(--background))" }}
+    >
+      <defs>
+        <pattern
+          id={patternId}
+          x="14"
+          y="14"
+          width="28"
+          height="28"
+          patternUnits="userSpaceOnUse"
+        >
+          <circle cx="0" cy="0" r="1" fill="hsl(var(--foreground))" opacity="0.25" />
+        </pattern>
+      </defs>
+      <rect width={sourceSize} height={sourceSize} fill={`url(#${patternId})`} />
+      <line
+        x1={0}
+        y1={sourceSize / 2}
+        x2={sourceSize}
+        y2={sourceSize / 2}
+        stroke="hsl(var(--foreground))"
+        strokeDasharray="10 4"
+      />
+      <line
+        x1={sourceSize / 2}
+        y1={0}
+        x2={sourceSize / 2}
+        y2={sourceSize}
+        stroke="hsl(var(--foreground))"
+        strokeDasharray="10 4"
+      />
+      {strokes.map((pts, i) => {
+        const d = renderPath(pts);
+        return d ? (
+          <path
+            key={i}
+            d={d}
+            style={{ fill: "rgba(var(--theme-color-selected), 1)" }}
+          />
+        ) : null;
+      })}
+    </svg>
+  );
+};

--- a/src/components/production-practice-v1/WritingPracticeModal.tsx
+++ b/src/components/production-practice-v1/WritingPracticeModal.tsx
@@ -1,0 +1,40 @@
+import { lazy, Suspense } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ErrorBoundary } from "@/components/error";
+import { StrokeAnimationLoadingScreen } from "@/components/sections/KanjiDetails/StrokeAnimationLoadingScreen";
+
+const StrokeAnimation = lazy(
+  () => import("@/components/sections/KanjiDetails/StrokeAnimation")
+);
+
+export const WritingPracticeModal = ({
+  open,
+  onOpenChange,
+  kanji,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  kanji: string;
+}) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[90dvh] overflow-y-auto px-4 py-0 sm:rounded-2xl">
+        <DialogHeader className="px-6 pt-6 pb-0">
+          <DialogTitle className="flex items-center text-center">
+            <span className="text-3xl kanji-font">{kanji}</span>
+          </DialogTitle>
+        </DialogHeader>
+        <ErrorBoundary details="StrokeAnimation in WritingPracticeModal">
+          <Suspense fallback={<StrokeAnimationLoadingScreen />}>
+            <StrokeAnimation key={kanji} kanji={kanji} defaultPracticeMode />
+          </Suspense>
+        </ErrorBoundary>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/production-practice-v1/build-candidates.ts
+++ b/src/components/production-practice-v1/build-candidates.ts
@@ -1,0 +1,58 @@
+import { shuffle } from "@/lib/utils";
+import { CANDIDATE_COUNT } from "./constants";
+
+/**
+ * Build a 10-kanji look-alike grid.
+ * Always shuffled so a top-model hit is not always in the first cell.
+ * Fill order before shuffle: target → similars / model guesses → random pool.
+ */
+export const buildCandidateGrid = ({
+  target,
+  inTop10,
+  modelGuesses,
+  similars,
+  randomPool,
+}: {
+  target: string;
+  inTop10: boolean;
+  modelGuesses: string[];
+  similars: string[];
+  randomPool: string[];
+}): string[] => {
+  if (inTop10) {
+    return padCandidates(
+      modelGuesses.slice(0, CANDIDATE_COUNT),
+      target,
+      [],
+      randomPool
+    );
+  }
+
+  return padCandidates([], target, similars, [
+    ...modelGuesses,
+    ...randomPool,
+  ]);
+};
+
+const padCandidates = (
+  seed: string[],
+  target: string,
+  similars: string[],
+  filler: string[]
+): string[] => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  const push = (k: string) => {
+    if (!k || seen.has(k) || out.length >= CANDIDATE_COUNT) return;
+    seen.add(k);
+    out.push(k);
+  };
+
+  push(target);
+  for (const k of seed) push(k);
+  for (const k of similars) push(k);
+  for (const k of filler) push(k);
+
+  return shuffle(out);
+};

--- a/src/components/production-practice-v1/constants.ts
+++ b/src/components/production-practice-v1/constants.ts
@@ -1,0 +1,19 @@
+import { JLPT_TYPE_ARR, JLTPTtypes } from "@/lib/jlpt";
+import { ProductionPracticeSettings } from "./types";
+
+export const SESSION_SIZE = 10;
+export const CANDIDATE_COUNT = 10;
+export const SETTINGS_KEY = "production-practice-v1-settings";
+
+export const DEFAULT_SETTINGS: ProductionPracticeSettings = {
+  jlpt: [...JLPT_TYPE_ARR] as JLTPTtypes[],
+  bookmarkedOnly: false,
+  randomizeOrder: true,
+  randomizeFont: false,
+  blurEnglishGloss: true,
+  hearPronunciationOnLoad: false,
+  celebratorySoundOnCorrect: true,
+};
+
+/** Same as Stroke Order · Writing Practice; shrink via useFitPadSize on narrow screens. */
+export { SVG_SIZE as DRAW_SVG_SIZE } from "@/components/sections/KanjiDetails/stroke-animation-constants";

--- a/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
+++ b/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { PracticeButton } from "@/components/ui/practice-button";
+import { feedbackTitle } from "@/lib/dakanji-grade";
+import { StrokeOrderPlayer } from "../StrokeOrderPlayer";
+import { StrokePreview } from "../StrokePreview";
+import { WritingPracticeModal } from "../WritingPracticeModal";
+import type { DrawingSnapshot, GradeRankInfo, PracticeItem } from "../types";
+import { ItemReveal } from "./ItemReveal";
+import { NextKanjiFooter, PracticeDrawerShell } from "./PracticeDrawerShell";
+
+/** Side-by-side preview size; stays under ~42vw so 320px phones don't overflow. */
+const PREVIEW_SIZE = 130;
+
+export const FeedbackDrawer = ({
+  open,
+  kind,
+  item,
+  grade,
+  drawing,
+  onNext,
+}: {
+  open: boolean;
+  kind: "noKanji" | "correct" | "incorrect";
+  item: PracticeItem;
+  grade: GradeRankInfo;
+  drawing: DrawingSnapshot | null;
+  onNext: () => void;
+}) => {
+  const [practiceOpen, setPracticeOpen] = useState(false);
+
+  const title =
+    kind === "noKanji"
+      ? "No worries — here it is"
+      : feedbackTitle(kind === "correct" ? "correct" : "incorrect", grade.rank);
+
+  const bounce = kind === "correct" && grade.rank === 0;
+
+  return (
+    <>
+      <PracticeDrawerShell
+        open={open}
+        showHandle={false}
+        title={title}
+        titleClassName={bounce ? "animate-practice-bounce-soft" : undefined}
+        description={<ItemReveal item={item} />}
+        footer={<NextKanjiFooter onNext={onNext} />}
+      >
+        {kind === "noKanji" ? (
+          <div className="flex flex-col items-center gap-2 px-3 pb-2 mt-4 overflow-y-auto sm:px-4">
+            <StrokeOrderPlayer kanji={item.kanji} size={PREVIEW_SIZE + 30} />
+            <PracticeButton
+              size="default"
+              variant="ghost"
+              className="text-sm underline underline-offset-4 decoration-dotted"
+              onClick={() => setPracticeOpen(true)}
+            >
+              Practice More
+            </PracticeButton>
+          </div>
+        ) : (
+          <div className="px-2 pt-4 pb-2 mt-2 overflow-y-auto sm:px-3">
+            {/* flex + w-fit keeps the two columns tight (grid max-w-* stretched them apart). */}
+            <div className="flex flex-row items-start justify-center gap-2 mx-auto w-fit sm:gap-3">
+              <div className="flex flex-col items-center gap-2 shrink-0">
+                <p className="text-xs font-bold uppercase text-muted-foreground">
+                  You Drew
+                </p>
+                {drawing && drawing.strokes.length > 0 ? (
+                  <StrokePreview
+                    strokes={drawing.strokes}
+                    sourceSize={drawing.width}
+                    displaySize={PREVIEW_SIZE}
+                  />
+                ) : (
+                  <div
+                    className="flex items-center justify-center text-sm border-2 border-dashed text-muted-foreground rounded-3xl"
+                    style={{ width: PREVIEW_SIZE, height: PREVIEW_SIZE }}
+                  >
+                    —
+                  </div>
+                )}
+                <PracticeButton
+                  size="default"
+                  variant="ghost"
+                  className="text-sm underline underline-offset-4 decoration-dotted"
+                  onClick={() => setPracticeOpen(true)}
+                >
+                  Practice More
+                </PracticeButton>
+              </div>
+              <div className="flex flex-col items-center gap-2 shrink-0">
+                <p className="text-xs font-bold uppercase text-muted-foreground">
+                  Stroke Order
+                </p>
+                <StrokeOrderPlayer kanji={item.kanji} size={PREVIEW_SIZE} />
+              </div>
+            </div>
+          </div>
+        )}
+      </PracticeDrawerShell>
+
+      <WritingPracticeModal
+        open={practiceOpen}
+        onOpenChange={setPracticeOpen}
+        kanji={item.kanji}
+      />
+    </>
+  );
+};

--- a/src/components/production-practice-v1/drawers/ItemReveal.tsx
+++ b/src/components/production-practice-v1/drawers/ItemReveal.tsx
@@ -1,0 +1,20 @@
+import { RomajiBadge } from "@/components/dependent/kana/RomajiBadge";
+import { SpeakButton } from "@/components/common/SpeakButton";
+import type { PracticeItem } from "../types";
+
+/** Kanji · reading badges · speak · gloss — shared across feedback drawers. */
+export const ItemReveal = ({ item }: { item: PracticeItem }) => (
+  <div className="flex flex-col items-center gap-1 text-foreground">
+    <div className="flex flex-wrap items-center justify-center gap-1">
+      <span className="text-2xl kanji-font">{item.kanji}</span>
+      <span className="mx-1 text-base font-normal">·</span>
+      {item.reading.split("・").map((r) => (
+        <RomajiBadge key={r} kana={r} />
+      ))}
+      <SpeakButton word={item.word} iconType="volume-2" />
+    </div>
+    <p className="text-xs font-bold text-muted-foreground">
+      {item.englishGloss || item.keyword}
+    </p>
+  </div>
+);

--- a/src/components/production-practice-v1/drawers/PracticeDrawerShell.tsx
+++ b/src/components/production-practice-v1/drawers/PracticeDrawerShell.tsx
@@ -1,0 +1,63 @@
+import { ReactNode } from "react";
+import { PracticeButton } from "@/components/ui/practice-button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+
+/** Shared bottom-sheet chrome for production-practice drawers. */
+export const PracticeDrawerShell = ({
+  open,
+  title,
+  titleClassName,
+  description,
+  children,
+  footer,
+  showHandle = true,
+}: {
+  open: boolean;
+  title: ReactNode;
+  titleClassName?: string;
+  description?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  /** Top drag-handle pill. Hide on feedback drawers. */
+  showHandle?: boolean;
+}) => {
+  return (
+    <Drawer open={open} dismissible={false}>
+      <DrawerContent
+        showHandle={showHandle}
+        className="max-h-[92dvh] border-2 border-t-4 [border-top-style:dashed]"
+      >
+        <DrawerHeader className="pb-2 text-center">
+          <DrawerTitle
+            className={`text-lg pb-2 font-bold text-center animate-practice-bounce-soft ${titleClassName ?? ""}`}
+          >
+            {title}
+          </DrawerTitle>
+          {description != null && (
+            <DrawerDescription asChild>
+              <div className="text-sm font-bold text-center text-foreground">
+                {description}
+              </div>
+            </DrawerDescription>
+          )}
+        </DrawerHeader>
+        {children}
+        {footer}
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export const NextKanjiFooter = ({ onNext }: { onNext: () => void }) => (
+  <div className="px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] max-w-md mx-auto w-full">
+    <PracticeButton size="lg" onClick={onNext}>
+      Next Kanji →
+    </PracticeButton>
+  </div>
+);

--- a/src/components/production-practice-v1/drawers/SelectSimilarKanjiDrawer.tsx
+++ b/src/components/production-practice-v1/drawers/SelectSimilarKanjiDrawer.tsx
@@ -1,0 +1,80 @@
+import { PracticeButton } from "@/components/ui/practice-button";
+import { gradeHeadline } from "@/lib/dakanji-grade";
+import { cn } from "@/lib/utils";
+import type { GradeRankInfo } from "../types";
+import { PracticeDrawerShell } from "./PracticeDrawerShell";
+
+export const SelectSimilarKanjiDrawer = ({
+  open,
+  grade,
+  candidates,
+  selected,
+  onSelect,
+  onForgot,
+  onNext,
+}: {
+  open: boolean;
+  grade: GradeRankInfo;
+  candidates: string[];
+  selected: string | null;
+  onSelect: (k: string | null) => void;
+  onForgot: () => void;
+  onNext: () => void;
+}) => {
+  const hasSelection = selected != null;
+
+  return (
+    <PracticeDrawerShell
+      open={open}
+      title={gradeHeadline(grade.rank)}
+      description={
+        grade.inTop10 ? "Which kanji did you draw?" : "Which kanji is correct?"
+      }
+      footer={
+        <div className="grid grid-cols-2 gap-2 px-3 sm:px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] max-w-md mx-auto w-full">
+          <PracticeButton
+            variant="danger"
+            size="md"
+            disabled={hasSelection}
+            onClick={onForgot}
+          >
+            Forgot
+          </PracticeButton>
+          <PracticeButton
+            variant="primary"
+            size="md"
+            disabled={!hasSelection}
+            onClick={onNext}
+          >
+            Next
+          </PracticeButton>
+        </div>
+      }
+    >
+      <div className="px-3 pb-2 overflow-y-auto sm:px-4">
+        <div className="grid max-w-md grid-cols-4 sm:grid-cols-5 gap-1.5 mx-auto sm:gap-2">
+          {candidates.map((c) => {
+            const isSelected = selected === c;
+            return (
+              <PracticeButton
+                key={c}
+                type="button"
+                size="icon"
+                variant={isSelected ? "primary" : "secondary"}
+                onClick={() => onSelect(isSelected ? null : c)}
+                className={cn(
+                  "aspect-square h-auto w-full min-h-0 p-0 sm:text-5xl text-4xl kanji-font rounded-xl",
+                  !isSelected && "border-dashed"
+                )}
+                aria-pressed={isSelected}
+                aria-label={isSelected ? `Deselect ${c}` : `Select ${c}`}
+              >
+                {c}
+              </PracticeButton>
+            );
+          })}
+        </div>
+      </div>
+    </PracticeDrawerShell>
+  );
+};

--- a/src/components/production-practice-v1/index.tsx
+++ b/src/components/production-practice-v1/index.tsx
@@ -1,0 +1,21 @@
+import { lazy, Suspense } from "react";
+import { ErrorBoundary } from "@/components/error";
+
+const LazyProductionPracticeV1 = lazy(() => import("./ProductionPracticeV1"));
+
+const PracticeRouteFallback = () => (
+  <div className="fixed inset-0 bg-background animate-fade-in" aria-hidden />
+);
+
+const ProductionPracticeV1Screen = () => {
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<PracticeRouteFallback />}>
+        <LazyProductionPracticeV1 />
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
+
+export { ProductionPracticeV1Screen };
+export default ProductionPracticeV1Screen;

--- a/src/components/production-practice-v1/types.ts
+++ b/src/components/production-practice-v1/types.ts
@@ -1,0 +1,34 @@
+import type { Stroke } from "@/components/dependent/DrawingPad";
+import type { PracticeItem as SharedPracticeItem } from "@/components/shared-practice";
+import { JLTPTtypes } from "@/lib/jlpt";
+
+export type ProductionPracticeSettings = {
+  jlpt: JLTPTtypes[];
+  bookmarkedOnly: boolean;
+  randomizeOrder: boolean;
+  randomizeFont: boolean;
+  blurEnglishGloss: boolean;
+  hearPronunciationOnLoad: boolean;
+  celebratorySoundOnCorrect: boolean;
+};
+
+export type PracticeItem = SharedPracticeItem;
+
+export type SessionResult = PracticeItem & {
+  correct: boolean;
+  gradeRank: number;
+};
+
+export type Phase = "initial" | "loading" | "playing" | "ended";
+
+export type GradeRankInfo = {
+  rank: number;
+  topGuess: string | null;
+  inTop10: boolean;
+};
+
+export type DrawingSnapshot = {
+  strokes: Stroke[];
+  width: number;
+  height: number;
+};

--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -164,22 +164,27 @@ export const Game = ({
             current.fontIndex === null
               ? undefined
               : {
-                fontFamily: `var(--jap-font-${current.fontIndex}), "Noto Sans JP", system-ui`,
-              }
+                  fontFamily: `var(--jap-font-${current.fontIndex}), "Noto Sans JP", system-ui`,
+                }
           }
         >
-          <p className={`${current.word.length > 4 ? "text-6xl" : current.word.length < 2 ? "text-8xl" : "text-7xl"} leading-tight break-all md:text-8xl whitespace-nowrap`}>
+          <p
+            className={`${current.word.length > 4 ? "text-6xl" : current.word.length < 2 ? "text-8xl" : "text-7xl"} leading-tight break-all md:text-8xl whitespace-nowrap`}
+          >
             {current.word}
           </p>
         </div>
 
         <button
           type="button"
-          className={`max-w-sm px-2 text-xs font-bold tracking-wide transition-all outline-none focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0 ${glossBlurred && feedback == null ? "blur-[5px] hover:blur-none" : ""
-            }`}
+          className={`max-w-sm px-2 text-xs font-bold tracking-wide transition-all outline-none focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0 ${
+            glossBlurred && feedback == null ? "blur-[5px] hover:blur-none" : ""
+          }`}
           onClick={() => setGlossBlurred((v) => !v)}
           aria-label={
-            glossBlurred && feedback == null ? "Reveal English gloss" : "Blur English gloss"
+            glossBlurred && feedback == null
+              ? "Reveal English gloss"
+              : "Blur English gloss"
           }
         >
           {current.englishGloss || "—"}
@@ -199,7 +204,7 @@ export const Game = ({
               spellCheck={false}
               aria-label='Type the reading or type "forgot"'
               placeholder='Type the reading or type "forgot"'
-              className="relative w-full mt-2 text-center border-2 rounded-2xl h-14 focus-visible:ring-offset-0 animate-fade-in"
+              className="relative w-full p-0 mt-2 text-xl text-center border-2 rounded-2xl h-14 focus-visible:ring-offset-0 animate-fade-in"
               onKeyDown={handleKeyDown}
               onCompositionStart={() => {
                 isComposingRef.current = true;

--- a/src/components/recognition-practice-v1/types.ts
+++ b/src/components/recognition-practice-v1/types.ts
@@ -1,3 +1,4 @@
+import type { PracticeItem as SharedPracticeItem } from "@/components/shared-practice";
 import { JLTPTtypes } from "@/lib/jlpt";
 
 export type SoundMode = "correct" | "speak";
@@ -10,14 +11,7 @@ export type RecognitionPracticeSettings = {
   sound: { enabled: true; type: SoundMode } | { enabled: false };
 };
 
-export type PracticeItem = {
-  kanji: string;
-  word: string;
-  reading: string;
-  englishGloss: string;
-  keyword: string;
-  fontIndex: number | null;
-};
+export type PracticeItem = SharedPracticeItem;
 
 export type SessionResult = PracticeItem & {
   correct: boolean;

--- a/src/components/screens/ListScreen/PracticeFab.tsx
+++ b/src/components/screens/ListScreen/PracticeFab.tsx
@@ -1,28 +1,19 @@
 import { useEffect, useRef, useState } from "react";
-import { Eye, Keyboard, NotebookPen } from "lucide-react";
+import { NotebookPen } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { PracticeButton } from "@/components/ui/practice-button";
-import { DashedNavLink } from "@/components/common/DashedNavLink";
-import { practicePageLinks } from "@/components/items/practice-pages";
+import { DashedNavLinkList } from "@/components/common/DashedNavLinkList";
+import { practiceNavLinks } from "@/components/items/nav-links";
 import { useBgSrc } from "@/components/dependent/routing/routing-hooks";
 import { cn } from "@/lib/utils";
 
-const practiceLinkIcons = {
-  "/recognition-practice": Eye,
-  "/speed-katakana": Keyboard,
-} as const;
-
-const practiceLinks = practicePageLinks.map((page) => ({
-  ...page,
-  Icon: practiceLinkIcons[page.href],
-}));
-
 const prefetchPracticeRoutes = () => {
   void import("@/components/recognition-practice-v1/RecognitionPracticeV1");
+  void import("@/components/production-practice-v1/ProductionPracticeV1");
   void import("@/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen");
 };
 
@@ -120,19 +111,11 @@ export const PracticeFab = () => {
         <p className="px-1 mb-2 text-sm font-semibold text-left">
           What do you want to do?
         </p>
-        <div className="flex flex-row gap-2">
-          {practiceLinks.map((item) => (
-            <DashedNavLink
-              key={item.href}
-              href={item.href}
-              title={item.title}
-              description={item.description}
-              Icon={item.Icon}
-              onClick={() => setOpen(false)}
-              className="flex-1"
-            />
-          ))}
-        </div>
+        <DashedNavLinkList
+          items={practiceNavLinks}
+          className="grid grid-cols-2 gap-2"
+          onItemClick={() => setOpen(false)}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -22,7 +22,7 @@ import { DebugInfo } from "@/components/common/DebugInfo";
 import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
 import { useKanjiRepresentativeWord } from "@/providers/kanji-representative-word-provider";
 import { KanjiWordStatusActions } from "./KanjiWordStatusActions";
-import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
+import { StrokeAnimationLoadingScreen } from "./StrokeAnimationLoadingScreen";
 
 
 export const RirikkuCTABadge = () => {
@@ -73,55 +73,6 @@ export const KanjiDetailsBottom = ({ kanji }: { kanji: string }) => {
   </>
 }
 const StrokeAnimation = lazy(() => import("./StrokeAnimation"));
-
-const StrokeAnimationLoadingScreen = () => {
-  return (
-    <div className="p-4">
-      <div className="flex px-4 pt-6 pb-2">
-        <div className="flex items-center gap-2">
-          <div className="h-5 rounded-full w-9 bg-muted animate-pulse" />
-          <div className="w-24 h-3 rounded-lg bg-muted animate-pulse" />
-        </div>
-      </div>
-      <div className={CONTAINER_CN} style={{ height: SVG_SIZE }}>
-        <div
-          className="relative overflow-hidden rounded-3xl bg-muted animate-pulse"
-          style={{ width: SVG_SIZE, height: SVG_SIZE }}
-        >
-          <svg
-            width={SVG_SIZE}
-            height={SVG_SIZE}
-            className="absolute inset-0 text-foreground opacity-10"
-            aria-hidden
-          >
-            <line
-              x1={SVG_SIZE / 2}
-              y1={0}
-              x2={SVG_SIZE / 2}
-              y2={SVG_SIZE}
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeDasharray="5 5"
-            />
-            <line
-              x1={0}
-              y1={SVG_SIZE / 2}
-              x2={SVG_SIZE}
-              y2={SVG_SIZE / 2}
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeDasharray="5 5"
-            />
-          </svg>
-        </div>
-      </div>
-      <div className="flex justify-center space-x-2">
-        <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
-        <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
-      </div>
-    </div>
-  );
-};
 
 const RepresentativeStudyWordAccordion = ({ kanji }: { kanji: string }) => {
 

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -13,6 +13,8 @@ import {
   Stroke,
 } from "@/components/dependent/DrawingPad";
 import { recognizeWithDaKanji } from "@/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/recognizers";
+import { gradeMessage, type GradeResult } from "@/lib/dakanji-grade";
+import { useFitPadSize } from "@/hooks/use-fit-pad-size";
 import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
 import { Rocket } from "lucide-react";
 
@@ -155,31 +157,6 @@ const HintSection = ({ kanji }: { kanji: string }) => {
 
 type GradeStatus = "idle" | "loading" | "success" | "error";
 
-type GradeResult = {
-  rank: number; // 0-based index in top-10, or -1 if missing
-  topGuess: string | null;
-};
-
-const gradeMessage = (kanji: string, result: GradeResult): string => {
-  const { rank, topGuess } = result;
-  if (rank === 0) {
-    return `🎯 Awesome · That's ${kanji}`;
-  }
-  if (rank >= 1 && rank <= 2) {
-    return topGuess
-      ? `💚 Solid · Near miss — a bit like ${topGuess}`
-      : `💚 Solid · Near miss — keep refining`;
-  }
-  if (rank >= 3) {
-    return topGuess
-      ? `🌀 Getting there · Looks more like ${topGuess}`
-      : `🌀 Getting there · Keep refining`;
-  }
-  return topGuess
-    ? `🙈 Not quite · Looks more like ${topGuess}`
-    : `🙈 Not quite · Try again`;
-};
-
 const DAKANJI_CREDIT_HREF =
   "https://github.com/dariyooo/DaKanji-Single-Kanji-Recognition";
 
@@ -187,6 +164,13 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
   const [strokes, setStrokes] = useState<Stroke[]>([]);
   const [status, setStatus] = useState<GradeStatus>("idle");
   const [result, setResult] = useState<GradeResult | null>(null);
+  const padSize = useFitPadSize(SVG_SIZE);
+
+  useEffect(() => {
+    setStrokes([]);
+    setStatus("idle");
+    setResult(null);
+  }, [padSize]);
 
   const onGrade = async (payload: DrawingSubmitPayload) => {
     if (payload.strokes.length === 0) {
@@ -213,9 +197,9 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
   };
 
   return (
-    <div className="flex flex-col items-center gap-3 px-4 pt-4 pb-6 animate-fade-in">
+    <div className="flex flex-col items-center gap-3 px-2 pt-4 pb-6 sm:px-4 animate-fade-in">
       <DrawingPad
-        svgSize={SVG_SIZE}
+        svgSize={padSize}
         strokes={strokes}
         setStrokes={setStrokes}
         showSubmitBtn
@@ -226,7 +210,7 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
         onClickClear={onClear}
       />
 
-      <div className="w-full max-w-[310px] min-h-10 px-2 text-base font-bold text-center">
+      <div className="w-full max-w-[310px] min-h-10 px-2 text-sm sm:text-base font-bold text-center">
         {status === "loading" && (
           <div className="animate-fade-in opacity-80">採点中 · Grading…</div>
         )}
@@ -261,8 +245,15 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
   );
 };
 
-const StrokeAnimationWithPracticeMode = ({ kanji }: { kanji: string }) => {
-  const [practiceMode, setPracticeMode] = useState(false);
+export const StrokeAnimationWithPracticeMode = ({
+  kanji,
+  defaultPracticeMode = false,
+}: {
+  kanji: string;
+  /** When true (e.g. practice modal), start on the drawing pad. */
+  defaultPracticeMode?: boolean;
+}) => {
+  const [practiceMode, setPracticeMode] = useState(defaultPracticeMode);
 
   return (
     <div key={kanji}>
@@ -280,16 +271,24 @@ const StrokeAnimationWithPracticeMode = ({ kanji }: { kanji: string }) => {
             Practice writing
           </label>
 
-          {practiceMode && <div className="absolute px-2 m-4 border border-dashed -right-8 animate-fade-in rounded-2xl -top-10 border-foreground">
-            <HintSection key={kanji} kanji={kanji} />
-          </div>}
+          {practiceMode && (
+            <div className="absolute z-10 px-2 m-4 border border-dashed right-0 sm:-right-8 animate-fade-in rounded-2xl -top-10 border-foreground bg-background/80">
+              <HintSection key={kanji} kanji={kanji} />
+            </div>
+          )}
         </div>
       </div>
-      {practiceMode ? (
-        <WritingPracticeMode kanji={kanji} />
-      ) : (
-        <StrokeAnimation kanji={kanji} />
-      )}
+      {/*
+        Cap min-height to the dialog/viewport so short phones don't get a
+        forced 530px panel (which overflows and feels broken).
+      */}
+      <div className="min-h-[min(530px,calc(90dvh-11rem))]">
+        {practiceMode ? (
+          <WritingPracticeMode kanji={kanji} />
+        ) : (
+          <StrokeAnimation kanji={kanji} />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/sections/KanjiDetails/StrokeAnimationLoadingScreen.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimationLoadingScreen.tsx
@@ -1,0 +1,51 @@
+import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
+
+/** Shared Suspense fallback for lazy-loaded StrokeAnimation. */
+export const StrokeAnimationLoadingScreen = () => {
+  return (
+    <div className="p-4">
+      <div className="flex px-4 pt-6 pb-2">
+        <div className="flex items-center gap-2">
+          <div className="h-5 rounded-full w-9 bg-muted animate-pulse" />
+          <div className="w-24 h-3 rounded-lg bg-muted animate-pulse" />
+        </div>
+      </div>
+      <div className={CONTAINER_CN} style={{ height: SVG_SIZE }}>
+        <div
+          className="relative overflow-hidden rounded-3xl bg-muted animate-pulse"
+          style={{ width: SVG_SIZE, height: SVG_SIZE }}
+        >
+          <svg
+            width={SVG_SIZE}
+            height={SVG_SIZE}
+            className="absolute inset-0 text-foreground opacity-10"
+            aria-hidden
+          >
+            <line
+              x1={SVG_SIZE / 2}
+              y1={0}
+              x2={SVG_SIZE / 2}
+              y2={SVG_SIZE}
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeDasharray="5 5"
+            />
+            <line
+              x1={0}
+              y1={SVG_SIZE / 2}
+              x2={SVG_SIZE}
+              y2={SVG_SIZE / 2}
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeDasharray="5 5"
+            />
+          </svg>
+        </div>
+      </div>
+      <div className="flex justify-center space-x-2">
+        <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
+        <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
+      </div>
+    </div>
+  );
+};

--- a/src/components/shared-practice/EndSession.tsx
+++ b/src/components/shared-practice/EndSession.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { pickEndCheer } from "@/lib/practice-cheers";
-import { SessionResult } from "./types";
+import { PracticeSessionResult } from "./types";
 import { RecapTile } from "./RecapTile";
 
 const COUNT_UP_MS = 900;
@@ -60,7 +60,7 @@ export const EndSession = ({
   onNext,
   onEnd,
 }: {
-  results: SessionResult[];
+  results: PracticeSessionResult[];
   /** False when every word in the deck has been answered correctly. */
   hasMore: boolean;
   /** Total words in the filtered deck (used on the final complete screen). */

--- a/src/components/shared-practice/PracticeShell.tsx
+++ b/src/components/shared-practice/PracticeShell.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from "react";
+import { PracticeHeader } from "@/components/site-layout/PracticeHeader";
+
+/**
+ * Full-screen practice layout.
+ * No scrollbar-padding compensation — opening the kanji drawer must not
+ * shift content horizontally (same approach as recognition-practice).
+ */
+export const PracticeShell = ({
+  progress,
+  playing,
+  children,
+  height,
+}: {
+  progress: number;
+  playing?: boolean;
+  children: ReactNode;
+  /** When set (e.g. visualViewport height for keyboard-safe recognition). */
+  height?: number;
+}) => (
+  <div
+    className={
+      height != null
+        ? "fixed inset-x-0 top-0 flex flex-col overflow-hidden bg-background"
+        : "fixed inset-x-0 top-0 bottom-0 flex flex-col overflow-hidden bg-background"
+    }
+    style={height != null ? { height } : undefined}
+  >
+    <PracticeHeader progress={progress} />
+    <main
+      className={`flex-1 min-h-0 overflow-hidden ${
+        playing ? "pt-0 pb-2" : "py-2"
+      }`}
+    >
+      {children}
+    </main>
+  </div>
+);

--- a/src/components/shared-practice/RecapTile.tsx
+++ b/src/components/shared-practice/RecapTile.tsx
@@ -1,6 +1,6 @@
 import { GlobalKanjiLink } from "@/components/dependent/routing";
 
-/** Compact recap tile — swap this component to change End Screen tile style. */
+/** Compact recap tile for practice end screens. */
 export const RecapTile = ({
   kanji,
   keyword,
@@ -12,8 +12,9 @@ export const RecapTile = ({
 }) => {
   return (
     <div
-      className={`relative rounded-xl border border-dashed ${correct ? "border-foreground" : " "
-        }`}
+      className={`relative rounded-xl border border-dashed ${
+        correct ? "border-foreground" : " "
+      }`}
     >
       <GlobalKanjiLink kanji={kanji} keyword={keyword} fontSize="text-4xl" />
     </div>

--- a/src/components/shared-practice/ToggleRow.tsx
+++ b/src/components/shared-practice/ToggleRow.tsx
@@ -1,0 +1,21 @@
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+
+export const ToggleRow = ({
+  id,
+  label,
+  checked,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) => (
+  <div className="flex items-center justify-between gap-4">
+    <Label htmlFor={id} className="text-sm cursor-pointer">
+      {label}
+    </Label>
+    <Switch id={id} checked={checked} onCheckedChange={onChange} />
+  </div>
+);

--- a/src/components/shared-practice/build-deck.ts
+++ b/src/components/shared-practice/build-deck.ts
@@ -2,7 +2,7 @@ import { JLPTOptionsCount, JLTPTtypes } from "@/lib/jlpt";
 import { isBookmarked } from "@/lib/bookmarks";
 import { shuffle } from "@/lib/utils";
 import { NUMBER_OF_FONTS } from "@/hooks/use-change-font";
-import { PracticeItem, RecognitionPracticeSettings } from "./types";
+import { DeckFilterSettings, PracticeItem } from "./types";
 
 type RepEntry = [string, string, string, string];
 
@@ -15,11 +15,10 @@ export const buildPracticeDeck = ({
   repWords: Record<string, RepEntry>;
   getJlpt: (kanji: string) => JLTPTtypes | null;
   getKeyword: (kanji: string) => string;
-  settings: RecognitionPracticeSettings;
+  settings: DeckFilterSettings;
 }): PracticeItem[] => {
   const jlptSet = new Set(settings.jlpt);
-  const applyJlpt =
-    jlptSet.size > 0 && jlptSet.size < JLPTOptionsCount;
+  const applyJlpt = jlptSet.size > 0 && jlptSet.size < JLPTOptionsCount;
 
   const items: PracticeItem[] = [];
 

--- a/src/components/shared-practice/index.ts
+++ b/src/components/shared-practice/index.ts
@@ -1,0 +1,10 @@
+export { buildPracticeDeck, withFreshFonts } from "./build-deck";
+export { EndSession } from "./EndSession";
+export { PracticeShell } from "./PracticeShell";
+export { RecapTile } from "./RecapTile";
+export { ToggleRow } from "./ToggleRow";
+export type {
+  DeckFilterSettings,
+  PracticeItem,
+  PracticeSessionResult,
+} from "./types";

--- a/src/components/shared-practice/types.ts
+++ b/src/components/shared-practice/types.ts
@@ -1,0 +1,27 @@
+import { JLTPTtypes } from "@/lib/jlpt";
+
+/** Shared deck item used by recognition + production practice. */
+export type PracticeItem = {
+  kanji: string;
+  word: string;
+  reading: string;
+  englishGloss: string;
+  keyword: string;
+  fontIndex: number | null;
+};
+
+/** Minimal result shape for the shared end-session screen. */
+export type PracticeSessionResult = {
+  kanji: string;
+  word: string;
+  keyword: string;
+  correct: boolean;
+};
+
+/** Settings fields needed to build a representative-word deck. */
+export type DeckFilterSettings = {
+  jlpt: JLTPTtypes[];
+  bookmarkedOnly: boolean;
+  randomizeOrder: boolean;
+  randomizeFont: boolean;
+};

--- a/src/components/site-layout/Header/HeaderDrawer.tsx
+++ b/src/components/site-layout/Header/HeaderDrawer.tsx
@@ -2,11 +2,11 @@ import { useState } from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 import { Link } from "@/components/dependent/routing";
 import { Button } from "@/components/ui/button";
-import { ChartLine, Eye, Keyboard, Menu, SearchIcon, } from "lucide-react";
-import pageItems from "@/components/items/page-items";
+import { Menu } from "lucide-react";
 import { docPages } from "@/components/items/nav-items";
+import { headerNavLinks } from "@/components/items/nav-links";
 import { LinksOutItems } from "@/components/common/LinksOutItems";
-import { DashedNavLink } from "@/components/common/DashedNavLink";
+import { DashedNavLinkList } from "@/components/common/DashedNavLinkList";
 import { cnTextLink } from "@/lib/generic-cn";
 import { HeaderTitle } from "./HeaderTitle";
 import { ModeToggle } from "@/components/dependent/site-wide/ModeToggle";
@@ -14,42 +14,11 @@ import { PikaPikaLinks } from "@/components/common/PikaPikaLinks";
 import { DebugInfo } from "../../common/DebugInfo";
 import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
 
-const { kanjiPage, cumUseGraphPage, speedKatakanaPage, recognitionPracticeV1Page } = pageItems;
-
-const navLinks = [
-  {
-    href: kanjiPage.href,
-    title: kanjiPage.title,
-    description: kanjiPage.description,
-    Icon: SearchIcon
-  },
-  {
-    href: recognitionPracticeV1Page.href,
-    title: recognitionPracticeV1Page.title,
-    description: recognitionPracticeV1Page.description,
-    Icon: Eye
-  },
-  {
-    href: speedKatakanaPage.href,
-    title: speedKatakanaPage.title,
-    description: speedKatakanaPage.description,
-    Icon: Keyboard
-  },
-  {
-    href: cumUseGraphPage.href,
-    title: cumUseGraphPage.title,
-    description: cumUseGraphPage.description,
-    Icon: ChartLine
-  },
-
-];
-
 const infoLinks = [
   { href: docPages.about.href, title: docPages.about.title },
   { href: docPages.terms.href, title: docPages.terms.title },
   { href: docPages.privacy.href, title: docPages.privacy.title },
 ];
-
 
 const HeaderDrawerContent = ({ onClose }: { onClose: () => void }) => {
   return (
@@ -59,20 +28,19 @@ const HeaderDrawerContent = ({ onClose }: { onClose: () => void }) => {
           <div onClick={onClose} onPointerDown={(e) => e.stopPropagation()}>
             <HeaderTitle />
           </div>
-          <div onPointerDown={(e) => e.stopPropagation()}><ModeToggle /></div>
+          <div onPointerDown={(e) => e.stopPropagation()}>
+            <ModeToggle />
+          </div>
         </div>
-        {navLinks.map((item) => (
-          <DrawerPrimitive.Close key={item.href} asChild>
-            <DashedNavLink
-              href={item.href}
-              title={item.title}
-              description={item.description}
-              Icon={item.Icon}
-              onPointerDown={(e) => e.stopPropagation()}
-              iconClassName="mt-0 mr-1"
-            />
-          </DrawerPrimitive.Close>
-        ))}
+        <DashedNavLinkList
+          items={headerNavLinks}
+          className="flex flex-col gap-2"
+          iconClassName="mt-0 mr-1"
+          onItemPointerDown={(e) => e.stopPropagation()}
+          wrapItem={(link) => (
+            <DrawerPrimitive.Close asChild>{link}</DrawerPrimitive.Close>
+          )}
+        />
       </div>
 
       <div className="flex flex-wrap justify-center w-full gap-2">
@@ -90,21 +58,22 @@ const HeaderDrawerContent = ({ onClose }: { onClose: () => void }) => {
 
         <PikaPikaLinks />
 
-
         <div className="mt-4">
           <div className="flex justify-center space-x-1">
             <LinksOutItems />
           </div>
         </div>
-
       </div>
-      <div className="flex items-end justify-end pt-4 mt-auto" onPointerDown={(e) => e.stopPropagation()}>
+      <div
+        className="flex items-end justify-end pt-4 mt-auto"
+        onPointerDown={(e) => e.stopPropagation()}
+      >
         <DebugInfo />
         <RefreshPageBtn />
       </div>
     </div>
-  )
-}
+  );
+};
 
 const HeaderDrawer = ({
   initiallyOpen = false,

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -34,8 +34,11 @@ DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> & {
+    /** Drag handle pill at the top. Defaults to true. */
+    showHandle?: boolean;
+  }
+>(({ className, children, showHandle = true, ...props }, ref) => (
   <DrawerPortal>
     <DrawerOverlay />
     <DrawerPrimitive.Content
@@ -46,7 +49,9 @@ const DrawerContent = React.forwardRef<
       )}
       {...props}
     >
-      <div className="mx-auto my-1 max-h-1 min-h-1 h-1 bg-muted w-[100px] rounded-full bg-theme" />
+      {showHandle ? (
+        <div className="mx-auto my-1 max-h-1 min-h-1 h-1 bg-muted w-[100px] rounded-full bg-theme" />
+      ) : null}
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>

--- a/src/hooks/use-fit-pad-size.ts
+++ b/src/hooks/use-fit-pad-size.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Pad edge length capped at `max`, shrunk to fit the viewport when needed.
+ * Matches Stroke Order · Writing Practice (310px when the screen permits).
+ */
+export const useFitPadSize = (max: number, gutter = 48) => {
+  const [size, setSize] = useState(() =>
+    typeof window !== "undefined"
+      ? Math.min(max, window.innerWidth - gutter)
+      : max
+  );
+
+  useEffect(() => {
+    const fit = () => setSize(Math.min(max, window.innerWidth - gutter));
+    fit();
+    window.addEventListener("resize", fit);
+    return () => window.removeEventListener("resize", fit);
+  }, [max, gutter]);
+
+  return size;
+};

--- a/src/lib/dakanji-adapter.ts
+++ b/src/lib/dakanji-adapter.ts
@@ -153,6 +153,10 @@ const topKLabels = (probs: Float32Array, labels: string, k: number): string[] =>
   return result;
 };
 
+/** Preload ORT + model + labels so the first recognize call is fast. */
+export const warmupDaKanji = (): Promise<void> =>
+  loadRuntime().then(() => undefined);
+
 export const recognizeDaKanji = async (
   payload: DrawingSubmitPayload
 ): Promise<string[]> => {

--- a/src/lib/dakanji-grade.ts
+++ b/src/lib/dakanji-grade.ts
@@ -1,0 +1,75 @@
+/** Shared DaKanji grade copy for writing practice + production quiz. */
+
+export type GradeResult = {
+  /** 0-based index in top-10, or -1 if missing */
+  rank: number;
+  topGuess: string | null;
+};
+
+export type GradeBand = "awesome" | "solid" | "getting-there" | "not-quite";
+
+export const getGradeBand = (rank: number): GradeBand => {
+  if (rank === 0) return "awesome";
+  if (rank >= 1 && rank <= 2) return "solid";
+  if (rank >= 3) return "getting-there";
+  return "not-quite";
+};
+
+/** Full message used under the writing-practice pad. */
+export const gradeMessage = (kanji: string, result: GradeResult): string => {
+  const { rank, topGuess } = result;
+  if (rank === 0) {
+    return `🎯 Awesome · That's ${kanji}`;
+  }
+  if (rank >= 1 && rank <= 2) {
+    return topGuess
+      ? `💚 Solid · Near miss — a bit like ${topGuess}`
+      : `💚 Solid · Near miss — keep refining`;
+  }
+  if (rank >= 3) {
+    return topGuess
+      ? `🌀 Getting there · Looks more like ${topGuess}`
+      : `🌀 Getting there · Keep refining`;
+  }
+  return topGuess
+    ? `🙈 Not quite · Looks more like ${topGuess}`
+    : `🙈 Not quite · Try again`;
+};
+
+/** Short headline for the select / feedback drawers. */
+export const gradeHeadline = (rank: number): string => {
+  switch (getGradeBand(rank)) {
+    case "awesome":
+      return "🎯 Awesome!";
+    case "solid":
+      return "💚 Solid · Almost perfect!";
+    case "getting-there":
+      return "🌀 Getting there";
+    case "not-quite":
+      return "🙈 Not quite";
+  }
+};
+
+/**
+ * Title for the feedback drawer after the user picks (or forgot).
+ * "correct" = they selected the right kanji (drawing grade may still be not-quite).
+ */
+export const feedbackTitle = (
+  variant: "correct" | "incorrect",
+  rank: number
+): string => {
+  if (variant === "incorrect") {
+    return "Not quite — here is the correct kanji";
+  }
+  switch (getGradeBand(rank)) {
+    case "awesome":
+      return "🎯 Awesome!";
+    case "solid":
+      return "💚 Solid!";
+    case "getting-there":
+      return "🌀 Getting there!";
+    case "not-quite":
+      // Right kanji picked, but drawing wasn't in the model top-10.
+      return "🎉 That's the one!";
+  }
+};


### PR DESCRIPTION
Introduce a cloze writing quiz with DaKanji grading, look-alike selection, and stroke-order feedback, and extract shared end-session/deck shell pieces used by recognition practice.