### PR TITLE
Polish kanji practice UX and harden stroke/look-alike flows

### DIFF
--- a/src/components/dependent/kana/RomajiBadge.tsx
+++ b/src/components/dependent/kana/RomajiBadge.tsx
@@ -4,7 +4,13 @@ import { cn } from "@/lib/utils";
 import { translateValue } from "@/lib/wanakana-adapter";
 import { useSpeak } from "@/hooks/use-jp-speak";
 
-export const RomajiBadge = ({ kana }: { kana: string }) => {
+export const RomajiBadge = ({
+  kana,
+  className,
+}: {
+  kana: string;
+  className?: string;
+}) => {
   const [isKana, setIsKana] = useState(true);
   const speak = useSpeak(kana);
 
@@ -15,10 +21,11 @@ export const RomajiBadge = ({ kana }: { kana: string }) => {
       type="button"
       className={cn(
         badgeVariants({ variant: "outline" }),
-        "m-1 py-2 px-3 cursor-pointer text-2xl whitespace-nowrap",
+        "m-1 py-2 px-3 cursor-pointer whitespace-nowrap",
         "hover:bg-[#2effff] hover:text-black",
         "outline-none focus:outline-none focus:ring-0",
-        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 text-2xl",
+        className,
         isKana && "kanji-font"
       )}
       aria-label={`Play reading and toggle kana or romaji for ${kana}`}

--- a/src/components/dependent/kana/RomajiBadge.tsx
+++ b/src/components/dependent/kana/RomajiBadge.tsx
@@ -15,7 +15,7 @@ export const RomajiBadge = ({ kana }: { kana: string }) => {
       type="button"
       className={cn(
         badgeVariants({ variant: "outline" }),
-        "m-1 cursor-pointer text-xl whitespace-nowrap",
+        "m-1 cursor-pointer text-2xl whitespace-nowrap",
         "hover:bg-[#2effff] hover:text-black",
         "outline-none focus:outline-none focus:ring-0",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",

--- a/src/components/dependent/kana/RomajiBadge.tsx
+++ b/src/components/dependent/kana/RomajiBadge.tsx
@@ -15,7 +15,7 @@ export const RomajiBadge = ({ kana }: { kana: string }) => {
       type="button"
       className={cn(
         badgeVariants({ variant: "outline" }),
-        "m-1 cursor-pointer text-2xl whitespace-nowrap",
+        "m-1 py-2 px-3 cursor-pointer text-2xl whitespace-nowrap",
         "hover:bg-[#2effff] hover:text-black",
         "outline-none focus:outline-none focus:ring-0",
         "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",

--- a/src/components/production-practice-v1/Game.tsx
+++ b/src/components/production-practice-v1/Game.tsx
@@ -169,7 +169,9 @@ export const Game = ({
         inTop10,
       };
       const similarList = similarState.data ?? similars;
-      const isRealKanji = (k: string) => getKanjiInfo?.(k) != null;
+      // Require a kanji_main entry (jlpt). getKanjiInfo also returns radical
+      // part-keywords (e.g. 囗 → "closed box"), which must not count.
+      const isRealKanji = (k: string) => getKanjiInfo?.(k)?.jlpt != null;
       const grid = buildCandidateGrid({
         target: current.kanji,
         inTop10,

--- a/src/components/production-practice-v1/Game.tsx
+++ b/src/components/production-practice-v1/Game.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { CircleArrowLeft, Rocket } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Rocket } from "lucide-react";
 import {
   DrawingPad,
   DrawingSubmitPayload,
@@ -12,6 +11,7 @@ import { useSpeak } from "@/hooks/use-jp-speak";
 import { useFitPadSize } from "@/hooks/use-fit-pad-size";
 import { useCorrectSound } from "@/hooks/use-correct-sound";
 import { BlurredGloss } from "@/components/shared-practice";
+import { EndSession } from "@/components/shared-practice/EndSessionButton";
 import {
   useGetKanjiInfoFn,
   useSimilarKanjis,
@@ -216,16 +216,7 @@ export const Game = ({
 
   return (
     <div className="relative flex flex-col w-full h-full overflow-hidden">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="absolute z-10 top-1 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
-        tabIndex={-1}
-        onClick={onEnd}
-        aria-label="End session"
-      >
-        <CircleArrowLeft />
-      </Button>
+      <EndSession onClick={onEnd} />
 
       <div className="flex flex-col items-center flex-1 min-h-0 px-3 pt-8 pb-2 overflow-y-auto sm:px-4">
         <ClozeWord

--- a/src/components/production-practice-v1/Game.tsx
+++ b/src/components/production-practice-v1/Game.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Rocket } from "lucide-react";
 import {
   DrawingPad,
@@ -10,16 +10,18 @@ import { SpeakButton } from "@/components/common/SpeakButton";
 import { useSpeak } from "@/hooks/use-jp-speak";
 import { useFitPadSize } from "@/hooks/use-fit-pad-size";
 import { useCorrectSound } from "@/hooks/use-correct-sound";
+import { useJsonFetch } from "@/hooks/use-json";
 import { BlurredGloss } from "@/components/shared-practice";
 import { EndSession } from "@/components/shared-practice/EndSessionButton";
 import {
   useGetKanjiInfoFn,
   useSimilarKanjis,
 } from "@/kanji-worker/kanji-worker-hooks";
-import { recognizeWithDaKanji } from "@/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/recognizers";
+import { recognizeDaKanji } from "@/lib/dakanji-adapter";
+import assetsPaths from "@/lib/assets-paths";
 import { ClozeWord } from "./ClozeWord";
 import { buildCandidateGrid } from "./build-candidates";
-import { DRAW_SVG_SIZE } from "./constants";
+import { DRAW_SVG_SIZE, GRADE_TOP_K, RECOGNIZE_TOP_K } from "./constants";
 import { SelectSimilarKanjiDrawer } from "./drawers/SelectSimilarKanjiDrawer";
 import { FeedbackDrawer } from "./drawers/FeedbackDrawer";
 import {
@@ -74,6 +76,13 @@ export const Game = ({
   const similarState = useSimilarKanjis(current?.kanji ?? "");
   const similars = similarState.data ?? [];
   const getKanjiInfo = useGetKanjiInfoFn();
+  const { data: similarMap } = useJsonFetch<Record<string, string[]>>(
+    assetsPaths.SIMILAR_KANJIS
+  );
+  const getSimilars = useMemo(() => {
+    const map = similarMap;
+    return (k: string) => map?.[k] ?? [];
+  }, [similarMap]);
   const speak = useSpeak(current?.word ?? "");
   const playCorrect = useCorrectSound();
 
@@ -160,9 +169,9 @@ export const Game = ({
     setDrawing(payload);
     setStep({ type: "recognizing" });
     try {
-      const candidates = await recognizeWithDaKanji(payload);
+      const candidates = await recognizeDaKanji(payload, RECOGNIZE_TOP_K);
       const rank = candidates.indexOf(current.kanji);
-      const inTop10 = rank >= 0;
+      const inTop10 = rank >= 0 && rank < GRADE_TOP_K;
       const grade: GradeRankInfo = {
         rank,
         topGuess: candidates[0] ?? null,
@@ -178,6 +187,7 @@ export const Game = ({
         modelGuesses: candidates,
         similars: similarList,
         randomPool: randomKanjiPool,
+        getSimilars,
         isRealKanji,
       });
       setSelected(null);

--- a/src/components/production-practice-v1/Game.tsx
+++ b/src/components/production-practice-v1/Game.tsx
@@ -12,7 +12,10 @@ import { useSpeak } from "@/hooks/use-jp-speak";
 import { useFitPadSize } from "@/hooks/use-fit-pad-size";
 import { useCorrectSound } from "@/hooks/use-correct-sound";
 import { BlurredGloss } from "@/components/shared-practice";
-import { useSimilarKanjis } from "@/kanji-worker/kanji-worker-hooks";
+import {
+  useGetKanjiInfoFn,
+  useSimilarKanjis,
+} from "@/kanji-worker/kanji-worker-hooks";
 import { recognizeWithDaKanji } from "@/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/recognizers";
 import { ClozeWord } from "./ClozeWord";
 import { buildCandidateGrid } from "./build-candidates";
@@ -62,11 +65,15 @@ export const Game = ({
   const [step, setStep] = useState<CardStep>({ type: "draw" });
   const [selected, setSelected] = useState<string | null>(null);
   const resultsRef = useRef<SessionResult[]>([]);
+  const drawSubmitRef = useRef<(payload: DrawingSubmitPayload) => void>(
+    () => {}
+  );
   const padSize = useFitPadSize(DRAW_SVG_SIZE);
 
   const current = sessionItems[index];
   const similarState = useSimilarKanjis(current?.kanji ?? "");
   const similars = similarState.data ?? [];
+  const getKanjiInfo = useGetKanjiInfoFn();
   const speak = useSpeak(current?.word ?? "");
   const playCorrect = useCorrectSound();
 
@@ -94,6 +101,29 @@ export const Game = ({
     speak();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- speak on card load only
   }, [index, settings.hearPronunciationOnLoad]);
+
+  // Enter/Space grades when there are strokes. Never Forgot via keyboard.
+  useEffect(() => {
+    if (step.type !== "draw" || strokes.length === 0) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.key !== "Enter" && e.key !== " ") || e.isComposing) return;
+      const el = e.target as HTMLElement | null;
+      if (!el) return;
+      const tag = el.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (el.isContentEditable) return;
+      e.preventDefault();
+      drawSubmitRef.current({
+        strokes,
+        width: padSize,
+        height: padSize,
+      });
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [step.type, strokes, padSize]);
 
   if (!current) {
     return null;
@@ -139,12 +169,14 @@ export const Game = ({
         inTop10,
       };
       const similarList = similarState.data ?? similars;
+      const isRealKanji = (k: string) => getKanjiInfo?.(k) != null;
       const grid = buildCandidateGrid({
         target: current.kanji,
         inTop10,
         modelGuesses: candidates,
         similars: similarList,
         randomPool: randomKanjiPool,
+        isRealKanji,
       });
       setSelected(null);
       setStep({ type: "select", grade, candidates: grid });
@@ -152,6 +184,8 @@ export const Game = ({
       setStep({ type: "draw" });
     }
   };
+
+  drawSubmitRef.current = onSubmit;
 
   const onSelectForgot = () => {
     if (step.type !== "select") return;
@@ -214,7 +248,7 @@ export const Game = ({
         />
 
         <div
-          className="relative mt-2 w-full mx-auto"
+          className="relative w-full mx-auto mt-2"
           style={{ maxWidth: padSize + 32 }}
         >
           <DrawingPad

--- a/src/components/production-practice-v1/StrokeOrderPlayer.tsx
+++ b/src/components/production-practice-v1/StrokeOrderPlayer.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Raphael from "raphael";
 import "dmak";
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { PlayCircle, Snail } from "@/components/icons";
 import assetsPaths from "@/lib/assets-paths";
-import { installSafeDmakLoader } from "@/lib/dmak-safe-loader";
+import { abandonDmak, installSafeDmakLoader } from "@/lib/dmak-safe-loader";
 
 installSafeDmakLoader();
 
@@ -25,18 +25,13 @@ const KanjiDMAK = ({
   step: number;
   size: number;
 }) => {
-  const dmakInstanceRef = useRef<any>(null);
   const id = useId();
   const kanjiId = `${id}-${kanji}-draw`;
 
   useEffect(() => {
     (window as any).Raphael = Raphael;
 
-    if (dmakInstanceRef.current) {
-      return;
-    }
-
-    dmakInstanceRef.current = new (window as any).Dmak(kanji, {
+    const dmak = new (window as any).Dmak(kanji, {
       element: kanjiId,
       uri:
         import.meta.env.MODE === "development" ||
@@ -51,7 +46,10 @@ const KanjiDMAK = ({
     });
 
     return () => {
-      (window as any).Raphael = null;
+      abandonDmak(dmak);
+      // Strict Mode re-runs this effect on the same host — clear leftover SVG.
+      document.getElementById(kanjiId)?.replaceChildren();
+      // Keep window.Raphael set; other KanjiDMAK instances may still need it.
     };
   }, [kanji, kanjiId, step, size]);
 
@@ -67,19 +65,35 @@ export const StrokeOrderPlayer = ({
 }) => {
   const [key, setKey] = useState(1);
   const [speed, setSpeed] = useState<AnimationSpeed>("fast");
+  const replay = () => setKey((x) => x + 1);
 
   return (
     <div className="flex flex-col items-center gap-2">
-      <div style={{ height: size }} key={`${kanji}-${speed}-${key}`}>
-        <KanjiDMAK kanji={kanji} step={SPEEDS[speed].rate} size={size} />
+      <div
+        role="button"
+        tabIndex={0}
+        title="Replay stroke order"
+        className="cursor-pointer"
+        style={{ height: size }}
+        onClick={replay}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            replay();
+          }
+        }}
+      >
+        <div key={`${kanji}-${speed}-${key}`}>
+          <KanjiDMAK kanji={kanji} step={SPEEDS[speed].rate} size={size} />
+        </div>
       </div>
       <div className="flex justify-center space-x-1.5 sm:space-x-2">
         <PracticeButton
           size="icon"
-          className="h-10 w-10 sm:h-12 sm:w-12"
+          className="w-10 h-10 sm:h-12 sm:w-12"
           onClick={() => {
             setSpeed("fast");
-            setKey((x) => x + 1);
+            replay();
           }}
         >
           <PlayCircle />
@@ -88,10 +102,10 @@ export const StrokeOrderPlayer = ({
         <PracticeButton
           size="icon"
           variant="secondary"
-          className="h-10 w-10 sm:h-12 sm:w-12"
+          className="w-10 h-10 sm:h-12 sm:w-12"
           onClick={() => {
             setSpeed("slow");
-            setKey((x) => x + 1);
+            replay();
           }}
         >
           <Snail />

--- a/src/components/production-practice-v1/WritingPracticeModal.tsx
+++ b/src/components/production-practice-v1/WritingPracticeModal.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from "react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -28,6 +29,9 @@ export const WritingPracticeModal = ({
           <DialogTitle className="flex items-center text-center">
             <span className="text-3xl kanji-font">{kanji}</span>
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Practice writing stroke order for {kanji}
+          </DialogDescription>
         </DialogHeader>
         <ErrorBoundary details="StrokeAnimation in WritingPracticeModal">
           <Suspense fallback={<StrokeAnimationLoadingScreen />}>

--- a/src/components/production-practice-v1/WritingPracticeModal.tsx
+++ b/src/components/production-practice-v1/WritingPracticeModal.tsx
@@ -23,7 +23,7 @@ export const WritingPracticeModal = ({
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md max-h-[90dvh] overflow-y-auto px-4 py-0 sm:rounded-2xl">
+      <DialogContent className="max-w-md max-h-[90dvh] overflow-y-auto px-4 py-0">
         <DialogHeader className="px-6 pt-6 pb-0">
           <DialogTitle className="flex items-center text-center">
             <span className="text-3xl kanji-font">{kanji}</span>

--- a/src/components/production-practice-v1/WritingPracticeModal.tsx
+++ b/src/components/production-practice-v1/WritingPracticeModal.tsx
@@ -35,7 +35,10 @@ export const WritingPracticeModal = ({
         </DialogHeader>
         <ErrorBoundary details="StrokeAnimation in WritingPracticeModal">
           <Suspense fallback={<StrokeAnimationLoadingScreen />}>
-            <StrokeAnimation key={kanji} kanji={kanji} defaultPracticeMode />
+            {/* Remount when opened so stroke order restarts from the first stroke. */}
+            {open && (
+              <StrokeAnimation key={kanji} kanji={kanji} defaultPracticeMode />
+            )}
           </Suspense>
         </ErrorBoundary>
       </DialogContent>

--- a/src/components/production-practice-v1/build-candidates.ts
+++ b/src/components/production-practice-v1/build-candidates.ts
@@ -4,9 +4,12 @@ import { CANDIDATE_COUNT } from "./constants";
 /**
  * Build a 12-kanji look-alike grid (always 4×3).
  * Always shuffled so a top-model hit is not always in the first cell.
- * Fill order before shuffle: target → similars / model guesses → random pool.
+ * Fill order before shuffle: target → seed → secondary → filler.
+ * Always pads to CANDIDATE_COUNT when the pools have enough unique real kanji.
  *
  * Hard rule: only real kanji — no hiragana, katakana, or radicals-only glyphs.
+ * Pass `isRealKanji` that checks kanji_main (e.g. `info?.jlpt != null`), not
+ * `getKanjiInfo != null` — that helper also returns radical part-keywords.
  */
 export const buildCandidateGrid = ({
   target,
@@ -24,32 +27,28 @@ export const buildCandidateGrid = ({
   /** Override for “in our kanji database” checks (recommended). */
   isRealKanji?: (k: string) => boolean;
 }): string[] => {
+  // Model top-K is 10; after filtering kana/radicals we may be short of 12.
+  // Always pad with similars / the other pool, then random deck kanji.
   if (inTop10) {
     return padCandidates(
-      modelGuesses.slice(0, CANDIDATE_COUNT),
+      modelGuesses,
       target,
-      [],
+      similars,
       randomPool,
       isRealKanji
     );
   }
 
-  return padCandidates(
-    [],
-    target,
-    similars,
-    [...modelGuesses, ...randomPool],
-    isRealKanji
-  );
+  return padCandidates(similars, target, modelGuesses, randomPool, isRealKanji);
 };
 
-/** Unicode CJK only — drops kana; pass `isRealKanji` from the kanji DB for radicals. */
+/** Unicode CJK only — drops kana; pass `isRealKanji` from kanji_main for radicals. */
 const defaultIsRealKanji = (k: string) => k.length === 1 && isKanji(k);
 
 const padCandidates = (
   seed: string[],
   target: string,
-  similars: string[],
+  secondary: string[],
   filler: string[],
   isRealKanji: (k: string) => boolean
 ): string[] => {
@@ -65,7 +64,7 @@ const padCandidates = (
 
   push(target, true);
   for (const k of seed) push(k);
-  for (const k of similars) push(k);
+  for (const k of secondary) push(k);
   for (const k of filler) push(k);
 
   return shuffle(out);

--- a/src/components/production-practice-v1/build-candidates.ts
+++ b/src/components/production-practice-v1/build-candidates.ts
@@ -4,8 +4,13 @@ import { CANDIDATE_COUNT } from "./constants";
 /**
  * Build a 12-kanji look-alike grid (always 4×3).
  * Always shuffled so a top-model hit is not always in the first cell.
- * Fill order before shuffle: target → seed → secondary → filler.
- * Always pads to CANDIDATE_COUNT when the pools have enough unique real kanji.
+ *
+ * Fill order before shuffle:
+ *   1. target (always)
+ *   2. seed — model guesses if in top 10, else database similars
+ *   3. secondary — the other of those two
+ *   4. related — similars of the model guesses / similars (lookalike neighbors)
+ *   5. random deck — last resort only
  *
  * Hard rule: only real kanji — no hiragana, katakana, or radicals-only glyphs.
  * Pass `isRealKanji` that checks kanji_main (e.g. `info?.jlpt != null`), not
@@ -17,6 +22,7 @@ export const buildCandidateGrid = ({
   modelGuesses,
   similars,
   randomPool,
+  getSimilars,
   isRealKanji = defaultIsRealKanji,
 }: {
   target: string;
@@ -24,31 +30,64 @@ export const buildCandidateGrid = ({
   modelGuesses: string[];
   similars: string[];
   randomPool: string[];
+  /** Similars lookup used to expand lookalikes of model/similar seeds. */
+  getSimilars?: (k: string) => string[];
   /** Override for “in our kanji database” checks (recommended). */
   isRealKanji?: (k: string) => boolean;
 }): string[] => {
-  // Model top-K is 10; after filtering kana/radicals we may be short of 12.
-  // Always pad with similars / the other pool, then random deck kanji.
+  const related = expandRelated(
+    [target, ...modelGuesses, ...similars],
+    getSimilars
+  );
+
   if (inTop10) {
     return padCandidates(
       modelGuesses,
       target,
       similars,
+      related,
       randomPool,
       isRealKanji
     );
   }
 
-  return padCandidates(similars, target, modelGuesses, randomPool, isRealKanji);
+  return padCandidates(
+    similars,
+    target,
+    modelGuesses,
+    related,
+    randomPool,
+    isRealKanji
+  );
 };
 
 /** Unicode CJK only — drops kana; pass `isRealKanji` from kanji_main for radicals. */
 const defaultIsRealKanji = (k: string) => k.length === 1 && isKanji(k);
 
+const expandRelated = (
+  seeds: string[],
+  getSimilars?: (k: string) => string[]
+): string[] => {
+  if (!getSimilars) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const seed of seeds) {
+    if (!seed || seen.has(seed)) continue;
+    seen.add(seed);
+    for (const s of getSimilars(seed)) {
+      if (!s || seen.has(s)) continue;
+      seen.add(s);
+      out.push(s);
+    }
+  }
+  return out;
+};
+
 const padCandidates = (
   seed: string[],
   target: string,
   secondary: string[],
+  related: string[],
   filler: string[],
   isRealKanji: (k: string) => boolean
 ): string[] => {
@@ -65,6 +104,7 @@ const padCandidates = (
   push(target, true);
   for (const k of seed) push(k);
   for (const k of secondary) push(k);
+  for (const k of related) push(k);
   for (const k of filler) push(k);
 
   return shuffle(out);

--- a/src/components/production-practice-v1/build-candidates.ts
+++ b/src/components/production-practice-v1/build-candidates.ts
@@ -1,10 +1,12 @@
-import { shuffle } from "@/lib/utils";
+import { isKanji, shuffle } from "@/lib/utils";
 import { CANDIDATE_COUNT } from "./constants";
 
 /**
- * Build a 10-kanji look-alike grid.
+ * Build a 12-kanji look-alike grid (always 4×3).
  * Always shuffled so a top-model hit is not always in the first cell.
  * Fill order before shuffle: target → similars / model guesses → random pool.
+ *
+ * Hard rule: only real kanji — no hiragana, katakana, or radicals-only glyphs.
  */
 export const buildCandidateGrid = ({
   target,
@@ -12,41 +14,56 @@ export const buildCandidateGrid = ({
   modelGuesses,
   similars,
   randomPool,
+  isRealKanji = defaultIsRealKanji,
 }: {
   target: string;
   inTop10: boolean;
   modelGuesses: string[];
   similars: string[];
   randomPool: string[];
+  /** Override for “in our kanji database” checks (recommended). */
+  isRealKanji?: (k: string) => boolean;
 }): string[] => {
   if (inTop10) {
     return padCandidates(
       modelGuesses.slice(0, CANDIDATE_COUNT),
       target,
       [],
-      randomPool
+      randomPool,
+      isRealKanji
     );
   }
 
-  return padCandidates([], target, similars, [...modelGuesses, ...randomPool]);
+  return padCandidates(
+    [],
+    target,
+    similars,
+    [...modelGuesses, ...randomPool],
+    isRealKanji
+  );
 };
+
+/** Unicode CJK only — drops kana; pass `isRealKanji` from the kanji DB for radicals. */
+const defaultIsRealKanji = (k: string) => k.length === 1 && isKanji(k);
 
 const padCandidates = (
   seed: string[],
   target: string,
   similars: string[],
-  filler: string[]
+  filler: string[],
+  isRealKanji: (k: string) => boolean
 ): string[] => {
   const seen = new Set<string>();
   const out: string[] = [];
 
-  const push = (k: string) => {
+  const push = (k: string, force = false) => {
     if (!k || seen.has(k) || out.length >= CANDIDATE_COUNT) return;
+    if (!force && !isRealKanji(k)) return;
     seen.add(k);
     out.push(k);
   };
 
-  push(target);
+  push(target, true);
   for (const k of seed) push(k);
   for (const k of similars) push(k);
   for (const k of filler) push(k);

--- a/src/components/production-practice-v1/constants.ts
+++ b/src/components/production-practice-v1/constants.ts
@@ -2,7 +2,8 @@ import { JLPT_TYPE_ARR, JLTPTtypes } from "@/lib/jlpt";
 import { ProductionPracticeSettings } from "./types";
 
 export const SESSION_SIZE = 10;
-export const CANDIDATE_COUNT = 10;
+/** Look-alike grid size: always 4×3. */
+export const CANDIDATE_COUNT = 12;
 export const SETTINGS_KEY = "production-practice-v1-settings";
 
 export const DEFAULT_SETTINGS: ProductionPracticeSettings = {

--- a/src/components/production-practice-v1/constants.ts
+++ b/src/components/production-practice-v1/constants.ts
@@ -4,6 +4,13 @@ import { ProductionPracticeSettings } from "./types";
 export const SESSION_SIZE = 10;
 /** Look-alike grid size: always 4×3. */
 export const CANDIDATE_COUNT = 12;
+/** Ranks that count as “in top 10” for session scoring. */
+export const GRADE_TOP_K = 10;
+/**
+ * Extra DaKanji guesses for the grid. After dropping kana/radicals we still
+ * need enough real kanji to pad to CANDIDATE_COUNT (especially on small decks).
+ */
+export const RECOGNIZE_TOP_K = 40;
 export const SETTINGS_KEY = "production-practice-v1-settings";
 
 export const DEFAULT_SETTINGS: ProductionPracticeSettings = {

--- a/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
+++ b/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { feedbackTitle } from "@/lib/dakanji-grade";
 import { StrokeOrderPlayer } from "../StrokeOrderPlayer";
@@ -27,6 +27,41 @@ export const FeedbackDrawer = ({
   onNext: () => void;
 }) => {
   const [practiceOpen, setPracticeOpen] = useState(false);
+
+  // Enter/Space → Next Kanji. Arm after a beat so the key that opened
+  // feedback (e.g. Enter on Select → Next) doesn't also advance.
+  useEffect(() => {
+    if (!open || practiceOpen) return;
+
+    let armed = false;
+    const arm = () => {
+      armed = true;
+    };
+    const armTimeout = window.setTimeout(arm, 300);
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") arm();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!armed || (e.key !== "Enter" && e.key !== " ") || e.isComposing) {
+        return;
+      }
+      const el = e.target as HTMLElement | null;
+      if (!el) return;
+      const tag = el.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+      if (el.isContentEditable) return;
+      e.preventDefault();
+      onNext();
+    };
+
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.clearTimeout(armTimeout);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, practiceOpen, onNext]);
 
   const title =
     kind === "noKanji"

--- a/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
+++ b/src/components/production-practice-v1/drawers/FeedbackDrawer.tsx
@@ -82,7 +82,10 @@ export const FeedbackDrawer = ({
       >
         {kind === "noKanji" ? (
           <div className="flex flex-col items-center gap-2 px-3 pb-2 mt-4 overflow-y-auto sm:px-4">
-            <StrokeOrderPlayer kanji={item.kanji} size={PREVIEW_SIZE + 30} />
+            {/* Mount only while open so DMAK doesn't finish animating off-screen. */}
+            {open && (
+              <StrokeOrderPlayer kanji={item.kanji} size={PREVIEW_SIZE + 30} />
+            )}
             <PracticeButton
               size="default"
               variant="ghost"
@@ -127,7 +130,9 @@ export const FeedbackDrawer = ({
                 <p className="text-xs font-bold uppercase text-muted-foreground">
                   Stroke Order
                 </p>
-                <StrokeOrderPlayer kanji={item.kanji} size={PREVIEW_SIZE} />
+                {open && (
+                  <StrokeOrderPlayer kanji={item.kanji} size={PREVIEW_SIZE} />
+                )}
               </div>
             </div>
           </div>

--- a/src/components/production-practice-v1/drawers/PracticeDrawerShell.tsx
+++ b/src/components/production-practice-v1/drawers/PracticeDrawerShell.tsx
@@ -17,6 +17,7 @@ export const PracticeDrawerShell = ({
   children,
   footer,
   showHandle = false,
+  autoFocus = false,
 }: {
   open: boolean;
   title: ReactNode;
@@ -26,9 +27,11 @@ export const PracticeDrawerShell = ({
   footer?: ReactNode;
   /** Top drag-handle pill. Hide on feedback drawers. */
   showHandle?: boolean;
+  /** Focus first focusable on open (vaul). See KanjiDrawer. */
+  autoFocus?: boolean;
 }) => {
   return (
-    <Drawer open={open} dismissible={false}>
+    <Drawer open={open} dismissible={false} autoFocus={autoFocus}>
       <DrawerContent
         showHandle={showHandle}
         className="max-h-[92dvh] border-2 border-t-4 [border-top-style:dashed]"

--- a/src/components/production-practice-v1/drawers/PracticeDrawerShell.tsx
+++ b/src/components/production-practice-v1/drawers/PracticeDrawerShell.tsx
@@ -16,7 +16,7 @@ export const PracticeDrawerShell = ({
   description,
   children,
   footer,
-  showHandle = true,
+  showHandle = false,
 }: {
   open: boolean;
   title: ReactNode;

--- a/src/components/production-practice-v1/drawers/SelectSimilarKanjiDrawer.tsx
+++ b/src/components/production-practice-v1/drawers/SelectSimilarKanjiDrawer.tsx
@@ -1,8 +1,11 @@
 import { PracticeButton } from "@/components/ui/practice-button";
+import { useEnterAction } from "@/hooks/use-enter-action";
 import { gradeHeadline } from "@/lib/dakanji-grade";
 import { cn } from "@/lib/utils";
 import type { GradeRankInfo } from "../types";
 import { PracticeDrawerShell } from "./PracticeDrawerShell";
+
+const CONFIRM_KEYS = ["Enter", " "] as const;
 
 export const SelectSimilarKanjiDrawer = ({
   open,
@@ -22,6 +25,8 @@ export const SelectSimilarKanjiDrawer = ({
   onNext: () => void;
 }) => {
   const hasSelection = selected != null;
+
+  useEnterAction(onNext, open && hasSelection, CONFIRM_KEYS);
 
   return (
     <PracticeDrawerShell
@@ -52,7 +57,7 @@ export const SelectSimilarKanjiDrawer = ({
       }
     >
       <div className="px-3 pb-2 overflow-y-auto sm:px-4">
-        <div className="grid max-w-md grid-cols-4 sm:grid-cols-5 gap-1.5 mx-auto sm:gap-2">
+        <div className="grid max-w-md grid-cols-4 gap-1.5 mx-auto sm:gap-2">
           {candidates.map((c) => {
             const isSelected = selected === c;
             return (

--- a/src/components/production-practice-v1/drawers/SelectSimilarKanjiDrawer.tsx
+++ b/src/components/production-practice-v1/drawers/SelectSimilarKanjiDrawer.tsx
@@ -31,6 +31,7 @@ export const SelectSimilarKanjiDrawer = ({
   return (
     <PracticeDrawerShell
       open={open}
+      autoFocus
       title={gradeHeadline(grade.rank)}
       description={
         grade.inTop10 ? "Which kanji did you draw?" : "Which kanji is correct?"
@@ -58,7 +59,7 @@ export const SelectSimilarKanjiDrawer = ({
     >
       <div className="px-3 pb-2 overflow-y-auto sm:px-4">
         <div className="grid max-w-md grid-cols-4 gap-1.5 mx-auto sm:gap-2">
-          {candidates.map((c) => {
+          {candidates.map((c, i) => {
             const isSelected = selected === c;
             return (
               <PracticeButton
@@ -66,6 +67,7 @@ export const SelectSimilarKanjiDrawer = ({
                 type="button"
                 size="icon"
                 variant={isSelected ? "primary" : "secondary"}
+                autoFocus={i === 0}
                 onClick={() => onSelect(isSelected ? null : c)}
                 className={cn(
                   "aspect-square h-auto w-full min-h-0 p-0 sm:text-5xl text-4xl kanji-font rounded-xl",

--- a/src/components/recognition-practice-v1/AnswerFeedback.tsx
+++ b/src/components/recognition-practice-v1/AnswerFeedback.tsx
@@ -48,19 +48,23 @@ export const AnswerFeedback = ({
 
   return (
     <div
-      className="flex flex-col items-center gap-3 animate-practice-bounce-soft"
+      className="flex flex-col items-center gap-3"
       role="status"
       aria-live="polite"
       aria-label={correct ? "Correct" : "Forgot"}
     >
-      <div className="flex flex-wrap items-center justify-center gap-1">
+      <div className="flex flex-wrap items-center justify-center gap-1 animate-practice-bounce-soft">
         <p>{correct ? "🎉 ·" : ""}</p>
         <SpeakButton word={word} iconType="volume-2" />
         {readings.map((r) => (
           <RomajiBadge key={r} kana={r} />
         ))}
       </div>
-      <PracticeButton size="lg" className="max-w-xs" onClick={onNext}>
+      <PracticeButton
+        size="lg"
+        className="max-w-xs animate-fade-in"
+        onClick={onNext}
+      >
         Continue
       </PracticeButton>
     </div>

--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useRef, useState } from "react";
-import { CircleArrowLeft } from "lucide-react";
 import { translateValue } from "@/lib/wanakana-adapter";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { useSpeak } from "@/hooks/use-jp-speak";
 import { useCorrectSound } from "@/hooks/use-correct-sound";
 import { useKanaInput } from "@/hooks/use-kana-input";
 import { BlurredGloss } from "@/components/shared-practice";
+import { EndSession } from "@/components/shared-practice/EndSessionButton";
 import {
   isForgotCommand,
   isForgotCommandPrefix,
@@ -128,16 +127,7 @@ export const Game = ({
 
   return (
     <div className="relative flex flex-col w-full h-full gap-5 [@media(pointer:fine)]:justify-center [@media(pointer:fine)]:gap-8 md:justify-center md:gap-8 [@media(min-height:900px)]:justify-center [@media(min-height:900px)]:gap-8">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="absolute z-10 top-1 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
-        tabIndex={-1}
-        onClick={onEnd}
-        aria-label="End session"
-      >
-        <CircleArrowLeft />
-      </Button>
+      <EndSession onClick={onEnd} />
       {/*
         Touch layout: keep the prompt + input as a top-anchored cluster with a
         fixed gap. A bottom spacer absorbs visual-viewport height changes so

--- a/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
+++ b/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
@@ -16,6 +16,9 @@ import {
   SessionResult,
 } from "./types";
 
+/** Toggle off to size the shell with `bottom-0` instead of visualViewport height. */
+const visualPortOn = true;
+
 const RecognitionPracticeV1 = () => {
   useHtmlDocumentTitle(recognitionPracticePageMeta.heading);
 
@@ -148,7 +151,7 @@ const RecognitionPracticeV1 = () => {
       <PracticeShell
         progress={progress}
         playing={phase === "playing"}
-        height={viewport.height}
+        height={visualPortOn ? viewport.height : undefined}
       >
         {phase === "initial" && (
           <div key="initial" className="h-full animate-fade-in">

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/HandwritingScreenDialog.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/HandwritingScreenDialog.tsx
@@ -27,11 +27,11 @@ export const HandwritingScreenDialog = ({
           Search by drawing a kanji
         </DrawerDescription>
         <ErrorBoundary>{children}</ErrorBoundary>
-        <DrawerClose asChild className="absolute z-50 top-2 right-2">
+        <DrawerClose asChild className="absolute top-2 right-2">
           <Button
             variant="ghost"
             size="icon"
-            className="p-4 border-2 border-dashed rounded-xl bg-background"
+            className="p-4 border-2 border-dashed rounded-xl bg-background z-1000!"
           >
             <CircleX className="size-8" />
           </Button>

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/RadicalScreen/RadicalScreenDialog.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/RadicalScreen/RadicalScreenDialog.tsx
@@ -27,11 +27,11 @@ export const RadicalsScreenDialog = ({
           Search by Radical
         </DrawerDescription>
         <ErrorBoundary>{children}</ErrorBoundary>
-        <DrawerClose asChild className="absolute z-50 top-2 right-2">
+        <DrawerClose asChild className="absolute top-2 right-2">
           <Button
             variant="ghost"
             size="icon"
-            className="p-4 border-2 border-dashed rounded-xl bg-background"
+            className="p-4 border-2 border-dashed rounded-xl bg-background z-1000!"
           >
             <CircleX className="size-8" />
           </Button>

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterDialog.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterDialog.tsx
@@ -15,6 +15,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { SortAndFilterButton } from "./SortAndFilterButton";
+import KaoMojiLoadingSpinner from "@/components/common/KaomojiLoading";
 
 const SortAndFilterSettingsForm = lazy(() =>
   import("./SortAndFilterForm").then((m) => ({
@@ -51,7 +52,7 @@ export const SortAndFilterSettingsDialog = ({
         className={"max-h-svh z-50 flex flex-col min-h-0 px-1 md:px-4 pb-4"}
       >
         <DialogHeader>
-          <DialogTitle className="m-0 text-left">
+          <DialogTitle className="px-2 m-0 text-left">
             Sorting and Filtering Settings
           </DialogTitle>
           <DialogDescription className="sr-only">
@@ -63,7 +64,8 @@ export const SortAndFilterSettingsDialog = ({
             <Suspense
               fallback={
                 <div className="py-8 text-sm text-center text-muted-foreground">
-                  Loading settings…
+                  <KaoMojiLoadingSpinner />
+                  Loading...
                 </div>
               }
             >

--- a/src/components/screens/SpeedKatakanaScreen/EndSession.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/EndSession.tsx
@@ -19,6 +19,7 @@ export const EndSession = ({
 }) => {
   const cheer = useMemo(() => pickEndCheer(), []);
   useEnterAction(onNext);
+  useEnterAction(onEnd, true, ["Escape"]);
 
   return (
     <div className="flex flex-col items-center justify-center w-full h-full gap-10 animate-fade-in">

--- a/src/components/screens/SpeedKatakanaScreen/Game.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/Game.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { translateValue, tryConvertRomaji } from "@/lib/wanakana-adapter";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DefaultErrorFallback } from "@/components/error";
 import KaomojiAnimation from "@/components/common/KaomojiLoading";
@@ -13,10 +12,10 @@ import {
   isForgotCommand,
   isForgotCommandPrefix,
 } from "@/lib/practice-commands";
+import { EndSession } from "@/components/shared-practice/EndSessionButton";
 import { ChallengeSetData, SessionStats, SpeedKatakanaSettings } from "./types";
 import { randomFontIndex } from "@/hooks/use-change-font";
 import { percent, shuffle } from "@/lib/utils";
-import { CircleArrowLeft } from "lucide-react";
 
 type GameWord = {
   katakana: string;
@@ -236,16 +235,7 @@ export const Game = ({
 
   return (
     <div className="flex flex-col w-full h-full gap-4 mx-auto [@media(min-height:900px)]:justify-center animate-fade-in-fast">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="absolute z-10 top-1 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
-        tabIndex={-1}
-        onClick={onEnd}
-        aria-label="End session"
-      >
-        <CircleArrowLeft />
-      </Button>
+      <EndSession onClick={onEnd} />
 
       <div className="flex flex-col items-center justify-center flex-1 min-h-0 [@media(min-height:900px)]:flex-none gap-3 text-center">
         <div className="flex items-center justify-center gap-1 pt-4">

--- a/src/components/sections/KanjiDetails/General.tsx
+++ b/src/components/sections/KanjiDetails/General.tsx
@@ -178,7 +178,7 @@ export const General = ({ kanji }: { kanji: string }) => {
             />
             <TableCellGrow>
               {data.allKun.map((kun) => (
-                <RomajiBadge key={kun} kana={kun} />
+                <RomajiBadge key={kun} kana={kun} className="text-lg" />
               ))}
               {data.allKun.length === 0 && <div> - </div>}
             </TableCellGrow>

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -223,7 +223,9 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
           </div>
         )}
         {status === "success" && result != null && (
-          <div className="animate-fade-in">{gradeMessage(kanji, result)}</div>
+          <div className="animate-practice-bounce-soft">
+            {gradeMessage(kanji, result)}
+          </div>
         )}
         {status === "idle" && (
           <div className="font-bold">Draw the kanji, then tap 🚀 to grade.</div>

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import Raphael from "raphael";
 import "dmak";
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { Switch } from "@/components/ui/switch";
 import assetsPaths from "@/lib/assets-paths";
-import { installSafeDmakLoader } from "@/lib/dmak-safe-loader";
+import { abandonDmak, installSafeDmakLoader } from "@/lib/dmak-safe-loader";
 import { PlayCircle, Snail } from "@/components/icons";
 import {
   DrawingPad,
@@ -42,18 +42,13 @@ const KanjiDMAK = ({
   staticMode?: boolean;
   gridShow?: boolean;
 }) => {
-  const dmakInstanceRef = useRef<any>(null);
   const id = useId();
   const kanjiId = `${id}-${kanji}-draw`;
 
   useEffect(() => {
     (window as any).Raphael = Raphael;
 
-    if (dmakInstanceRef.current) {
-      return;
-    }
-
-    dmakInstanceRef.current = new (window as any).Dmak(kanji, {
+    const dmak = new (window as any).Dmak(kanji, {
       element: kanjiId,
       uri:
         import.meta.env.MODE === "development" ||
@@ -77,7 +72,10 @@ const KanjiDMAK = ({
     });
 
     return () => {
-      (window as any).Raphael = null;
+      abandonDmak(dmak);
+      // Strict Mode re-runs this effect on the same host — clear leftover SVG.
+      document.getElementById(kanjiId)?.replaceChildren();
+      // Keep window.Raphael set; other KanjiDMAK instances may still need it.
     };
   }, [kanji, kanjiId, step, size, staticMode, gridShow]);
 
@@ -87,25 +85,35 @@ const KanjiDMAK = ({
 export const StrokeAnimation = ({ kanji }: { kanji: string }) => {
   const [key, setKey] = useState(1);
   const [speed, setSpeed] = useState<AnimationSpeed>("fast");
+  const replay = () => setKey((x) => x + 1);
 
   return (
     <div className="p-4">
       {/** key needed to redraw on change  */}
       <div
-        className={CONTAINER_CN}
+        role="button"
+        tabIndex={0}
+        title="Replay stroke order"
+        className={`${CONTAINER_CN} cursor-pointer`}
         style={{ height: SVG_SIZE }}
-        key={`${kanji}-${speed}-${key}`}
+        onClick={replay}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            replay();
+          }
+        }}
       >
-        <KanjiDMAK kanji={kanji} step={SPEEDS[speed].rate} />
+        <div key={`${kanji}-${speed}-${key}`}>
+          <KanjiDMAK kanji={kanji} step={SPEEDS[speed].rate} />
+        </div>
       </div>
       <div className="flex justify-center space-x-2">
         <PracticeButton
           size="icon"
           onClick={() => {
             setSpeed("fast");
-            setKey((x) => {
-              return x + 1;
-            });
+            replay();
           }}
         >
           <PlayCircle />
@@ -116,9 +124,7 @@ export const StrokeAnimation = ({ kanji }: { kanji: string }) => {
           variant="secondary"
           onClick={() => {
             setSpeed("slow");
-            setKey((x) => {
-              return x + 1;
-            });
+            replay();
           }}
         >
           <Snail /> <span className="sr-only">Animate Slowly</span>

--- a/src/components/shared-practice/EndSession.tsx
+++ b/src/components/shared-practice/EndSession.tsx
@@ -29,6 +29,7 @@ export const EndSession = ({
   const accuracy = percent(correctCount, results.length, 100);
 
   useEnterAction(hasMore ? onNext : onEnd, true, CONTINUE_KEYS);
+  useEnterAction(onEnd, true, ["Escape"]);
 
   if (!hasMore) {
     return (

--- a/src/components/shared-practice/EndSession.tsx
+++ b/src/components/shared-practice/EndSession.tsx
@@ -7,6 +7,8 @@ import { Stat } from "./CountUpStat";
 import { PracticeSessionResult } from "./types";
 import { RecapTile } from "./RecapTile";
 
+const CONTINUE_KEYS = ["Enter", " "] as const;
+
 export const EndSession = ({
   results,
   hasMore,
@@ -26,7 +28,7 @@ export const EndSession = ({
   const correctCount = results.filter((r) => r.correct).length;
   const accuracy = percent(correctCount, results.length, 100);
 
-  useEnterAction(hasMore ? onNext : onEnd);
+  useEnterAction(hasMore ? onNext : onEnd, true, CONTINUE_KEYS);
 
   if (!hasMore) {
     return (

--- a/src/components/shared-practice/EndSessionButton.tsx
+++ b/src/components/shared-practice/EndSessionButton.tsx
@@ -1,0 +1,21 @@
+import { CircleArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useEnterAction } from "@/hooks/use-enter-action";
+
+/** Back/exit control for in-progress practice games. Escape also ends. */
+export const EndSession = ({ onClick }: { onClick: () => void }) => {
+  useEnterAction(onClick, true, ["Escape"]);
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="absolute z-10 top-1 left-1 text-foreground opacity-70 hover:opacity-100 hover:bg-opacity-0"
+      tabIndex={-1}
+      onClick={onClick}
+      aria-label="End session"
+    >
+      <CircleArrowLeft />
+    </Button>
+  );
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { X } from "lucide-react";
 
+import { CircleX } from "@/components/icons";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 const Dialog = DialogPrimitive.Root;
@@ -36,15 +37,21 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-6xl translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-6xl translate-x-[-50%] translate-y-[-50%] gap-4 border-2 rounded-3xl bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+      <DialogPrimitive.Close asChild className="absolute top-3 right-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="p-4 border-2 border-dashed rounded-xl bg-background z-1000!"
+        >
+          <CircleX className="size-8" />
+          <span className="sr-only">Close</span>
+        </Button>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -44,7 +44,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-12 flex h-auto flex-col rounded-t-3xl border bg-background",
+        "fixed inset-x-0 bottom-0 z-50 mt-12 flex h-auto flex-col rounded-t-3xl border-2 bg-background",
         className
       )}
       {...props}

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -7,10 +7,9 @@ const HoverCard = HoverCardPrimitive.Root;
 const HoverCardArrow = () => {
   return (
     <HoverCardPrimitive.Arrow
-      className="-my-px border-none fill-[white] dark:fill-black drop-shadow-[0_1px_0_#dddddd] dark:drop-shadow-[0_1px_0_#262626]"
+      className="-my-px fill-popover drop-shadow-[0_1px_0_hsl(var(--border))]"
       width={15}
       height={10}
-      stroke={"3"}
       aria-hidden="true"
     />
   );

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -33,7 +33,7 @@ const HoverCardContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-64 rounded-3xl border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -10,10 +10,9 @@ const PopoverTrigger = PopoverPrimitive.Trigger;
 export const PopoverCardArrow = () => {
   return (
     <PopoverPrimitive.Arrow
-      className="-my-px border-none fill-background drop-shadow-[0_1px_0_#dddddd] dark:drop-shadow-[0_1px_0_#262626]"
+      className="-my-px fill-popover drop-shadow-[0_1px_0_hsl(var(--border))]"
       width={15}
       height={10}
-      stroke={"5"}
       aria-hidden="true"
     />
   );

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -29,7 +29,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-2xl border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/src/hooks/use-enter-action.ts
+++ b/src/hooks/use-enter-action.ts
@@ -1,15 +1,20 @@
 import { useEffect } from "react";
 
 /**
- * Fire `action` on Enter when focus isn't in a text field / select.
- * Skips while IME is composing.
+ * Fire `action` on the given keys when focus isn't in a text field / select.
+ * Skips while IME is composing. Default key is Enter; pass `["Enter", " "]`
+ * to also accept Space.
  */
-export const useEnterAction = (action: (() => void) | null, enabled = true) => {
+export const useEnterAction = (
+  action: (() => void) | null,
+  enabled = true,
+  keys: readonly string[] = ["Enter"]
+) => {
   useEffect(() => {
     if (!enabled || !action) return;
 
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== "Enter" || e.isComposing) return;
+      if (!keys.includes(e.key) || e.isComposing) return;
       const el = e.target as HTMLElement | null;
       if (!el) return;
       const tag = el.tagName;
@@ -24,5 +29,5 @@ export const useEnterAction = (action: (() => void) | null, enabled = true) => {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [action, enabled]);
+  }, [action, enabled, keys]);
 };

--- a/src/lib/dakanji-adapter.ts
+++ b/src/lib/dakanji-adapter.ts
@@ -8,7 +8,7 @@ import type {
 
 const MODEL_URL = "/onnx/char_classifier.onnx";
 const LABELS_URL = "/onnx/char_classifier_labels.txt";
-const TOP_K = 10;
+const DEFAULT_TOP_K = 10;
 // Match DrawingPad's perfect-freehand `size` so the raster looks like what the user drew.
 const STROKE_WIDTH = 16;
 
@@ -169,7 +169,8 @@ export const warmupDaKanji = (): Promise<void> =>
   loadRuntime().then(() => undefined);
 
 export const recognizeDaKanji = async (
-  payload: DrawingSubmitPayload
+  payload: DrawingSubmitPayload,
+  topK: number = DEFAULT_TOP_K
 ): Promise<string[]> => {
   if (payload.strokes.length === 0) {
     return [];
@@ -195,5 +196,5 @@ export const recognizeDaKanji = async (
   }
 
   const probs = output.data as Float32Array;
-  return topKLabels(probs, labels, TOP_K);
+  return topKLabels(probs, labels, topK);
 };

--- a/src/lib/dakanji-grade.ts
+++ b/src/lib/dakanji-grade.ts
@@ -23,7 +23,7 @@ export const gradeMessage = (kanji: string, result: GradeResult): string => {
   }
   if (rank >= 1 && rank <= 2) {
     return topGuess
-      ? `💚 Solid · Near miss — a bit like ${topGuess}`
+      ? `💚 Solid · Near miss — Looks a bit like ${topGuess}`
       : `💚 Solid · Near miss — keep refining`;
   }
   if (rank >= 3) {

--- a/src/lib/dmak-safe-loader.ts
+++ b/src/lib/dmak-safe-loader.ts
@@ -2,7 +2,11 @@
  * Stock dmak crashes when an SVG loads (HTTP 200) but has no `kvg:{code}` root:
  * it calls getElementById, gets null, then immediately reads `.childNodes`.
  *
- * Replaces window.DmakLoader with the same API plus a null guard.
+ * It also crashes when the React host unmounts before the async SVG fetch
+ * finishes: prepare() still runs and Raphael throws "SVG container not found."
+ *
+ * Replaces window.DmakLoader with a guarded loader, and no-ops prepare() when
+ * the target element is already gone.
  */
 
 type StrokePath = {
@@ -15,6 +19,41 @@ type LoaderCallbacks = {
   done: (index: number, data: StrokePath[]) => void;
   error: (msg: string) => void;
 };
+
+type DmakLike = {
+  options: { element: string | HTMLElement };
+  prepare: (data: StrokePath[][]) => void;
+  pause?: () => void;
+};
+
+type DmakConstructor = {
+  fn: { prepare: (this: DmakLike, data: StrokePath[][]) => void };
+  __kanjiHeatmapGuards?: boolean;
+};
+
+/** Instances torn down by React (Strict Mode remount / unmount) before SVG XHR finishes. */
+const abandonedDmakInstances = new WeakSet<object>();
+
+/** Pause + ignore later prepare/render from this instance; clear host SVG separately. */
+export function abandonDmak(dmak: object | null | undefined) {
+  if (dmak == null) return;
+  abandonedDmakInstances.add(dmak);
+  try {
+    (dmak as DmakLike).pause?.();
+  } catch {
+    // ignore — may be mid-load / already torn down
+  }
+}
+
+function resolveElement(
+  element: string | HTMLElement | null | undefined
+): HTMLElement | null {
+  if (element == null) return null;
+  if (typeof element === "string") {
+    return document.getElementById(element);
+  }
+  return element.isConnected ? element : null;
+}
 
 function parseResponse(response: string, code: string): StrokePath[] {
   const data: StrokePath[] = [];
@@ -80,6 +119,8 @@ function loadSvg(
     if (xhr.readyState !== 4) return;
     if (xhr.status === 200) {
       callbacks.done(index, parseResponse(xhr.response, code));
+    } else if (xhr.status === 0) {
+      // Aborted / navigated away — ignore.
     } else {
       callbacks.error(xhr.statusText);
       // Still complete so Dmak.prepare runs instead of hanging forever.
@@ -120,7 +161,27 @@ class SafeDmakLoader {
   }
 }
 
+function installPrepareGuard() {
+  const Dmak = (window as unknown as { Dmak?: DmakConstructor }).Dmak;
+  if (!Dmak?.fn?.prepare || Dmak.__kanjiHeatmapGuards) return;
+
+  const originalPrepare = Dmak.fn.prepare;
+  Dmak.fn.prepare = function (data) {
+    // Strict Mode remounts keep the same host div: an abandoned instance's
+    // late XHR must not append a second SVG. Also skip if the host is gone.
+    if (
+      abandonedDmakInstances.has(this) ||
+      !resolveElement(this.options.element)
+    ) {
+      return;
+    }
+    return originalPrepare.call(this, data);
+  };
+  Dmak.__kanjiHeatmapGuards = true;
+}
+
 export function installSafeDmakLoader() {
   (window as unknown as { DmakLoader: typeof SafeDmakLoader }).DmakLoader =
     SafeDmakLoader;
+  installPrepareGuard();
 }


### PR DESCRIPTION
## Summary
- Unify dialog/drawer chrome and polish recognition/production practice UX (4×3 grids, keyboard shortcuts, feedback, fonts, Escape to end session).
- Harden DMAK stroke loading on remount and keep production look-alike grids filled with 12 real kanji only.
- Theme hover-card/popover arrows and round popovers for consistent light/dark overlays.

## Test plan
- [ ] Open recognition practice: verify 4×3 look-alike grid, Enter/Space grade/next, Escape ends session
- [ ] Open production/writing practice: verify stroke order replay, look-alikes stay at 12 real kanji, select drawer autofocus
- [ ] Remount/rapidly open stroke animation: no DMAK crash
- [ ] Check dialogs/drawers close buttons and borders match across kanji drawer, practice drawers, and sort/filter
- [ ] Hover cards and popovers: arrows match surface color in light and dark themes
- [ ] Speed Katakana end session still works with shared back button


Made with [Cursor](https://cursor.com)