### PR TITLE
Only autofocus search on fine-pointer devices

### DIFF
--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
@@ -101,8 +101,12 @@ export const SearchInput = ({
     setValue(translateValue(initialText, translateMap[initialSearchType]));
   }
 
-  // force focus input ref on mount
+  // Autofocus on fine-pointer devices only — avoids opening the soft
+  // keyboard on touch screens when landing on "/".
   useEffect(() => {
+    if (!window.matchMedia("(pointer: fine)").matches) {
+      return;
+    }
     inputRef.current?.focus?.();
   }, []);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- The search input on `/` previously autofocused on every device, which opens the soft keyboard on touch screens.
- Autofocus now runs only when `(pointer: fine)` matches (mouse/trackpad primary pointer).
- Touch / coarse-pointer devices skip mount focus so the keyboard stays closed until the user taps the field.

## Test plan
- [ ] On desktop (mouse/trackpad): open `/` and confirm the search input is focused.
- [ ] On a phone or tablet: open `/` and confirm the search input is not focused and the soft keyboard does not open.
- [ ] On touch: tap the search input and confirm it still focuses normally.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c35-00f5-7c09-8c99-ee02da6c00db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c35-00f5-7c09-8c99-ee02da6c00db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

