### PR TITLE
Fix iOS PWA fixed header/FAB drifting on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,7 @@
     />
     <meta
       name="viewport"
-      viewport-fit="cover"
-      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <title>Kanji Heatmap</title>
     <style>

--- a/src/components/dependent/site-wide/PageWrapper.tsx
+++ b/src/components/dependent/site-wide/PageWrapper.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary } from "@/components/error";
 
 const PageWrapper = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="min-h-dvh bg-background pt-12 pb-28 px-2">
+    <div className="min-h-dvh bg-background pt-[calc(var(--app-header-height)+env(safe-area-inset-top,0px))] pb-28 px-2">
       <ErrorBoundary>
         <Suspense fallback={<KaomojiAnimation />}>{children}</Suspense>
       </ErrorBoundary>

--- a/src/components/screens/ListScreen/ListScreen.tsx
+++ b/src/components/screens/ListScreen/ListScreen.tsx
@@ -18,15 +18,15 @@ const Layout = ({
 }) => {
   return (
     <>
-      <div className="fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
-        <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 sticky pt-1 pl-2 pr-1 w-full ">
+      <div className="fix-scroll-layout-shift-right fixed top-0 left-0 w-full pt-[calc(var(--app-header-height)+env(safe-area-inset-top,0px))] pb-2 z-40 bg-background">
+        <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 pt-1 pl-2 pr-1 w-full">
           <ErrorBoundary fallback={<LinksOutItems />}>
             <ControlBar />
             {badge}
           </ErrorBoundary>
         </section>
       </div>
-      <div className="relative pt-24 -z-0 flex flex-wrap items-center justify-center overflow-x-hidden">
+      <div className="relative pt-[calc(6rem+env(safe-area-inset-top,0px))] -z-0 flex flex-wrap items-center justify-center overflow-x-hidden">
         {children}
       </div>
     </>

--- a/src/components/screens/ListScreen/index.tsx
+++ b/src/components/screens/ListScreen/index.tsx
@@ -7,8 +7,8 @@ const LazyListScreen = lazy(() =>
 /** Reserves ControlBar space so nav from other routes doesn't flash empty. */
 const ListScreenFallback = () => (
   <>
-    <div className="fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
-      <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 sticky pt-1 pl-2 pr-1 w-full">
+    <div className="fix-scroll-layout-shift-right fixed top-0 left-0 w-full pt-[calc(var(--app-header-height)+env(safe-area-inset-top,0px))] pb-2 z-40 bg-background">
+      <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 pt-1 pl-2 pr-1 w-full">
         <div
           className="h-9 flex-1 min-w-0 rounded-md border bg-muted/40"
           aria-hidden
@@ -24,7 +24,7 @@ const ListScreenFallback = () => (
       </section>
     </div>
     <div
-      className="relative pt-24 -z-0 flex min-h-48 items-center justify-center overflow-x-hidden"
+      className="relative pt-[calc(6rem+env(safe-area-inset-top,0px))] -z-0 flex min-h-48 items-center justify-center overflow-x-hidden"
       role="status"
       aria-label="Loading"
     />

--- a/src/components/site-layout/FloatingIsland.tsx
+++ b/src/components/site-layout/FloatingIsland.tsx
@@ -22,7 +22,7 @@ export const FloatingIsland = () => {
     <nav
       ref={settleRef}
       aria-label="Primary"
-      className="fixed z-40 left-[calc(0.75rem+env(safe-area-inset-left))] bottom-[calc(0.75rem+env(safe-area-inset-bottom))]"
+      className="fixed z-40 left-[calc(0.75rem+env(safe-area-inset-left,0px))] bottom-[calc(0.75rem+env(safe-area-inset-bottom,0px))]"
     >
       <div
         className={cn(

--- a/src/components/site-layout/Header/Header.tsx
+++ b/src/components/site-layout/Header/Header.tsx
@@ -6,7 +6,7 @@ import { HeaderTitle } from "./HeaderTitle";
 
 const Header = () => {
   return (
-    <header className="fixed top-0 left-0 z-50 flex items-center justify-between w-full px-2 border-b-4 border-dashed fix-scroll-layout-shift-right bg-background backdrop-blur-sm">
+    <header className="fixed top-0 left-0 z-50 flex items-center justify-between w-full px-2 pt-[env(safe-area-inset-top,0px)] border-b-4 border-dashed fix-scroll-layout-shift-right bg-background backdrop-blur-sm">
       <HeaderTitle />
       <section className="flex items-center pr-1 space-x-1">
         <ErrorBoundary fallback={null}>

--- a/src/components/site-layout/PracticeFab.tsx
+++ b/src/components/site-layout/PracticeFab.tsx
@@ -50,7 +50,7 @@ export const PracticeFab = () => {
           size="icon"
           variant={hasBgMeaning ? "secondary" : "primary"}
           className={cn(
-            "fixed z-40 rounded-full h-[5rem] w-[5rem] p-6 border-b-[8px] active:translate-y-[5px] active:border-b-[3px] [&_svg]:size-10 right-[calc(0.35rem+5px)] bottom-[calc(1rem+env(safe-area-inset-bottom))]",
+            "fixed z-40 rounded-full h-[5rem] w-[5rem] p-6 border-b-[8px] active:translate-y-[5px] active:border-b-[3px] [&_svg]:size-10 right-[calc(0.35rem+5px+env(safe-area-inset-right,0px))] bottom-[calc(1rem+env(safe-area-inset-bottom,0px))]",
             hasBgMeaning && "border-foreground/40"
           )}
           aria-label="Open practice menu"

--- a/src/index.css
+++ b/src/index.css
@@ -23,11 +23,12 @@
 
   padding: 0;
   margin: 0;
-  display: flex;
 
   --scrollbar-bg: hsl(var(--background));
   --thumb-bg: rgba(0, 0, 0, 0.3);
   scrollbar-color: var(--thumb-bg) var(--scrollbar-bg);
+  /* Header bar height (excl. notch/status safe area). */
+  --app-header-height: 3rem;
 
   margin: 0 auto;
   text-align: center;
@@ -69,14 +70,23 @@
   box-sizing: border-box;
 }
 
+/*
+ * Keep the *document* as the scrollport. A height-constrained body with
+ * overflow-y: scroll becomes a nested scroller on iOS Safari/PWA and makes
+ * position:fixed chrome (header, control bar, island, FAB) drift while scrolling.
+ */
+html {
+  overflow-y: scroll;
+  overscroll-behavior-y: none;
+}
+
 body {
   min-height: 100dvh;
-  height: 100vh;
   width: 100%;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  overflow-y: scroll;
+  overscroll-behavior-y: none;
 }
 
 p,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On iOS standalone PWA, the fixed top chrome (header + search/control bar) and bottom chrome (nav island + practice FAB) were drifting while scrolling instead of staying pinned.

## Cause
Two layout issues stacked on top of known iOS WebKit quirks:
1. `body` used `height: 100vh` + `overflow-y: scroll`, which turns the body into a nested scrollport — `position: fixed` then fails to stick reliably in Safari/PWA.
2. `viewport-fit=cover` was set as a separate meta attribute instead of inside `content`, so safe-area insets were never applied.
3. The Explore control bar was `fixed` without an explicit `top-0`, which is especially brittle on iOS.

## Fix
- Scroll on `html` (document scrollport); drop the fixed `body` height.
- Put `viewport-fit=cover` in the viewport `content` string.
- Pin the control bar with `top-0` and offset header/control-bar/page padding with `env(safe-area-inset-*)`.
- Soften rubber-banding with `overscroll-behavior-y: none`.

## Test plan
- [ ] Install/update the iOS PWA and open Explore, Dashboard, and Mastery
- [ ] Scroll up/down: header, search bar, bottom island, and practice FAB should stay put
- [ ] Confirm chrome clears the notch / home indicator
- [ ] Open a drawer/popover and confirm scroll-lock settle still looks fine
- [ ] Desktop: scrollbar gutter / no horizontal jump when modals lock scroll

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c6f-fd3c-7f9b-b751-11562f7d0178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c6f-fd3c-7f9b-b751-11562f7d0178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

