### PR TITLE
REFACTOR DUPLICATE CODE + Polish practice modes: shared modules and copy

### DIFF
--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -22,8 +22,8 @@ export const CopyButton = ({
   return (
     <Button
       variant={"outline"}
-      size="icon"
-      className={"h-8 w-8 relative rounded-xl"}
+      size="iconXl"
+      className="relative"
       onClick={(e) => {
         copy(textToCopy, e);
         e.preventDefault();

--- a/src/components/common/DashedNavLink.tsx
+++ b/src/components/common/DashedNavLink.tsx
@@ -2,7 +2,9 @@ import { ComponentType, SVGProps, forwardRef } from "react";
 import { Link } from "@/components/dependent/routing";
 import { cn } from "@/lib/utils";
 
-type IconComponent = ComponentType<SVGProps<SVGSVGElement> & { className?: string }>;
+type IconComponent = ComponentType<
+  SVGProps<SVGSVGElement> & { className?: string }
+>;
 
 type DashedNavLinkProps = {
   href: string;
@@ -42,9 +44,11 @@ export const DashedNavLink = forwardRef<HTMLAnchorElement, DashedNavLinkProps>(
         )}
         {...rest}
       >
-        <div className="flex items-center text-sm font-semibold text-left">
+        <div className="flex text-sm font-semibold text-left">
           {Icon && (
-            <Icon className={cn("mr-2 size-4 shrink-0", iconClassName)} />
+            <Icon
+              className={cn("mr-2 mt-0.5 size-4 shrink-0", iconClassName)}
+            />
           )}
           {title}
         </div>

--- a/src/components/common/DebugInfo.tsx
+++ b/src/components/common/DebugInfo.tsx
@@ -95,7 +95,7 @@ const DeviceSpecs = () => {
 export const DebugInfo = () => (
   <Popover>
     <PopoverTrigger asChild>
-      <Button variant="outline" size="icon" className="w-8 h-8 mr-1 rounded-xl" aria-label="Debug info">
+      <Button variant="outline" size="iconXl" className="mr-1" aria-label="Debug info">
         <Info className="w-[1.2rem] h-[1.2rem]" />
       </Button>
     </PopoverTrigger>

--- a/src/components/common/DictionaryPopover.tsx
+++ b/src/components/common/DictionaryPopover.tsx
@@ -1,0 +1,63 @@
+import { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { GenericPopover } from "./GenericPopover";
+
+/** "読み込み中 · Loading…" state shared by dictionary lookups. */
+export const DictLoading = () => (
+  <div className="py-2 text-xs text-muted-foreground">読み込み中 · Loading…</div>
+);
+
+/** Service-unreachable state (network/API error). */
+export const DictError = ({ service }: { service: string }) => (
+  <div className="py-2 text-xs">
+    すみません. {service} cannot be accessed right now. Try again later.
+  </div>
+);
+
+/** No-results state. */
+export const DictEmpty = ({ service }: { service: string }) => (
+  <div className="py-2 text-xs text-muted-foreground">
+    すみません. {service} does not contain information about this word.
+  </div>
+);
+
+/** "Powered by … 💪" attribution header. */
+export const DictHeader = ({ label }: { label: string }) => (
+  <div className="pb-1 mb-2 border-b text-[10px] uppercase tracking-widest text-muted-foreground font-medium">
+    Powered by {label} 💪
+  </div>
+);
+
+/**
+ * Outline icon button + popover with the scrollable content container used by
+ * both the Jisho and Jotoba lookups. Owns the vaul/touch-scroll handling so it
+ * lives in one place.
+ */
+export const DictionaryPopoverShell = ({
+  icon,
+  contentClassName,
+  children,
+}: {
+  icon: ReactNode;
+  contentClassName: string;
+  children: ReactNode;
+}) => (
+  <GenericPopover
+    trigger={
+      <Button variant="outline" size="iconXl" className="relative">
+        {icon}
+      </Button>
+    }
+    content={
+      <div
+        className={contentClassName}
+        data-vaul-no-drag
+        style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-y" }}
+        onWheel={(e) => e.stopPropagation()}
+        onTouchMove={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    }
+  />
+);

--- a/src/components/common/JishoBtn.tsx
+++ b/src/components/common/JishoBtn.tsx
@@ -1,8 +1,13 @@
-import { Button } from "@/components/ui/button";
 import { BookOpen } from "lucide-react";
-import { GenericPopover } from "./GenericPopover";
 import { SpanBadge } from "@/components/ui/badge";
 import { useJsonFetch } from "@/hooks/use-json";
+import {
+  DictEmpty,
+  DictError,
+  DictHeader,
+  DictionaryPopoverShell,
+  DictLoading,
+} from "./DictionaryPopover";
 
 type JishoJapanese = { word?: string; reading: string };
 type JishoSense = {
@@ -36,29 +41,16 @@ export const JishoContent = ({ word }: { word: string }) => {
     );
 
     if (!data) {
-        if (status === "error") {
-            return (
-                <div className="py-2 text-xs">
-                    すみません. Jisho.org cannot be accessed right now. Try again later.
-                </div>
-            );
-        }
-        return <div className="py-2 text-xs text-muted-foreground">読み込み中 · Loading…</div>;
+        return status === "error" ? <DictError service="Jisho.org" /> : <DictLoading />;
     }
 
     if (data.data.length === 0) {
-        return (
-            <div className="py-2 text-xs text-muted-foreground">
-                すみません. Jisho.org does not contain information about this word.
-            </div>
-        );
+        return <DictEmpty service="Jisho.org" />;
     }
 
     return (
         <div className="space-y-3">
-            <div className="pb-1 mb-2 border-b text-[10px] uppercase tracking-widest text-muted-foreground font-medium">
-                Powered by JISHO.ORG 💪
-            </div>
+            <DictHeader label="JISHO.ORG" />
             {data.data.map((entry, i) => (
                 <div key={entry.slug} className={i > 0 ? "border-t pt-3" : ""}>
                     <div className="flex items-baseline gap-1.5 mb-1">
@@ -112,17 +104,11 @@ export const JishoContent = ({ word }: { word: string }) => {
 
 export const JishoBtn = ({ word }: { word: string }) => {
     return (
-        <GenericPopover
-            trigger={
-                <Button variant={"outline"} size="icon" className="relative w-8 h-8 rounded-xl">
-                    <BookOpen />
-                </Button>
-            }
-            content={
-                <div className="p-4 overflow-y-scroll max-h-48 min-w-36 max-w-64" data-vaul-no-drag style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-y" }} onWheel={(e) => e.stopPropagation()} onTouchMove={(e) => e.stopPropagation()}>
-                    <JishoContent word={word} />
-                </div>
-            }
-        />
+        <DictionaryPopoverShell
+            icon={<BookOpen />}
+            contentClassName="p-4 overflow-y-scroll max-h-48 min-w-36 max-w-64"
+        >
+            <JishoContent word={word} />
+        </DictionaryPopoverShell>
     );
 };

--- a/src/components/common/JotobaBtn.tsx
+++ b/src/components/common/JotobaBtn.tsx
@@ -1,8 +1,13 @@
-import { Button } from "@/components/ui/button";
 import { Library } from "lucide-react";
-import { GenericPopover } from "./GenericPopover";
 import { SpanBadge } from "@/components/ui/badge";
 import { useJsonFetch } from "@/hooks/use-json";
+import {
+  DictEmpty,
+  DictError,
+  DictHeader,
+  DictionaryPopoverShell,
+  DictLoading,
+} from "./DictionaryPopover";
 
 type JotobaReading = { kana: string; kanji?: string; furigana?: string };
 type JotobaSense = {
@@ -30,29 +35,16 @@ export const JotobaContent = ({ word }: { word: string }) => {
     );
 
     if (!data) {
-        if (status === "error") {
-            return (
-                <div className="py-2 text-xs">
-                    すみません. Jotoba.de cannot be accessed right now. Try again later.
-                </div>
-            );
-        }
-        return <div className="py-2 text-xs text-muted-foreground">読み込み中 · Loading…</div>;
+        return status === "error" ? <DictError service="Jotoba.de" /> : <DictLoading />;
     }
 
     if (data.words.length === 0) {
-        return (
-            <div className="py-2 text-xs text-muted-foreground">
-                すみません. Jotoba.de does not contain information about this word.
-            </div>
-        );
+        return <DictEmpty service="Jotoba.de" />;
     }
 
     return (
         <div className="w-48 space-y-3">
-            <div className="pb-1 mb-2 border-b text-[10px] uppercase tracking-widest text-muted-foreground font-medium">
-                Powered by Jotoba.de 💪
-            </div>
+            <DictHeader label="Jotoba.de" />
             {data.words.slice(0, 5).map((entry, i) => (
                 <div key={i} className={i > 0 ? "border-t pt-3" : ""}>
                     <div className="flex items-center gap-1.5 mb-1 flex-wrap">
@@ -101,17 +93,11 @@ export const JotobaContent = ({ word }: { word: string }) => {
 
 export const JotobaBtn = ({ word }: { word: string }) => {
     return (
-        <GenericPopover
-            trigger={
-                <Button variant={"outline"} size="icon" className="relative w-8 h-8 rounded-xl">
-                    <Library />
-                </Button>
-            }
-            content={
-                <div className="px-4 py-2 overflow-y-scroll max-w-64 min-w-36 max-h-48" data-vaul-no-drag style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-y" }} onWheel={(e) => e.stopPropagation()} onTouchMove={(e) => e.stopPropagation()}>
-                    <JotobaContent word={word} />
-                </div>
-            }
-        />
+        <DictionaryPopoverShell
+            icon={<Library />}
+            contentClassName="px-4 py-2 overflow-y-scroll max-w-64 min-w-36 max-h-48"
+        >
+            <JotobaContent word={word} />
+        </DictionaryPopoverShell>
     );
 };

--- a/src/components/common/RefreshPageBtn.tsx
+++ b/src/components/common/RefreshPageBtn.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
 
 export const RefreshPageBtn = () => (
-    <Button variant="outline" size="icon" className="w-8 h-8 rounded-xl" onClick={() => window.location.reload()} aria-label="Refresh page">
+    <Button variant="outline" size="iconXl" onClick={() => window.location.reload()} aria-label="Refresh page">
         <RefreshCw className="w-[1.2rem] h-[1.2rem]" />
     </Button>
 );

--- a/src/components/common/SpeakButton.tsx
+++ b/src/components/common/SpeakButton.tsx
@@ -23,8 +23,8 @@ export const SpeakButton = ({
   return (
     <Button
       variant={"outline"}
-      size="icon"
-      className="h-8 w-8 relative rounded-xl"
+      size="iconXl"
+      className="relative"
       onClick={() => {
         speak();
       }}

--- a/src/components/dependent/routing/NextPrevLinks.tsx
+++ b/src/components/dependent/routing/NextPrevLinks.tsx
@@ -2,6 +2,8 @@ import { useMemo } from "react";
 import { URL_PARAMS } from "@/lib/settings/url-params";
 import { ArrowLeft, ArrowRight } from "@/components/icons";
 import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-utils";
+import { cn } from "@/lib/utils";
 import { useSearchParams } from "./routing-hooks";
 import { Link } from "./router-adapter";
 import { useNextPrevKanji } from "@/hooks/use-next-prev-kanji";
@@ -32,8 +34,11 @@ const useNextPrevUrls = (currentKanji: string) => {
   return nextPrevUrls;
 };
 
-const btnLinkCn =
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-8 w-8 relative rounded-xl";
+// Links aren't <Button>, so borrow the same visual via buttonVariants.
+const btnLinkCn = cn(
+  buttonVariants({ variant: "outline", size: "iconXl" }),
+  "relative"
+);
 export const NextPrevLinks = ({ currentKanji }: { currentKanji: string }) => {
   const links = useNextPrevUrls(currentKanji);
   return (
@@ -45,9 +50,9 @@ export const NextPrevLinks = ({ currentKanji }: { currentKanji: string }) => {
       ) : (
         <Button
           disabled
-          size="icon"
+          size="iconXl"
           variant={"outline"}
-          className="h-8 w-8 relative rounded-xl cursor-not-allowed"
+          className="relative cursor-not-allowed"
         >
           <ArrowLeft />
         </Button>
@@ -59,9 +64,9 @@ export const NextPrevLinks = ({ currentKanji }: { currentKanji: string }) => {
       ) : (
         <Button
           disabled
-          size="icon"
+          size="iconXl"
           variant={"outline"}
-          className="h-8 w-8 relative rounded-xl cursor-not-allowed"
+          className="relative cursor-not-allowed"
         >
           <ArrowRight />
         </Button>

--- a/src/components/dependent/site-wide/ModeToggle.tsx
+++ b/src/components/dependent/site-wide/ModeToggle.tsx
@@ -32,7 +32,7 @@ export function ModeToggle0() {
         }}
         asChild
       >
-        <Button variant="outline" size="icon" className="relative w-8 h-8 rounded-xl">
+        <Button variant="outline" size="iconXl" className="relative">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>
@@ -61,7 +61,7 @@ export const ModeToggle = () => {
       window.matchMedia("(prefers-color-scheme: dark)").matches);
 
   return (
-    <Button variant="outline" size="icon" className="relative w-8 h-8 rounded-xl"
+    <Button variant="outline" size="iconXl" className="relative"
       onClick={() => setTheme(isDark ? "light" : "dark")}
     >
       <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />

--- a/src/components/items/practice-pages.ts
+++ b/src/components/items/practice-pages.ts
@@ -2,14 +2,14 @@
 
 export const recognitionPracticePageMeta = {
   href: "/recognition-practice",
-  title: "Kanji Recognition",
+  title: "Kanji Recognition Practice",
   description: "Type the reading of kanji anchor words",
 } as const;
 
 export const productionPracticePageMeta = {
   href: "/production-practice",
-  title: "Kanji Production",
-  description: "Draw the missing kanji in anchor words",
+  title: "Kanji Production Practice",
+  description: "Draw the missing kanji of anchor words",
 } as const;
 
 export const speedKatakanaPageMeta = {

--- a/src/components/items/practice-pages.ts
+++ b/src/components/items/practice-pages.ts
@@ -3,19 +3,22 @@
 export const recognitionPracticePageMeta = {
   href: "/recognition-practice",
   title: "Kanji Recognition Practice",
-  description: "Type the reading of kanji anchor words",
+  heading: "👁️ Kanji Recognition",
+  description: "Type the correct reading for each word",
 } as const;
 
 export const productionPracticePageMeta = {
   href: "/production-practice",
   title: "Kanji Production Practice",
-  description: "Draw the missing kanji of anchor words",
+  heading: "✍️ Kanji Production",
+  description: "Complete words by drawing the missing kanji",
 } as const;
 
 export const speedKatakanaPageMeta = {
   href: "/speed-katakana",
   title: "Speed Katakana",
-  description: "Practice speed typing katakana words",
+  heading: "🐇 Speed Katakana",
+  description: "Type katakana words as quickly as you can",
 } as const;
 
 export const practicePageLinks = [

--- a/src/components/production-practice-v1/Game.tsx
+++ b/src/components/production-practice-v1/Game.tsx
@@ -10,9 +10,10 @@ import { RomajiBadge } from "@/components/dependent/kana/RomajiBadge";
 import { SpeakButton } from "@/components/common/SpeakButton";
 import { useSpeak } from "@/hooks/use-jp-speak";
 import { useFitPadSize } from "@/hooks/use-fit-pad-size";
+import { useCorrectSound } from "@/hooks/use-correct-sound";
+import { BlurredGloss } from "@/components/shared-practice";
 import { useSimilarKanjis } from "@/kanji-worker/kanji-worker-hooks";
 import { recognizeWithDaKanji } from "@/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/recognizers";
-import assetsPaths from "@/lib/assets-paths";
 import { ClozeWord } from "./ClozeWord";
 import { buildCandidateGrid } from "./build-candidates";
 import { DRAW_SVG_SIZE } from "./constants";
@@ -58,25 +59,23 @@ export const Game = ({
   const [index, setIndex] = useState(0);
   const [strokes, setStrokes] = useState<Stroke[]>([]);
   const [drawing, setDrawing] = useState<DrawingSnapshot | null>(null);
-  const [glossBlurred, setGlossBlurred] = useState(settings.blurEnglishGloss);
   const [step, setStep] = useState<CardStep>({ type: "draw" });
   const [selected, setSelected] = useState<string | null>(null);
   const resultsRef = useRef<SessionResult[]>([]);
-  const correctAudioRef = useRef<HTMLAudioElement | null>(null);
   const padSize = useFitPadSize(DRAW_SVG_SIZE);
 
   const current = sessionItems[index];
   const similarState = useSimilarKanjis(current?.kanji ?? "");
   const similars = similarState.data ?? [];
   const speak = useSpeak(current?.word ?? "");
+  const playCorrect = useCorrectSound();
 
   useEffect(() => {
-    setGlossBlurred(settings.blurEnglishGloss);
     setStrokes([]);
     setDrawing(null);
     setStep({ type: "draw" });
     setSelected(null);
-  }, [index, settings.blurEnglishGloss]);
+  }, [index]);
 
   useEffect(() => {
     setStrokes([]);
@@ -99,21 +98,6 @@ export const Game = ({
   if (!current) {
     return null;
   }
-
-  const playCorrectSound = () => {
-    if (!settings.celebratorySoundOnCorrect) return;
-    try {
-      if (!correctAudioRef.current) {
-        correctAudioRef.current = new Audio(
-          assetsPaths.SPEED_KATAKANA_CORRECT_SOUND
-        );
-      }
-      correctAudioRef.current.currentTime = 0;
-      void correctAudioRef.current.play();
-    } catch {
-      // ignore playback failures
-    }
-  };
 
   const pushResult = (correct: boolean, gradeRank: number) => {
     const result: SessionResult = { ...current, correct, gradeRank };
@@ -179,7 +163,9 @@ export const Game = ({
     if (step.type !== "select" || selected == null) return;
     const pickedCorrect = selected === current.kanji;
     const sessionCorrect = pickedCorrect && step.grade.inTop10;
-    if (sessionCorrect) playCorrectSound();
+    if (sessionCorrect) {
+      playCorrect({ enabled: settings.celebratorySoundOnCorrect });
+    }
     pushResult(sessionCorrect, step.grade.rank);
     setStep({
       type: "feedback",
@@ -220,24 +206,12 @@ export const Game = ({
           <SpeakButton word={current.word} iconType="volume-2" />
         </div>
 
-        {settings.blurEnglishGloss ? (
-          <button
-            type="button"
-            className={`max-w-sm px-2 text-xs mt-2 font-bold tracking-wide transition-all outline-none ${
-              glossBlurred ? "blur-[5px] hover:blur-none" : ""
-            }`}
-            onClick={() => setGlossBlurred((v) => !v)}
-            aria-label={
-              glossBlurred ? "Reveal English gloss" : "Blur English gloss"
-            }
-          >
-            {current.englishGloss || "—"}
-          </button>
-        ) : (
-          <p className="max-w-sm px-2 mt-1 text-xs font-bold tracking-wide">
-            {current.englishGloss || "—"}
-          </p>
-        )}
+        <BlurredGloss
+          text={current.englishGloss}
+          resetKey={index}
+          blurrable={settings.blurEnglishGloss}
+          className="mt-2"
+        />
 
         <div
           className="relative mt-2 w-full mx-auto"

--- a/src/components/production-practice-v1/InitialScreen.tsx
+++ b/src/components/production-practice-v1/InitialScreen.tsx
@@ -11,6 +11,7 @@ import { JLTPTtypes } from "@/lib/jlpt";
 import assetsPaths from "@/lib/assets-paths";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { buildPracticeDeck, ToggleRow } from "@/components/shared-practice";
+import { productionPracticePageMeta } from "@/components/items/practice-pages";
 import { DEFAULT_SETTINGS, SETTINGS_KEY } from "./constants";
 import { PracticeItem, ProductionPracticeSettings } from "./types";
 
@@ -53,10 +54,10 @@ export const InitialScreen = ({
         <div className="flex flex-col max-w-md gap-6 px-4 py-6 mx-auto">
           <div className="text-left">
             <h1 className="pt-4 text-xl font-bold text-center">
-              ✍️ Kanji Production
+              {productionPracticePageMeta.heading}
             </h1>
             <p className="mt-1 text-sm text-center text-muted-foreground">
-              Draw the missing kanji of anchor words
+              {productionPracticePageMeta.description}
             </p>
           </div>
 

--- a/src/components/production-practice-v1/InitialScreen.tsx
+++ b/src/components/production-practice-v1/InitialScreen.tsx
@@ -53,10 +53,10 @@ export const InitialScreen = ({
         <div className="flex flex-col max-w-md gap-6 px-4 py-6 mx-auto">
           <div className="text-left">
             <h1 className="pt-4 text-xl font-bold text-center">
-              ✍️ Kanji Writing
+              ✍️ Kanji Production
             </h1>
             <p className="mt-1 text-sm text-center text-muted-foreground">
-              Draw the missing kanji in anchor words
+              Draw the missing kanji of anchor words
             </p>
           </div>
 

--- a/src/components/production-practice-v1/ProductionPracticeV1.tsx
+++ b/src/components/production-practice-v1/ProductionPracticeV1.tsx
@@ -4,6 +4,7 @@ import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useSetOpenedParam } from "@/components/dependent/routing/routing-hooks";
 import KanjiDrawerGlobal from "@/components/screens/ListScreen/Drawer/KanjiDrawerGlobal";
 import { EndSession, PracticeShell } from "@/components/shared-practice";
+import { productionPracticePageMeta } from "@/components/items/practice-pages";
 import { warmupDaKanji } from "@/lib/dakanji-adapter";
 import { InitialScreen } from "./InitialScreen";
 import { ModelLoadingScreen } from "./ModelLoadingScreen";
@@ -17,7 +18,7 @@ import {
 } from "./types";
 
 const ProductionPracticeV1 = () => {
-  useHtmlDocumentTitle("Kanji Production");
+  useHtmlDocumentTitle(productionPracticePageMeta.heading);
 
   const [settings] = useLocalStorage<ProductionPracticeSettings>(
     SETTINGS_KEY,

--- a/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
+++ b/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
@@ -61,7 +61,7 @@ export const FeedbackDrawer = ({
           <div className="px-2 pt-4 pb-2 mt-2 overflow-y-auto sm:px-3">
             {/* flex + w-fit keeps the two columns tight (grid max-w-* stretched them apart). */}
             <div className="flex flex-row items-start justify-center gap-2 mx-auto w-fit sm:gap-3">
-              <div className="flex flex-col items-center gap-2 shrink-0">
+              <div className="flex flex-col items-center gap-2 shrink-0 min-w-[155px]">
                 <p className="text-xs font-bold uppercase text-muted-foreground">
                   You Drew
                 </p>
@@ -88,7 +88,7 @@ export const FeedbackDrawer = ({
                   Practice More
                 </PracticeButton>
               </div>
-              <div className="flex flex-col items-center gap-2 shrink-0">
+              <div className="flex flex-col items-center gap-2  shrink-0 min-w-[155px]">
                 <p className="text-xs font-bold uppercase text-muted-foreground">
                   Stroke Order
                 </p>

--- a/src/components/production-practice-v1/types.ts
+++ b/src/components/production-practice-v1/types.ts
@@ -1,12 +1,10 @@
 import type { Stroke } from "@/components/dependent/DrawingPad";
-import type { PracticeItem as SharedPracticeItem } from "@/components/shared-practice";
-import { JLTPTtypes } from "@/lib/jlpt";
+import type {
+  DeckFilterSettings,
+  PracticeItem as SharedPracticeItem,
+} from "@/components/shared-practice";
 
-export type ProductionPracticeSettings = {
-  jlpt: JLTPTtypes[];
-  bookmarkedOnly: boolean;
-  randomizeOrder: boolean;
-  randomizeFont: boolean;
+export type ProductionPracticeSettings = DeckFilterSettings & {
   blurEnglishGloss: boolean;
   hearPronunciationOnLoad: boolean;
   celebratorySoundOnCorrect: boolean;

--- a/src/components/recognition-practice-v1/AnswerFeedback.tsx
+++ b/src/components/recognition-practice-v1/AnswerFeedback.tsx
@@ -48,13 +48,13 @@ export const AnswerFeedback = ({
 
   return (
     <div
-      className="flex flex-col items-center gap-3 animate-fade-in-fast"
+      className="flex flex-col items-center gap-3 animate-practice-bounce-soft"
       role="status"
       aria-live="polite"
       aria-label={correct ? "Correct" : "Forgot"}
     >
       <div className="flex flex-wrap items-center justify-center gap-1">
-        <p >{correct ? "🎉 ·" : ""}</p>
+        <p>{correct ? "🎉 ·" : ""}</p>
         <SpeakButton word={word} iconType="volume-2" />
         {readings.map((r) => (
           <RomajiBadge key={r} kana={r} />

--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -5,7 +5,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { useSpeak } from "@/hooks/use-jp-speak";
-import assetsPaths from "@/lib/assets-paths";
+import { useCorrectSound } from "@/hooks/use-correct-sound";
+import { useKanaInput } from "@/hooks/use-kana-input";
+import { BlurredGloss } from "@/components/shared-practice";
 import {
   isForgotCommand,
   isForgotCommandPrefix,
@@ -29,14 +31,10 @@ export const Game = ({
 }) => {
   const [index, setIndex] = useState(0);
   const [inputValue, setInputValue] = useState("");
-  const [glossBlurred, setGlossBlurred] = useState(true);
   const [feedback, setFeedback] = useState<"correct" | "forgot" | null>(null);
   const resultsRef = useRef<SessionResult[]>([]);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const isComposingRef = useRef(false);
-  const suppressNextChangeRef = useRef(false);
-  const correctAudioRef = useRef<HTMLAudioElement | null>(null);
 
   const current = sessionItems[index];
   const matched = current
@@ -45,10 +43,21 @@ export const Game = ({
   const forgotTyped = isForgotCommand(inputValue);
 
   const speak = useSpeak(current?.word ?? "");
+  const playCorrect = useCorrectSound();
 
-  useEffect(() => {
-    setGlossBlurred(true);
-  }, [index]);
+  const handleChange = (raw: string) => {
+    // Keep "forgot" / "skip" as latin so the command stays typable.
+    if (isForgotCommandPrefix(raw)) {
+      setInputValue(raw.replace(/\s+/g, ""));
+      return;
+    }
+    setInputValue(translateValue(raw, "hiragana"));
+  };
+
+  const kanaInput = useKanaInput({
+    setRawValue: setInputValue,
+    onCommit: handleChange,
+  });
 
   useEffect(() => {
     if (feedback == null) {
@@ -66,31 +75,17 @@ export const Game = ({
     return null;
   }
 
-  const playCorrectFeedback = () => {
-    if (!sound.enabled) return;
-    if (sound.type === "speak") {
-      speak();
-      return;
-    }
-    try {
-      if (!correctAudioRef.current) {
-        correctAudioRef.current = new Audio(
-          assetsPaths.SPEED_KATAKANA_CORRECT_SOUND
-        );
-      }
-      correctAudioRef.current.currentTime = 0;
-      void correctAudioRef.current.play();
-    } catch {
-      // ignore playback failures
-    }
-  };
-
   const openFeedback = (correct: boolean) => {
     if (feedback != null) return;
     inputRef.current?.blur();
     const result: SessionResult = { ...current, correct };
     resultsRef.current = [...resultsRef.current, result];
-    if (correct) playCorrectFeedback();
+    if (correct) {
+      playCorrect({
+        enabled: sound.enabled,
+        speak: sound.enabled && sound.type === "speak" ? speak : undefined,
+      });
+    }
     setFeedback(correct ? "correct" : "forgot");
   };
 
@@ -108,15 +103,6 @@ export const Game = ({
     }
 
     setIndex(nextIndex);
-  };
-
-  const handleChange = (raw: string) => {
-    // Keep "forgot" / "skip" as latin so the command stays typable.
-    if (isForgotCommandPrefix(raw)) {
-      setInputValue(raw.replace(/\s+/g, ""));
-      return;
-    }
-    setInputValue(translateValue(raw, "hiragana"));
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -175,20 +161,12 @@ export const Game = ({
           </p>
         </div>
 
-        <button
-          type="button"
-          className={`max-w-sm px-2 text-xs font-bold tracking-wide transition-all outline-none focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0 ${
-            glossBlurred && feedback == null ? "blur-[5px] hover:blur-none" : ""
-          }`}
-          onClick={() => setGlossBlurred((v) => !v)}
-          aria-label={
-            glossBlurred && feedback == null
-              ? "Reveal English gloss"
-              : "Blur English gloss"
-          }
-        >
-          {current.englishGloss || "—"}
-        </button>
+        <BlurredGloss
+          text={current.englishGloss}
+          resetKey={index}
+          forceReveal={feedback != null}
+          className="focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0"
+        />
       </div>
 
       <div className="flex flex-col gap-3 shrink-0 px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] [@media(pointer:fine)]:pb-0 md:pb-0">
@@ -206,33 +184,7 @@ export const Game = ({
               placeholder='Type the reading or type "forgot"'
               className="relative w-full p-0 mt-2 text-xl text-center border-2 rounded-2xl h-14 focus-visible:ring-offset-0 animate-fade-in"
               onKeyDown={handleKeyDown}
-              onCompositionStart={() => {
-                isComposingRef.current = true;
-                suppressNextChangeRef.current = false;
-              }}
-              onCompositionEnd={(e) => {
-                isComposingRef.current = false;
-                suppressNextChangeRef.current = true;
-                setTimeout(() => {
-                  suppressNextChangeRef.current = false;
-                }, 0);
-                handleChange(e.currentTarget.value);
-              }}
-              onChange={(e) => {
-                const raw = e.target.value;
-                const composing =
-                  "isComposing" in e.nativeEvent &&
-                  (e.nativeEvent as InputEvent).isComposing;
-                if (isComposingRef.current || composing) {
-                  setInputValue(raw);
-                  return;
-                }
-                if (suppressNextChangeRef.current) {
-                  suppressNextChangeRef.current = false;
-                  return;
-                }
-                handleChange(raw);
-              }}
+              {...kanaInput}
             />
 
             <div className="grid grid-cols-2 gap-2">

--- a/src/components/recognition-practice-v1/InitialScreen.tsx
+++ b/src/components/recognition-practice-v1/InitialScreen.tsx
@@ -11,12 +11,9 @@ import { JLTPTtypes } from "@/lib/jlpt";
 import assetsPaths from "@/lib/assets-paths";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { buildPracticeDeck, ToggleRow } from "@/components/shared-practice";
+import { recognitionPracticePageMeta } from "@/components/items/practice-pages";
 import { DEFAULT_SETTINGS, SETTINGS_KEY } from "./constants";
-import {
-  PracticeItem,
-  RecognitionPracticeSettings,
-  SoundMode,
-} from "./types";
+import { PracticeItem, RecognitionPracticeSettings, SoundMode } from "./types";
 
 type RepEntry = [string, string, string, string];
 
@@ -79,10 +76,7 @@ export const InitialScreen = ({
   const soundType: SoundMode =
     settings.sound?.enabled === true ? settings.sound.type : "correct";
 
-  useEnterAction(
-    canStart ? () => onStart(deck) : null,
-    canStart
-  );
+  useEnterAction(canStart ? () => onStart(deck) : null, canStart);
 
   return (
     <div className="flex flex-col h-full">
@@ -90,11 +84,11 @@ export const InitialScreen = ({
         <div className="flex flex-col max-w-md gap-6 px-4 py-6 mx-auto">
           <div className="text-left">
             <h1 className="pt-4 text-xl font-bold text-center">
-              👁️ Kanji Recognition
+              {recognitionPracticePageMeta.heading}
             </h1>
 
             <p className="mt-1 text-sm text-center text-muted-foreground">
-              Type the reading of kanji anchor words
+              {recognitionPracticePageMeta.description}
             </p>
           </div>
 
@@ -143,9 +137,7 @@ export const InitialScreen = ({
                 onChange={(v) =>
                   setSetting(
                     "sound",
-                    v
-                      ? { enabled: true, type: soundType }
-                      : { enabled: false }
+                    v ? { enabled: true, type: soundType } : { enabled: false }
                   )
                 }
               />

--- a/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
+++ b/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
@@ -5,6 +5,7 @@ import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { useSetOpenedParam } from "@/components/dependent/routing/routing-hooks";
 import KanjiDrawerGlobal from "@/components/screens/ListScreen/Drawer/KanjiDrawerGlobal";
 import { EndSession, PracticeShell } from "@/components/shared-practice";
+import { recognitionPracticePageMeta } from "@/components/items/practice-pages";
 import { InitialScreen } from "./InitialScreen";
 import { Game } from "./Game";
 import { DEFAULT_SETTINGS, SESSION_SIZE, SETTINGS_KEY } from "./constants";
@@ -16,7 +17,7 @@ import {
 } from "./types";
 
 const RecognitionPracticeV1 = () => {
-  useHtmlDocumentTitle("Kanji Recognition");
+  useHtmlDocumentTitle(recognitionPracticePageMeta.heading);
 
   const [settings] = useLocalStorage<RecognitionPracticeSettings>(
     SETTINGS_KEY,

--- a/src/components/recognition-practice-v1/types.ts
+++ b/src/components/recognition-practice-v1/types.ts
@@ -1,13 +1,11 @@
-import type { PracticeItem as SharedPracticeItem } from "@/components/shared-practice";
-import { JLTPTtypes } from "@/lib/jlpt";
+import type {
+  DeckFilterSettings,
+  PracticeItem as SharedPracticeItem,
+} from "@/components/shared-practice";
 
 export type SoundMode = "correct" | "speak";
 
-export type RecognitionPracticeSettings = {
-  jlpt: JLTPTtypes[];
-  bookmarkedOnly: boolean;
-  randomizeOrder: boolean;
-  randomizeFont: boolean;
+export type RecognitionPracticeSettings = DeckFilterSettings & {
   sound: { enabled: true; type: SoundMode } | { enabled: false };
 };
 

--- a/src/components/screens/ListScreen/PracticeFab.tsx
+++ b/src/components/screens/ListScreen/PracticeFab.tsx
@@ -24,8 +24,9 @@ const isBodyScrollLocked = () => {
     body.style.overflow === "hidden" ||
     body.style.paddingRight !== "" ||
     body.hasAttribute("data-scroll-locked") ||
-    getComputedStyle(body).getPropertyValue("--removed-body-scroll-bar-size").trim() !==
-    ""
+    getComputedStyle(body)
+      .getPropertyValue("--removed-body-scroll-bar-size")
+      .trim() !== ""
   );
 };
 
@@ -109,7 +110,7 @@ export const PracticeFab = () => {
         className="z-50 w-[min(100vw-1.5rem,28rem)] p-3"
       >
         <p className="px-1 mb-2 text-sm font-semibold text-left">
-          What do you want to do?
+          Select a mode
         </p>
         <DashedNavLinkList
           items={practiceNavLinks}

--- a/src/components/screens/SpeedKatakanaScreen/EndSession.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/EndSession.tsx
@@ -1,57 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { pickEndCheer } from "@/lib/practice-cheers";
+import { Stat } from "@/components/shared-practice";
 import { SessionStats } from "./types";
 import { SpeedKatakanaStatsSummary } from "./SpeedKatakanaStatsSummary";
-
-const COUNT_UP_MS = 900;
-
-/** Animates from 0 up to `target` over COUNT_UP_MS once on mount. */
-const useCountUp = (target: number) => {
-  const [value, setValue] = useState(0);
-
-  useEffect(() => {
-    let frame = 0;
-    const start = performance.now();
-    const tick = (now: number) => {
-      const progress = Math.min((now - start) / COUNT_UP_MS, 1);
-      // easeOutCubic
-      const eased = 1 - Math.pow(1 - progress, 3);
-      setValue(Math.round(target * eased));
-      if (progress < 1) frame = requestAnimationFrame(tick);
-    };
-    frame = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frame);
-  }, [target]);
-
-  return value;
-};
-
-const Stat = ({
-  value,
-  unit,
-  label,
-}: {
-  value: number;
-  unit: string;
-  label: string;
-}) => {
-  const animated = useCountUp(value);
-  return (
-    <div className="flex flex-col items-center gap-1 animate-practice-tile-in">
-      <div className="text-5xl font-bold tabular-nums sm:text-6xl">
-        {animated}
-        <span className="ml-1 text-2xl font-semibold text-muted-foreground">
-          {unit}
-        </span>
-      </div>
-      <div className="text-xs font-bold uppercase text-muted-foreground ">
-        {label}
-      </div>
-    </div>
-  );
-};
 
 export const EndSession = ({
   stats,

--- a/src/components/screens/SpeedKatakanaScreen/Game.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/Game.tsx
@@ -6,6 +6,8 @@ import { DefaultErrorFallback } from "@/components/error";
 import KaomojiAnimation from "@/components/common/KaomojiLoading";
 import { useJsonFetch } from "@/hooks/use-json";
 import { useSpeak } from "@/hooks/use-jp-speak";
+import { useCorrectSound } from "@/hooks/use-correct-sound";
+import { useKanaInput } from "@/hooks/use-kana-input";
 import assetsPaths from "@/lib/assets-paths";
 import {
   isForgotCommand,
@@ -16,8 +18,8 @@ import {
   SessionStats,
   SpeedKatakanaSettings,
 } from "./types";
-import { NUMBER_OF_FONTS } from "@/hooks/use-change-font";
-import { shuffle } from "@/lib/utils";
+import { randomFontIndex } from "@/hooks/use-change-font";
+import { percent, shuffle } from "@/lib/utils";
 import { CircleArrowLeft } from "lucide-react";
 
 type GameWord = {
@@ -47,9 +49,7 @@ export const Game = ({
     const list: GameWord[] = data.data.map(([katakana, english]) => ({
       katakana,
       english,
-      fontIndex: settings.randomizeFont
-        ? Math.floor(Math.random() * NUMBER_OF_FONTS)
-        : null,
+      fontIndex: settings.randomizeFont ? randomFontIndex() : null,
     }));
     const ordered = settings.randomizeOrder ? shuffle(list) : list;
     return ordered.slice(0, settings.wordCount);
@@ -65,15 +65,6 @@ export const Game = ({
   const [flash, setFlash] = useState<{ english: string; key: number; skipped: boolean } | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // True while an IME (e.g. iOS Japanese romaji/kana keyboard) is mid-composition.
-  // During composition we must not re-transform the value, or iOS Safari renders
-  // the committed character twice. See onChange handler below.
-  const isComposingRef = useRef(false);
-  // Set right after compositionend so the redundant trailing change event that
-  // desktop browsers fire isn't processed a second time. Cleared on a macrotask
-  // so it only ever swallows that one synchronous follow-up event.
-  const suppressNextChangeRef = useRef(false);
-
   // Stats live in refs so per-keystroke bookkeeping doesn't trigger re-renders.
   const startTimeRef = useRef<number | null>(null);
   const correctCharsRef = useRef(0);
@@ -85,7 +76,11 @@ export const Game = ({
   // Sound feedback. useSpeak is a hook, so it must run before any early return;
   // an empty word is harmless while the set is still loading.
   const speak = useSpeak(words[index]?.katakana ?? "");
-  const correctAudioRef = useRef<HTMLAudioElement | null>(null);
+  const playCorrect = useCorrectSound();
+  const kanaInput = useKanaInput({
+    setRawValue: setInputValue,
+    onCommit: (raw) => handleChange(raw),
+  });
 
   // Keep the input focused as words advance and once the set has loaded.
   useEffect(() => {
@@ -118,22 +113,13 @@ export const Game = ({
   const current = words[index];
 
   const playFeedback = () => {
-    if (!settings.sound.enabled) return;
-    if (settings.sound.type === "speak") {
-      speak();
-      return;
-    }
-    try {
-      if (!correctAudioRef.current) {
-        correctAudioRef.current = new Audio(
-          assetsPaths.SPEED_KATAKANA_CORRECT_SOUND
-        );
-      }
-      correctAudioRef.current.currentTime = 0;
-      void correctAudioRef.current.play();
-    } catch {
-      // ignore audio playback failures
-    }
+    playCorrect({
+      enabled: settings.sound.enabled,
+      speak:
+        settings.sound.enabled && settings.sound.type === "speak"
+          ? speak
+          : undefined,
+    });
   };
 
   const advance = () => {
@@ -233,10 +219,7 @@ export const Game = ({
       minutes > 0 ? Math.round(correctCharsRef.current / minutes) : 0;
 
     const attempts = correctCharsRef.current + errorsRef.current;
-    const accuracy =
-      attempts > 0
-        ? Math.round((100 * correctCharsRef.current) / attempts)
-        : 100;
+    const accuracy = percent(correctCharsRef.current, attempts, 100);
 
     onProgress(100);
     onComplete({ accuracy, charsPerMinute });
@@ -315,44 +298,7 @@ export const Game = ({
           placeholder='Type romaji or "skip"'
           className="w-full text-2xl text-center border-2 z-1000 rounded-2xl h-14"
           onKeyDown={handleKeyDown}
-          onCompositionStart={() => {
-            isComposingRef.current = true;
-            // A new composition means any pending suppression is stale.
-            suppressNextChangeRef.current = false;
-          }}
-          onCompositionEnd={(e) => {
-            isComposingRef.current = false;
-            // iOS commits hiragana and fires no trailing change event, so the
-            // conversion + match logic must run here or the value stays raw
-            // hiragana. Desktop *does* fire a trailing change, so suppress that
-            // one duplicate (cleared on a macrotask, after it has fired).
-            suppressNextChangeRef.current = true;
-            setTimeout(() => {
-              suppressNextChangeRef.current = false;
-            }, 0);
-            handleChange(e.currentTarget.value);
-          }}
-          onChange={(e) => {
-            const raw = e.target.value;
-            // While an IME is composing, keep the field exactly as the IME has
-            // it (no romaji→katakana transform). Transforming mid-composition
-            // makes iOS Safari duplicate the committed character; the real
-            // conversion runs in onCompositionEnd instead.
-            // nativeEvent is typed as Event; isComposing lives on InputEvent.
-            const composing =
-              "isComposing" in e.nativeEvent &&
-              (e.nativeEvent as InputEvent).isComposing;
-            if (isComposingRef.current || composing) {
-              setInputValue(raw);
-              return;
-            }
-            // Swallow the redundant change desktop fires right after commit.
-            if (suppressNextChangeRef.current) {
-              suppressNextChangeRef.current = false;
-              return;
-            }
-            handleChange(raw);
-          }}
+          {...kanaInput}
         />
       </div>
     </div>

--- a/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { FreqCategory, freqCategoryCn } from "@/lib/freq/freq-category";
 import { roundedMean } from "@/lib/utils";
 import { useEnterAction } from "@/hooks/use-enter-action";
+import { speedKatakanaPageMeta } from "@/components/items/practice-pages";
 import { SoundMode, SpeedKatakanaSettings, WordCount } from "./types";
 import { readSetStats } from "./storage";
 import { SpeedKatakanaStatsSummary } from "./SpeedKatakanaStatsSummary";
@@ -155,7 +156,9 @@ export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
       <div className="flex-1 min-h-0 pl-4 pr-2 overflow-auto">
         <div className="flex flex-col justify-center w-full max-w-lg min-h-full gap-6 px-1 mx-auto">
           <div className="flex flex-col items-center gap-1 px-6">
-            <h1 className="pt-4 text-lg font-bold text-center">🐇 Speed Katakana</h1>
+            <h1 className="pt-4 text-lg font-bold text-center">
+              {speedKatakanaPageMeta.heading}
+            </h1>
             <SpeedKatakanaStatsSummary
               completed={summary.completed}
               averageCpm={summary.averageCpm}

--- a/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
@@ -4,6 +4,7 @@ import { PracticeButton } from "@/components/ui/practice-button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { FreqCategory, freqCategoryCn } from "@/lib/freq/freq-category";
+import { roundedMean } from "@/lib/utils";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { SoundMode, SpeedKatakanaSettings, WordCount } from "./types";
 import { readSetStats } from "./storage";
@@ -112,15 +113,14 @@ export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
   );
 
   const summary = useMemo(() => {
-    let completed = 0;
-    let totalCpm = 0;
+    const cpms: number[] = [];
     for (let i = 1; i <= SPEED_KATAKANA_TOTAL_CHALLENGES; i++) {
       const s = readSetStats(i);
-      if (s) { completed++; totalCpm += s.latestCpm; }
+      if (s) cpms.push(s.latestCpm);
     }
     return {
-      completed,
-      averageCpm: completed > 0 ? Math.round(totalCpm / completed) : null,
+      completed: cpms.length,
+      averageCpm: roundedMean(cpms),
     };
   }, []);
 

--- a/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
+import { speedKatakanaPageMeta } from "@/components/items/practice-pages";
 import { SpeedKatakanaHeader } from "./SpeedKatakanaHeader";
 import { InitialScreen } from "./InitialScreen";
 import { Game } from "./Game";
@@ -19,7 +20,7 @@ const nextChallengeSet = (current: number) =>
   current >= SPEED_KATAKANA_TOTAL_CHALLENGES ? 1 : current + 1;
 
 const SpeedKatakanaScreen = () => {
-  useHtmlDocumentTitle("Speed Katakana");
+  useHtmlDocumentTitle(speedKatakanaPageMeta.heading);
 
   const [phase, setPhase] = useState<Phase>("initial");
   const [settings, setSetting] = useLocalStorage<SpeedKatakanaSettings>(

--- a/src/components/screens/SpeedKatakanaScreen/storage.ts
+++ b/src/components/screens/SpeedKatakanaScreen/storage.ts
@@ -1,3 +1,5 @@
+import { safeReadJson, notifyStorage } from "@/lib/storage";
+import { roundedMean } from "@/lib/utils";
 import { SessionStats } from "./types";
 
 export type ChallengeSetStats = {
@@ -8,18 +10,13 @@ export type ChallengeSetStats = {
   timesTaken: number;
 };
 
-const statsKey = (setNumber: number) =>
-  `speed-katakana-stats-${setNumber}`;
+export const STATS_KEY_PREFIX = "speed-katakana-stats-";
+
+const statsKey = (setNumber: number) => `${STATS_KEY_PREFIX}${setNumber}`;
 
 /** Returns the stored stats for a challenge set, or null if never attempted. */
-export const readSetStats = (setNumber: number): ChallengeSetStats | null => {
-  try {
-    const raw = localStorage.getItem(statsKey(setNumber));
-    return raw ? (JSON.parse(raw) as ChallengeSetStats) : null;
-  } catch {
-    return null;
-  }
-};
+export const readSetStats = (setNumber: number): ChallengeSetStats | null =>
+  safeReadJson<ChallengeSetStats | null>(statsKey(setNumber), null);
 
 /** Returns how many unique sets have recorded stats out of totalSets. */
 export const countCompletedSets = (totalSets: number): number => {
@@ -37,7 +34,7 @@ export const computeAverageCpm = (totalSets: number): number | null => {
     const stats = readSetStats(i);
     if (stats) cpms.push(stats.latestCpm);
   }
-  return cpms.length > 0 ? Math.round(cpms.reduce((a, b) => a + b, 0) / cpms.length) : null;
+  return roundedMean(cpms);
 };
 
 /** Merges a finished session's result into the stored stats for a set. */
@@ -55,7 +52,7 @@ export const recordSetResult = (
   };
   try {
     localStorage.setItem(statsKey(setNumber), JSON.stringify(next));
-    window.dispatchEvent(new StorageEvent("storage", { key: statsKey(setNumber) }));
+    notifyStorage(statsKey(setNumber));
   } catch {
     // ignore storage write failures (e.g. private mode quota)
   }

--- a/src/components/screens/SpeedKatakanaScreen/use-completed-sets-count.ts
+++ b/src/components/screens/SpeedKatakanaScreen/use-completed-sets-count.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { countCompletedSets } from "./storage";
+import { countCompletedSets, STATS_KEY_PREFIX } from "./storage";
 import { SPEED_KATAKANA_TOTAL_CHALLENGES } from "./constants";
 
 export const useCompletedSetsCount = () => {
@@ -9,7 +9,7 @@ export const useCompletedSetsCount = () => {
 
   useEffect(() => {
     const onStorage = (e: StorageEvent) => {
-      if (e.key?.startsWith("speed-katakana-stats-")) {
+      if (e.key?.startsWith(STATS_KEY_PREFIX)) {
         setCount(countCompletedSets(SPEED_KATAKANA_TOTAL_CHALLENGES));
       }
     };

--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -24,14 +24,14 @@ import { useKanjiRepresentativeWord } from "@/providers/kanji-representative-wor
 import { KanjiWordStatusActions } from "./KanjiWordStatusActions";
 import { StrokeAnimationLoadingScreen } from "./StrokeAnimationLoadingScreen";
 
-
 export const RirikkuCTABadge = () => {
   return (
     <Badge className="w-full py-2 mb-3 rounded-md">
       <a href={outLinks.ririkku} target="_blank" rel="noopener noreferrer">
         Lyrics make Japanese stick.{" "}
         <span className="underline">{"Ririkku,"}</span> the{" Internet's"}{" "}
-        coolest music player™ helps you absorb real Japanese from memorable songs.
+        coolest music player™ helps you absorb real Japanese from memorable
+        songs.
       </a>
     </Badge>
   );
@@ -52,41 +52,53 @@ export const ImprovementCTA = () => {
 };
 
 export const KanjiDetailsBottom = ({ kanji }: { kanji: string }) => {
-  return <>
+  return (
+    <>
+      <p className="my-4 text-xs text-left">
+        <strong>⚠ Note:</strong> The speak buttons 🔊 🎧 rely on your{" "}
+        {"browser's"} built-in text-to-speech, which may not work in some
+        devices.
+      </p>
 
-    <p className="my-4 text-xs text-left">
-      <strong>⚠ Note:</strong> The speak buttons 🔊 🎧 rely on your {"browser's"} built-in text-to-speech, which may not work in some devices.
-    </p>
+      <div className="my-4 w-fit">
+        <PikaPikaLinks />
+      </div>
 
-    <div className="my-4 w-fit">
-      <PikaPikaLinks />
-    </div>
-
-    <div className="flex items-center justify-start w-full mt-4 mb-8 space-x-1">
-      <LinksOutItems />
-      <DotIcon className="w-2 m-0" />
-      <DebugInfo />
-      <RefreshPageBtn />
-      <KanjiKeyboardShortcuts kanji={kanji} />
-      <ModeToggle />
-    </div>
-  </>
-}
+      <div className="flex items-center justify-start w-full mt-4 mb-8 space-x-1">
+        <LinksOutItems />
+        <DotIcon className="w-2 m-0" />
+        <DebugInfo />
+        <RefreshPageBtn />
+        <KanjiKeyboardShortcuts kanji={kanji} />
+        <ModeToggle />
+      </div>
+    </>
+  );
+};
 const StrokeAnimation = lazy(() => import("./StrokeAnimation"));
 
 const RepresentativeStudyWordAccordion = ({ kanji }: { kanji: string }) => {
+  const info = useKanjiRepresentativeWord(kanji);
 
-  const info = useKanjiRepresentativeWord(kanji)
+  return (
+    <>
+      <SimpleAccordion
+        trigger={`Anchor Word${info?.word ? `: ${info?.word}` : ""}`}
+        defaultOpen={false}
+      >
+        <RepresentativeStudyWord kanji={kanji} />
+      </SimpleAccordion>
+    </>
+  );
+};
 
-  return <>
-    <SimpleAccordion trigger={`Anchor Word${info?.word ? `: ${info?.word}` : ""}`} defaultOpen={false}>
-      <RepresentativeStudyWord kanji={kanji} />
-    </SimpleAccordion >
-  </>
-
-}
-
-export const KanjiDetails = ({ kanji, smallScreenNode }: { kanji: string, smallScreenNode: ReactNode }) => {
+export const KanjiDetails = ({
+  kanji,
+  smallScreenNode,
+}: {
+  kanji: string;
+  smallScreenNode: ReactNode;
+}) => {
   const getInfo = useGetKanjiInfoFn();
 
   if (getInfo == null) {
@@ -137,7 +149,10 @@ export const KanjiDetails = ({ kanji, smallScreenNode }: { kanji: string, smallS
           <ReadingFrequencyCategory kanji={kanji} />
         </ErrorBoundary>
       </SimpleAccordion>
-      <SimpleAccordion trigger={`External Links for ${kanji}`} defaultOpen={true}>
+      <SimpleAccordion
+        trigger={`External Links for ${kanji}`}
+        defaultOpen={true}
+      >
         <div className="mt-2 text-left">
           <ExternalKanjiLinks kanji={kanji} />
         </div>

--- a/src/components/sections/KanjiDetails/KanjiKeyboardShortcuts.tsx
+++ b/src/components/sections/KanjiDetails/KanjiKeyboardShortcuts.tsx
@@ -60,8 +60,8 @@ export const KanjiKeyboardShortcuts = ({ kanji }: { kanji: string }) => {
     return (
       <Button
         variant={"outline"}
-        size="icon"
-        className="h-8 w-8 relative rounded-xl"
+        size="iconXl"
+        className="relative"
         disabled={true}
       >
         <Keyboard />

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -258,7 +258,7 @@ export const StrokeAnimationWithPracticeMode = ({
 
   return (
     <div key={kanji}>
-      <div className="flex px-4 pt-6">
+      <div className="flex px-4 pt-6 pb-3">
         <div className="relative flex items-center w-full gap-2 mb-4">
           <Switch
             id="practice-mode"

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -33,14 +33,14 @@ const KanjiDMAK = ({
   step = SPEEDS.slow.rate,
   size = SVG_SIZE,
   staticMode = false,
-  gridShow = true
+  gridShow = true,
 }: {
   kanji: string;
   step?: number;
   size?: number;
   // when true: draws all strokes instantly with stroke-order numbers visible
   staticMode?: boolean;
-  gridShow?: boolean
+  gridShow?: boolean;
 }) => {
   const dmakInstanceRef = useRef<any>(null);
   const id = useId();
@@ -57,7 +57,7 @@ const KanjiDMAK = ({
       element: kanjiId,
       uri:
         import.meta.env.MODE === "development" ||
-          window.location.protocol === "http:"
+        window.location.protocol === "http:"
           ? assetsPaths.dev.KANJI_SVGS
           : assetsPaths.KANJI_SVGS,
       height: size,
@@ -67,13 +67,13 @@ const KanjiDMAK = ({
       // Passing a plain boolean breaks stroke.animated.drawing access — do not change.
       stroke: staticMode
         ? {
-          animated: { drawing: false, erasing: false },
-          order: { visible: true },
-          attr: { stroke: "random" },
-        }
+            animated: { drawing: false, erasing: false },
+            order: { visible: true },
+            attr: { stroke: "random" },
+          }
         : { attr: { stroke: "random" } },
 
-      grid: { show: gridShow }
+      grid: { show: gridShow },
     });
 
     return () => {
@@ -121,14 +121,12 @@ export const StrokeAnimation = ({ kanji }: { kanji: string }) => {
             });
           }}
         >
-          <Snail />{" "}
-          <span className="sr-only">Animate Slowly</span>
+          <Snail /> <span className="sr-only">Animate Slowly</span>
         </PracticeButton>
       </div>
     </div>
   );
 };
-
 
 const HINT_SVG_SIZE = 85;
 
@@ -149,7 +147,12 @@ const HintSection = ({ kanji }: { kanji: string }) => {
           pointerEvents: "none",
         }}
       >
-        <KanjiDMAK kanji={kanji} staticMode size={HINT_SVG_SIZE} gridShow={false} />
+        <KanjiDMAK
+          kanji={kanji}
+          staticMode
+          size={HINT_SVG_SIZE}
+          gridShow={false}
+        />
       </div>
     </div>
   );
@@ -210,7 +213,7 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
         onClickClear={onClear}
       />
 
-      <div className="w-full max-w-[310px] min-h-10 px-2 text-sm sm:text-base font-bold text-center">
+      <div className="w-full max-w-[310px] min-h-10 px-2 text-base font-bold text-center">
         {status === "loading" && (
           <div className="animate-fade-in opacity-80">採点中 · Grading…</div>
         )}
@@ -223,9 +226,7 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
           <div className="animate-fade-in">{gradeMessage(kanji, result)}</div>
         )}
         {status === "idle" && (
-          <div className="font-bold">
-            Draw the kanji, then tap 🚀 to grade.
-          </div>
+          <div className="font-bold">Draw the kanji, then tap 🚀 to grade.</div>
         )}
       </div>
 
@@ -272,7 +273,7 @@ export const StrokeAnimationWithPracticeMode = ({
           </label>
 
           {practiceMode && (
-            <div className="absolute z-10 px-2 m-4 border border-dashed right-0 sm:-right-8 animate-fade-in rounded-2xl -top-10 border-foreground bg-background/80">
+            <div className="absolute right-0 z-10 px-2 m-4 border border-dashed sm:-right-8 animate-fade-in rounded-2xl -top-10 border-foreground bg-background/80">
               <HintSection key={kanji} kanji={kanji} />
             </div>
           )}

--- a/src/components/sections/KanjiDetails/StrokeAnimationLoadingScreen.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimationLoadingScreen.tsx
@@ -4,7 +4,7 @@ import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
 export const StrokeAnimationLoadingScreen = () => {
   return (
     <div className="p-4">
-      <div className="flex px-4 pt-6 pb-2">
+      <div className="flex px-4 pt-6 pb-3">
         <div className="flex items-center gap-2">
           <div className="h-5 rounded-full w-9 bg-muted animate-pulse" />
           <div className="w-24 h-3 rounded-lg bg-muted animate-pulse" />

--- a/src/components/shared-practice/BlurredGloss.tsx
+++ b/src/components/shared-practice/BlurredGloss.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * English-gloss text that starts blurred and reveals on tap. Owns the toggle
+ * state and re-applies the initial blur whenever `resetKey` changes (e.g. the
+ * card index). When `blurrable` is false it renders as plain, non-interactive
+ * text; `forceReveal` un-blurs regardless of the toggle (e.g. answer revealed).
+ */
+export const BlurredGloss = ({
+  text,
+  resetKey,
+  blurrable = true,
+  forceReveal = false,
+  className,
+}: {
+  text: string;
+  resetKey: unknown;
+  blurrable?: boolean;
+  forceReveal?: boolean;
+  className?: string;
+}) => {
+  const [blurred, setBlurred] = useState(blurrable);
+
+  useEffect(() => {
+    setBlurred(blurrable);
+  }, [resetKey, blurrable]);
+
+  const gloss = text || "—";
+  const base = "max-w-sm px-2 text-xs font-bold tracking-wide";
+
+  if (!blurrable) {
+    return <p className={cn(base, className)}>{gloss}</p>;
+  }
+
+  const isBlurred = blurred && !forceReveal;
+  return (
+    <button
+      type="button"
+      className={cn(
+        base,
+        "transition-all outline-none",
+        isBlurred && "blur-[5px] hover:blur-none",
+        className
+      )}
+      onClick={() => setBlurred((v) => !v)}
+      aria-label={isBlurred ? "Reveal English gloss" : "Blur English gloss"}
+    >
+      {gloss}
+    </button>
+  );
+};

--- a/src/components/shared-practice/CountUpStat.tsx
+++ b/src/components/shared-practice/CountUpStat.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+
+const COUNT_UP_MS = 900;
+
+/** Animates from 0 up to `target` over COUNT_UP_MS once on mount. */
+const useCountUp = (target: number) => {
+  const [value, setValue] = useState(0);
+
+  useEffect(() => {
+    let frame = 0;
+    const start = performance.now();
+    const tick = (now: number) => {
+      const progress = Math.min((now - start) / COUNT_UP_MS, 1);
+      // easeOutCubic
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setValue(Math.round(target * eased));
+      if (progress < 1) frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [target]);
+
+  return value;
+};
+
+/** A single count-up stat tile (big number + optional unit + label). */
+export const Stat = ({
+  value,
+  unit,
+  label,
+}: {
+  value: number;
+  unit: string;
+  label: string;
+}) => {
+  const animated = useCountUp(value);
+  return (
+    <div className="flex flex-col items-center gap-1 animate-practice-tile-in">
+      <div className="text-5xl font-bold tabular-nums sm:text-6xl">
+        {animated}
+        {unit ? (
+          <span className="ml-1 text-2xl font-semibold text-muted-foreground">
+            {unit}
+          </span>
+        ) : null}
+      </div>
+      <div className="text-xs font-bold uppercase text-muted-foreground">
+        {label}
+      </div>
+    </div>
+  );
+};

--- a/src/components/shared-practice/EndSession.tsx
+++ b/src/components/shared-practice/EndSession.tsx
@@ -1,57 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { pickEndCheer } from "@/lib/practice-cheers";
+import { percent } from "@/lib/utils";
+import { Stat } from "./CountUpStat";
 import { PracticeSessionResult } from "./types";
 import { RecapTile } from "./RecapTile";
-
-const COUNT_UP_MS = 900;
-
-const useCountUp = (target: number) => {
-  const [value, setValue] = useState(0);
-
-  useEffect(() => {
-    let frame = 0;
-    const start = performance.now();
-    const tick = (now: number) => {
-      const progress = Math.min((now - start) / COUNT_UP_MS, 1);
-      const eased = 1 - Math.pow(1 - progress, 3);
-      setValue(Math.round(target * eased));
-      if (progress < 1) frame = requestAnimationFrame(tick);
-    };
-    frame = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(frame);
-  }, [target]);
-
-  return value;
-};
-
-const Stat = ({
-  value,
-  unit,
-  label,
-}: {
-  value: number;
-  unit: string;
-  label: string;
-}) => {
-  const animated = useCountUp(value);
-  return (
-    <div className="flex flex-col items-center gap-1 animate-practice-tile-in">
-      <div className="text-5xl font-bold tabular-nums sm:text-6xl">
-        {animated}
-        {unit ? (
-          <span className="ml-1 text-2xl font-semibold text-muted-foreground">
-            {unit}
-          </span>
-        ) : null}
-      </div>
-      <div className="text-xs font-bold uppercase text-muted-foreground">
-        {label}
-      </div>
-    </div>
-  );
-};
 
 export const EndSession = ({
   results,
@@ -70,10 +24,7 @@ export const EndSession = ({
 }) => {
   const cheer = useMemo(() => pickEndCheer(), []);
   const correctCount = results.filter((r) => r.correct).length;
-  const accuracy =
-    results.length > 0
-      ? Math.round((100 * correctCount) / results.length)
-      : 100;
+  const accuracy = percent(correctCount, results.length, 100);
 
   useEnterAction(hasMore ? onNext : onEnd);
 

--- a/src/components/shared-practice/build-deck.ts
+++ b/src/components/shared-practice/build-deck.ts
@@ -1,7 +1,7 @@
 import { JLPTOptionsCount, JLTPTtypes } from "@/lib/jlpt";
 import { isBookmarked } from "@/lib/bookmarks";
 import { shuffle } from "@/lib/utils";
-import { NUMBER_OF_FONTS } from "@/hooks/use-change-font";
+import { randomFontIndex } from "@/hooks/use-change-font";
 import { DeckFilterSettings, PracticeItem } from "./types";
 
 type RepEntry = [string, string, string, string];
@@ -39,9 +39,7 @@ export const buildPracticeDeck = ({
       reading,
       englishGloss: englishGloss ?? "",
       keyword: getKeyword(kanji) || "...",
-      fontIndex: settings.randomizeFont
-        ? Math.floor(Math.random() * NUMBER_OF_FONTS)
-        : null,
+      fontIndex: settings.randomizeFont ? randomFontIndex() : null,
     });
   }
 
@@ -58,6 +56,6 @@ export const withFreshFonts = (
   }
   return items.map((item) => ({
     ...item,
-    fontIndex: Math.floor(Math.random() * NUMBER_OF_FONTS),
+    fontIndex: randomFontIndex(),
   }));
 };

--- a/src/components/shared-practice/index.ts
+++ b/src/components/shared-practice/index.ts
@@ -1,4 +1,6 @@
 export { buildPracticeDeck, withFreshFonts } from "./build-deck";
+export { BlurredGloss } from "./BlurredGloss";
+export { Stat } from "./CountUpStat";
 export { EndSession } from "./EndSession";
 export { PracticeShell } from "./PracticeShell";
 export { RecapTile } from "./RecapTile";

--- a/src/components/site-layout/Header/HeaderDrawer.tsx
+++ b/src/components/site-layout/Header/HeaderDrawer.tsx
@@ -91,8 +91,7 @@ const HeaderDrawer = ({
       <DrawerPrimitive.Trigger asChild>
         <Button
           variant="outline"
-          size="icon"
-          className="w-8 h-8 rounded-xl"
+          size="iconXl"
           aria-label="Open menu"
         >
           <Menu className="w-7 h-7" />

--- a/src/components/site-layout/Header/LazyHeaderDrawer.tsx
+++ b/src/components/site-layout/Header/LazyHeaderDrawer.tsx
@@ -7,8 +7,7 @@ const HeaderDrawer = lazy(() => import("./HeaderDrawer"));
 const MenuTriggerFallback = ({ disabled = false }: { disabled?: boolean }) => (
   <Button
     variant="outline"
-    size="icon"
-    className="w-8 h-8 rounded-xl"
+    size="iconXl"
     aria-label="Open menu"
     disabled={disabled}
   >
@@ -26,8 +25,7 @@ const LazyHeaderDrawer = () => {
     return (
       <Button
         variant="outline"
-        size="icon"
-        className="w-8 h-8 rounded-xl"
+        size="iconXl"
         aria-label="Open menu"
         onClick={() => setShouldLoad(true)}
       >

--- a/src/components/ui/button-utils.ts
+++ b/src/components/ui/button-utils.ts
@@ -20,6 +20,7 @@ const buttonVariants = cva(
         sm: "h-9 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",
+        iconXl: "h-8 w-8 rounded-xl",
       },
     },
     defaultVariants: {

--- a/src/hooks/use-change-font.ts
+++ b/src/hooks/use-change-font.ts
@@ -3,6 +3,10 @@ import { useCallback, useLayoutEffect, useRef } from "react";
 const LOCAL_STORAGE_KANJI_FONT_KEY = "kanji-font";
 export const NUMBER_OF_FONTS = 15;
 
+/** A random valid kanji-font index. */
+export const randomFontIndex = () =>
+  Math.floor(Math.random() * NUMBER_OF_FONTS);
+
 export const useChangeFont = () => {
   const fontIdRef = useRef(0);
 

--- a/src/hooks/use-correct-sound.ts
+++ b/src/hooks/use-correct-sound.ts
@@ -1,0 +1,32 @@
+import { useCallback, useRef } from "react";
+import assetsPaths from "@/lib/assets-paths";
+
+/**
+ * Returns a `play` function for the on-correct feedback used by the practice
+ * modes. It owns the lazily-created <audio> element and the speak/beep choice:
+ * pass a `speak` callback to speak instead of playing the beep. Callers supply
+ * their own `enabled` flag (settings differ per mode).
+ */
+export const useCorrectSound = () => {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  return useCallback(
+    ({ enabled, speak }: { enabled: boolean; speak?: () => void }) => {
+      if (!enabled) return;
+      if (speak) {
+        speak();
+        return;
+      }
+      try {
+        if (!audioRef.current) {
+          audioRef.current = new Audio(assetsPaths.SPEED_KATAKANA_CORRECT_SOUND);
+        }
+        audioRef.current.currentTime = 0;
+        void audioRef.current.play();
+      } catch {
+        // ignore playback failures
+      }
+    },
+    []
+  );
+};

--- a/src/hooks/use-kana-input.ts
+++ b/src/hooks/use-kana-input.ts
@@ -1,0 +1,60 @@
+import { useRef } from "react";
+
+/**
+ * Composition-aware input handlers shared by the kana/romaji typing practice
+ * modes. IMEs (e.g. the iOS Japanese keyboard) fire change events mid- and
+ * post-composition inconsistently; transforming the value during composition
+ * makes iOS Safari duplicate the committed character. These handlers keep the
+ * raw value while composing (via `setRawValue`) and only run the real
+ * conversion once per commit (via `onCommit`), swallowing the redundant
+ * trailing change desktop browsers fire.
+ *
+ * Spread the returned object onto the <input>:
+ *   <Input {...useKanaInput({ setRawValue: setValue, onCommit: handleChange })} />
+ */
+export const useKanaInput = ({
+  setRawValue,
+  onCommit,
+}: {
+  setRawValue: (raw: string) => void;
+  onCommit: (raw: string) => void;
+}) => {
+  const isComposingRef = useRef(false);
+  const suppressNextChangeRef = useRef(false);
+
+  return {
+    onCompositionStart: () => {
+      isComposingRef.current = true;
+      // A new composition means any pending suppression is stale.
+      suppressNextChangeRef.current = false;
+    },
+    onCompositionEnd: (e: React.CompositionEvent<HTMLInputElement>) => {
+      isComposingRef.current = false;
+      // iOS commits kana and fires no trailing change event, so the conversion
+      // must run here. Desktop *does* fire a trailing change, so suppress that
+      // one duplicate (cleared on a macrotask, after it has fired).
+      suppressNextChangeRef.current = true;
+      setTimeout(() => {
+        suppressNextChangeRef.current = false;
+      }, 0);
+      onCommit(e.currentTarget.value);
+    },
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      // nativeEvent is typed as Event; isComposing lives on InputEvent.
+      const composing =
+        "isComposing" in e.nativeEvent &&
+        (e.nativeEvent as InputEvent).isComposing;
+      if (isComposingRef.current || composing) {
+        setRawValue(raw);
+        return;
+      }
+      // Swallow the redundant change desktop fires right after commit.
+      if (suppressNextChangeRef.current) {
+        suppressNextChangeRef.current = false;
+        return;
+      }
+      onCommit(raw);
+    },
+  };
+};

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,18 +1,19 @@
 import { useState, useCallback, useEffect, useRef } from "react";
+import { safeReadJson, notifyStorage } from "@/lib/storage";
 
 type DispatchFunction<T> = (key: keyof T, value: T[keyof T]) => void;
 
 const readFromStorage = <T>(storageKey: string, defaultValue: T): T => {
-  try {
-    const storedData = localStorage.getItem(storageKey);
-    if (storedData == null) {
+  // Seed storage with the default the first time the key is read.
+  if (localStorage.getItem(storageKey) == null) {
+    try {
       localStorage.setItem(storageKey, JSON.stringify(defaultValue));
-      return defaultValue;
+    } catch {
+      // ignore write failures (e.g. private mode quota)
     }
-    return JSON.parse(storedData);
-  } catch {
     return defaultValue;
   }
+  return safeReadJson(storageKey, defaultValue);
 };
 
 export function useLocalStorage2(storageKey: string) {
@@ -30,7 +31,7 @@ export function useLocalStorage2(storageKey: string) {
         localStorage.removeItem(storageKey);
       }
       setValue(next);
-      window.dispatchEvent(new StorageEvent("storage", { key: storageKey }));
+      notifyStorage(storageKey);
     },
     [storageKey]
   );
@@ -66,10 +67,10 @@ export function useLocalStorage<T>(storageKey: string, defaultValue: T) {
       setStorageData((prevData) => {
         const newData = { ...prevData, [key]: value };
         localStorage.setItem(storageKey, JSON.stringify(newData));
-        // Dispatch so other hook instances on the same key (and the listener
-        // above) pick up the change. The browser only fires StorageEvent
-        // cross-tab automatically; same-page listeners need an explicit dispatch.
-        window.dispatchEvent(new StorageEvent("storage", { key: storageKey }));
+        // Notify other hook instances on the same key (and the listener above).
+        // The browser only fires StorageEvent cross-tab automatically;
+        // same-page listeners need an explicit dispatch.
+        notifyStorage(storageKey);
         return newData;
       });
     },

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,23 @@
+/**
+ * Safely reads and JSON-parses a localStorage value, returning `fallback` when
+ * the key is missing or the stored value can't be parsed (or storage throws,
+ * e.g. private-mode restrictions).
+ */
+export const safeReadJson = <T>(key: string, fallback: T): T => {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw != null ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+};
+
+/**
+ * Notifies same-page listeners of a storage write. The browser fires
+ * StorageEvent automatically across tabs, but same-page `window` listeners
+ * (e.g. other useLocalStorage instances on the same key) need this explicit
+ * dispatch.
+ */
+export const notifyStorage = (key: string) => {
+  window.dispatchEvent(new StorageEvent("storage", { key }));
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,6 +14,14 @@ export const clamp = (num: number, min: number, max: number) => {
   return Math.min(max, Math.max(num, min));
 };
 
+/** Rounded percentage of `part` out of `total`, or `fallback` when total is 0. */
+export const percent = (part: number, total: number, fallback = 0) =>
+  total > 0 ? Math.round((100 * part) / total) : fallback;
+
+/** Rounded mean of a numeric array, or null when empty. */
+export const roundedMean = (nums: number[]): number | null =>
+  nums.length ? Math.round(nums.reduce((a, b) => a + b, 0) / nums.length) : null;
+
 export const toNum = (str?: string | null | number, fallback?: number) => {
   if (typeof str === "string" && !Number.isNaN(Number(str))) {
     return Number(str);


### PR DESCRIPTION
## Summary
- Extract duplicated practice/UI code (count-up stats, blurred gloss, correct-sound and kana-input hooks, dictionary popover shell, storage helpers) into shared modules used by Recognition, Production, and Speed Katakana
- Reuse practice page metadata for headings and descriptions so screens, document titles, and nav stay in sync
- Small polish: wording, font size, and padding tweaks across practice screens

## Test plan
- [ ] Recognition, Production, and Speed Katakana practice flows start, play, and end correctly
- [ ] Dictionary popovers (Jisho/Jotoba) still open and behave as before
- [ ] Practice headings/descriptions match nav and document titles
- [ ] Local storage / completed-sets stats still persist correctly
- [ ] Production build succeeds


Made with [Cursor](https://cursor.com)