### PR TITLE
Fix fixed controls drifting in iOS standalone PWAs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,8 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       ...reactPluginRecommended,
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "error",
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "vite --port 5174",
     "dev:cf": "vite --port 5173",
-    "build": "node scripts/generate-more-info.mjs && node scripts/generate-speed-katakana.mjs && tsc -b && vite build",
+    "build": "eslint . && node scripts/generate-more-info.mjs && node scripts/generate-speed-katakana.mjs && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "peek": "prettier --write . && eslint . && tsc -b && vite build && vite preview --host",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,8 @@ import {
   PageNotFound,
   DefaultErrorFallback,
 } from "./components/error";
-import { Header } from "@/components/site-layout/";
+import { Header, FloatingIsland } from "@/components/site-layout/";
+import { PageFadeIn } from "@/components/dependent/site-wide/PageFadeIn";
 import pageItems from "@/components/items/page-items";
 import { GlobalKeyboardShortcutProvider } from "./providers/global-keyboard-shortcut-provider";
 
@@ -19,6 +20,7 @@ const {
   kanjiPage,
   cumUseGraphPage,
   dashboardPage,
+  masteryPage,
   aboutPage,
   termsPage,
   privacyPage,
@@ -73,43 +75,50 @@ const App = () => {
                   }
                 >
                   <KanjiFunctionalityProvider>
-                    <Switch>
-                      <Route
-                        path={dashboardPage.href}
-                        component={dashboardPage.Component}
-                      />
-                      <Route
-                        path={cumUseGraphPage.href}
-                        component={cumUseGraphPage.Component}
-                      />
-                      <Route
-                        path={kanjiPage.href}
-                        component={kanjiPage.Component}
-                      />
-                      <Route
-                        path={aboutPage.href}
-                        component={aboutPage.Component}
-                      />
-                      <Route
-                        path={termsPage.href}
-                        component={termsPage.Component}
-                      />
-                      <Route
-                        path={privacyPage.href}
-                        component={privacyPage.Component}
-                      />
-                      <Route path="/docs">
-                        <Redirect to="/about" />
-                      </Route>
-                      <Route path="*">
-                        <div className="w-full pr-4 mt-14">
-                          <PageNotFound />
-                        </div>
-                      </Route>
-                    </Switch>
+                    <PageFadeIn>
+                      <Switch>
+                        <Route
+                          path={dashboardPage.href}
+                          component={dashboardPage.Component}
+                        />
+                        <Route
+                          path={masteryPage.href}
+                          component={masteryPage.Component}
+                        />
+                        <Route
+                          path={cumUseGraphPage.href}
+                          component={cumUseGraphPage.Component}
+                        />
+                        <Route
+                          path={kanjiPage.href}
+                          component={kanjiPage.Component}
+                        />
+                        <Route
+                          path={aboutPage.href}
+                          component={aboutPage.Component}
+                        />
+                        <Route
+                          path={termsPage.href}
+                          component={termsPage.Component}
+                        />
+                        <Route
+                          path={privacyPage.href}
+                          component={privacyPage.Component}
+                        />
+                        <Route path="/docs">
+                          <Redirect to="/about" />
+                        </Route>
+                        <Route path="*">
+                          <div className="w-full pr-4 mt-14">
+                            <PageNotFound />
+                          </div>
+                        </Route>
+                      </Switch>
+                    </PageFadeIn>
                   </KanjiFunctionalityProvider>
                 </ErrorBoundary>
               </main>
+              <FloatingIsland />
             </Route>
           </Switch>
         </GlobalKeyboardShortcutProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { GlobalKeyboardShortcutProvider } from "./providers/global-keyboard-shor
 const {
   kanjiPage,
   cumUseGraphPage,
+  dashboardPage,
   aboutPage,
   termsPage,
   privacyPage,
@@ -62,7 +63,7 @@ const App = () => {
             </Route>
             <Route>
               <Header />
-              <main className="bg-background">
+              <main className="min-h-dvh bg-background">
                 <ErrorBoundary
                   details="App"
                   fallback={
@@ -73,6 +74,10 @@ const App = () => {
                 >
                   <KanjiFunctionalityProvider>
                     <Switch>
+                      <Route
+                        path={dashboardPage.href}
+                        component={dashboardPage.Component}
+                      />
                       <Route
                         path={cumUseGraphPage.href}
                         component={cumUseGraphPage.Component}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {
   PageNotFound,
   DefaultErrorFallback,
 } from "./components/error";
-import { Header, FloatingIsland } from "@/components/site-layout/";
+import { Header, FloatingIsland, PracticeFab } from "@/components/site-layout/";
 import { PageFadeIn } from "@/components/dependent/site-wide/PageFadeIn";
 import pageItems from "@/components/items/page-items";
 import { GlobalKeyboardShortcutProvider } from "./providers/global-keyboard-shortcut-provider";
@@ -119,6 +119,7 @@ const App = () => {
                 </ErrorBoundary>
               </main>
               <FloatingIsland />
+              <PracticeFab />
             </Route>
           </Switch>
         </GlobalKeyboardShortcutProvider>

--- a/src/components/common/BottomBar.tsx
+++ b/src/components/common/BottomBar.tsx
@@ -6,14 +6,22 @@ import { DebugInfo } from "@/components/common/DebugInfo";
 import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
 import { ModeToggle } from "@/components/dependent/site-wide/ModeToggle";
 
-export const BottomBar = ({ includeNode }: { includeNode?: ReactNode }) => {
+export const BottomBar = ({
+  includeNode,
+  justify = "start",
+}: {
+  includeNode?: ReactNode;
+  justify?: "start" | "center";
+}) => {
   return (
     <>
-      <div className="my-4 w-fit">
+      <div className={`my-4 w-fit ${justify === "center" ? "mx-auto" : ""}`}>
         <PikaPikaLinks />
       </div>
 
-      <div className="flex items-center justify-start w-full mt-4 mb-8 space-x-1">
+      <div
+        className={`flex items-center justify-${justify} w-full mt-4 mb-8 space-x-1`}
+      >
         <LinksOutItems />
         <DotIcon className="w-2 m-0" />
         <DebugInfo />

--- a/src/components/common/BottomBar.tsx
+++ b/src/components/common/BottomBar.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+import { LinksOutItems } from "@/components/common/LinksOutItems";
+import { PikaPikaLinks } from "@/components/common/PikaPikaLinks";
+import { DotIcon } from "@/components/icons";
+import { DebugInfo } from "@/components/common/DebugInfo";
+import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
+import { ModeToggle } from "@/components/dependent/site-wide/ModeToggle";
+
+export const BottomBar = ({ includeNode }: { includeNode?: ReactNode }) => {
+  return (
+    <>
+      <div className="my-4 w-fit">
+        <PikaPikaLinks />
+      </div>
+
+      <div className="flex items-center justify-start w-full mt-4 mb-8 space-x-1">
+        <LinksOutItems />
+        <DotIcon className="w-2 m-0" />
+        <DebugInfo />
+        <RefreshPageBtn />
+        <ModeToggle />
+        {includeNode}
+      </div>
+    </>
+  );
+};

--- a/src/components/common/freq/FreqGradient.tsx
+++ b/src/components/common/freq/FreqGradient.tsx
@@ -5,15 +5,21 @@ import {
 } from "@/lib/freq/freq-category";
 import { FreqSquare } from "./FreqSquare";
 
-export const FreqGradient = () => {
+export const FreqGradient = ({
+  lessLabel = "Less",
+  moreLabel = "More",
+}: {
+  lessLabel?: string;
+  moreLabel?: string;
+} = {}) => {
   return (
     <div className="flex my-3 space-x-1 items-center w-full">
-      <div className="text-xs">Less</div>
+      <div className="text-xs">{lessLabel}</div>
       {Array.from({ length: freqCategoryCount }).map((_, item) => {
         const cn = freqCategoryCn[item as FreqCategory];
         return <FreqSquare key={item} srOnly={item.toString()} cn={cn} />;
       })}
-      <div className="text-xs">More</div>{" "}
+      <div className="text-xs">{moreLabel}</div>
     </div>
   );
 };

--- a/src/components/dependent/site-wide/PageFadeIn.tsx
+++ b/src/components/dependent/site-wide/PageFadeIn.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+import { useLocation } from "@/components/dependent/routing/router-adapter";
+
+/** Remounts children on route change so `animate-fade-in` plays. */
+export const PageFadeIn = ({ children }: { children: ReactNode }) => {
+  const [location] = useLocation();
+
+  return (
+    <div key={location} className="animate-fade-in">
+      {children}
+    </div>
+  );
+};

--- a/src/components/dependent/site-wide/PageWrapper.tsx
+++ b/src/components/dependent/site-wide/PageWrapper.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary } from "@/components/error";
 
 const PageWrapper = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="pt-12 pb-20 px-2 h-dvh">
+    <div className="min-h-dvh bg-background pt-12 pb-20 px-2">
       <ErrorBoundary>
         <Suspense fallback={<KaomojiAnimation />}>{children}</Suspense>
       </ErrorBoundary>

--- a/src/components/dependent/site-wide/PageWrapper.tsx
+++ b/src/components/dependent/site-wide/PageWrapper.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary } from "@/components/error";
 
 const PageWrapper = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="min-h-dvh bg-background pt-12 pb-20 px-2">
+    <div className="min-h-dvh bg-background pt-12 pb-28 px-2">
       <ErrorBoundary>
         <Suspense fallback={<KaomojiAnimation />}>{children}</Suspense>
       </ErrorBoundary>

--- a/src/components/items/nav-links.ts
+++ b/src/components/items/nav-links.ts
@@ -1,4 +1,11 @@
-import { ChartLine, Eye, Keyboard, PenLine, SearchIcon } from "lucide-react";
+import {
+  ChartLine,
+  Eye,
+  Keyboard,
+  LayoutDashboard,
+  PenLine,
+  SearchIcon,
+} from "lucide-react";
 import type { ComponentType, SVGProps } from "react";
 import {
   productionPracticePageMeta,
@@ -29,6 +36,12 @@ export const cumUseGraphPageMeta = {
   description: "Inspect kanji usage vs rank trends",
 } as const;
 
+export const dashboardPageMeta = {
+  href: "/dashboard",
+  title: "Dashboard",
+  description: "Activity stats, calendar, and progress breakdowns",
+} as const;
+
 /** Practice destinations shown in the FAB menu. */
 export const practiceNavLinks: NavLinkItem[] = [
   { ...recognitionPracticePageMeta, Icon: Eye },
@@ -39,6 +52,7 @@ export const practiceNavLinks: NavLinkItem[] = [
 /** Primary destinations in the header drawer. */
 export const headerNavLinks: NavLinkItem[] = [
   { ...exploreKanjiPageMeta, Icon: SearchIcon },
+  { ...dashboardPageMeta, Icon: LayoutDashboard },
   { ...recognitionPracticePageMeta, Icon: Eye },
   { ...productionPracticePageMeta, Icon: PenLine },
   { ...speedKatakanaPageMeta, Icon: Keyboard },

--- a/src/components/items/nav-links.ts
+++ b/src/components/items/nav-links.ts
@@ -1,6 +1,7 @@
 import {
   ChartLine,
   Eye,
+  GraduationCap,
   Keyboard,
   LayoutDashboard,
   PenLine,
@@ -42,6 +43,12 @@ export const dashboardPageMeta = {
   description: "Activity stats, calendar, and progress breakdowns",
 } as const;
 
+export const masteryPageMeta = {
+  href: "/mastery",
+  title: "Mastery",
+  description: "Track mastery progress — coming soon",
+} as const;
+
 /** Practice destinations shown in the FAB menu. */
 export const practiceNavLinks: NavLinkItem[] = [
   { ...recognitionPracticePageMeta, Icon: Eye },
@@ -49,10 +56,18 @@ export const practiceNavLinks: NavLinkItem[] = [
   { ...speedKatakanaPageMeta, Icon: Keyboard },
 ];
 
+/** Bottom floating island tabs (Dashboard / Explore / Mastery). */
+export const floatingIslandNavLinks: NavLinkItem[] = [
+  { ...dashboardPageMeta, Icon: LayoutDashboard },
+  { ...exploreKanjiPageMeta, Icon: SearchIcon },
+  { ...masteryPageMeta, Icon: GraduationCap },
+];
+
 /** Primary destinations in the header drawer. */
 export const headerNavLinks: NavLinkItem[] = [
   { ...exploreKanjiPageMeta, Icon: SearchIcon },
   { ...dashboardPageMeta, Icon: LayoutDashboard },
+  { ...masteryPageMeta, Icon: GraduationCap },
   { ...recognitionPracticePageMeta, Icon: Eye },
   { ...productionPracticePageMeta, Icon: PenLine },
   { ...speedKatakanaPageMeta, Icon: Keyboard },

--- a/src/components/items/page-items.tsx
+++ b/src/components/items/page-items.tsx
@@ -6,6 +6,7 @@ import {
   PrivacyScreen,
   SpeedKatakanaScreen,
   DashboardScreen,
+  MasteryScreen,
 } from "@/components/screens";
 import { RecognitionPracticeV1Screen } from "@/components/recognition-practice-v1";
 import { ProductionPracticeV1Screen } from "@/components/production-practice-v1";
@@ -18,6 +19,7 @@ import {
   cumUseGraphPageMeta,
   dashboardPageMeta,
   exploreKanjiPageMeta,
+  masteryPageMeta,
 } from "@/components/items/nav-links";
 
 const kanjiPage = {
@@ -33,6 +35,11 @@ const cumUseGraphPage = {
 const dashboardPage = {
   ...dashboardPageMeta,
   Component: DashboardScreen,
+};
+
+const masteryPage = {
+  ...masteryPageMeta,
+  Component: MasteryScreen,
 };
 
 const aboutPage = {
@@ -72,6 +79,7 @@ const pageItems = {
   kanjiPage,
   cumUseGraphPage,
   dashboardPage,
+  masteryPage,
   aboutPage,
   termsPage,
   privacyPage,

--- a/src/components/items/page-items.tsx
+++ b/src/components/items/page-items.tsx
@@ -5,6 +5,7 @@ import {
   TermsScreen,
   PrivacyScreen,
   SpeedKatakanaScreen,
+  DashboardScreen,
 } from "@/components/screens";
 import { RecognitionPracticeV1Screen } from "@/components/recognition-practice-v1";
 import { ProductionPracticeV1Screen } from "@/components/production-practice-v1";
@@ -15,6 +16,7 @@ import {
 } from "@/components/items/practice-pages";
 import {
   cumUseGraphPageMeta,
+  dashboardPageMeta,
   exploreKanjiPageMeta,
 } from "@/components/items/nav-links";
 
@@ -26,6 +28,11 @@ const kanjiPage = {
 const cumUseGraphPage = {
   ...cumUseGraphPageMeta,
   Component: CumUseScreen,
+};
+
+const dashboardPage = {
+  ...dashboardPageMeta,
+  Component: DashboardScreen,
 };
 
 const aboutPage = {
@@ -64,6 +71,7 @@ const productionPracticeV1Page = {
 const pageItems = {
   kanjiPage,
   cumUseGraphPage,
+  dashboardPage,
   aboutPage,
   termsPage,
   privacyPage,

--- a/src/components/items/practice-pages.ts
+++ b/src/components/items/practice-pages.ts
@@ -1,22 +1,25 @@
 /** Route metadata only — no screen Components, so ListScreen can import safely. */
 
 export const recognitionPracticePageMeta = {
-  href: "/recognition-practice",
-  title: "Kanji Recognition Practice",
-  heading: "👁️ Kanji Recognition",
+  href: "/reading-practice",
+  title: "Kanji Reading Practice",
+  shortLabel: "Kanji Reading",
+  heading: "👁️ Kanji Reading",
   description: "Type the correct reading for each word",
 } as const;
 
 export const productionPracticePageMeta = {
-  href: "/production-practice",
-  title: "Kanji Production Practice",
-  heading: "✍️ Kanji Production",
+  href: "/writing-practice",
+  title: "Kanji Writing Practice",
+  shortLabel: "Kanji Writing",
+  heading: "✍️ Kanji Writing",
   description: "Complete words by drawing the missing kanji",
 } as const;
 
 export const speedKatakanaPageMeta = {
   href: "/speed-katakana",
   title: "Speed Katakana",
+  shortLabel: "Speed Katakana",
   heading: "🐇 Speed Katakana",
   description: "Type katakana words as quickly as you can",
 } as const;

--- a/src/components/production-practice-v1/ProductionPracticeV1.tsx
+++ b/src/components/production-practice-v1/ProductionPracticeV1.tsx
@@ -6,6 +6,7 @@ import KanjiDrawerGlobal from "@/components/screens/ListScreen/Drawer/KanjiDrawe
 import { EndSession, PracticeShell } from "@/components/shared-practice";
 import { productionPracticePageMeta } from "@/components/items/practice-pages";
 import { warmupDaKanji } from "@/lib/dakanji-adapter";
+import { recordActivity } from "@/lib/activity";
 import { InitialScreen } from "./InitialScreen";
 import { ModelLoadingScreen } from "./ModelLoadingScreen";
 import { Game } from "./Game";
@@ -108,6 +109,7 @@ const ProductionPracticeV1 = () => {
     const forgottens = sessionResults.filter((r) => !r.correct);
     const moreLeft = forgottens.length > 0 || cursor < deck.length;
 
+    recordActivity("production");
     setRunResults((prev) => [...prev, ...sessionResults]);
     setResults(sessionResults);
     setHasMore(moreLeft);

--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -135,7 +135,7 @@ export const Game = ({
       */}
       <div className="flex flex-col items-center shrink-0 px-4 pt-8 text-center [@media(pointer:fine)]:pt-8 md:pt-8 [@media(min-height:900px)]:pt-8">
         <div
-          className={current.fontIndex === null ? "kanji-font" : undefined}
+          className={current.fontIndex === null ? "kanji-font" : ""}
           style={
             current.fontIndex === null
               ? undefined
@@ -155,7 +155,7 @@ export const Game = ({
           text={current.englishGloss}
           resetKey={index}
           forceReveal={feedback != null}
-          className="focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0"
+          className="mt-6 focus:outline-none focus-visible:outline-none ring-0 focus:ring-0 focus-visible:ring-0"
         />
       </div>
 

--- a/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
+++ b/src/components/recognition-practice-v1/RecognitionPracticeV1.tsx
@@ -6,6 +6,7 @@ import { useSetOpenedParam } from "@/components/dependent/routing/routing-hooks"
 import KanjiDrawerGlobal from "@/components/screens/ListScreen/Drawer/KanjiDrawerGlobal";
 import { EndSession, PracticeShell } from "@/components/shared-practice";
 import { recognitionPracticePageMeta } from "@/components/items/practice-pages";
+import { recordActivity } from "@/lib/activity";
 import { InitialScreen } from "./InitialScreen";
 import { Game } from "./Game";
 import { DEFAULT_SETTINGS, SESSION_SIZE, SETTINGS_KEY } from "./constants";
@@ -100,6 +101,7 @@ const RecognitionPracticeV1 = () => {
     const forgottens = sessionResults.filter((r) => !r.correct);
     const moreLeft = forgottens.length > 0 || cursor < deck.length;
 
+    recordActivity("recognition");
     setRunResults((prev) => [...prev, ...sessionResults]);
     setResults(sessionResults);
     setHasMore(moreLeft);

--- a/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import {
+  ActivityKind,
+  ActivityKindFilters,
+  buildCalendarWeeks,
+  DEFAULT_KIND_FILTERS,
+  DurationOption,
+  getDurationRange,
+  maxDayTotalInRange,
+  monthLabelsForWeeks,
+  summarizeActivityInRange,
+} from "@/lib/activity";
+import { useActivityData } from "@/hooks/use-activity-data";
+import { SectionHeading } from "./SectionHeading";
+import { ActivityCountsGrid } from "./ActivityCountsGrid";
+import { ActivityKindFiltersRow } from "./ActivityKindFiltersRow";
+import { DurationNav } from "./DurationNav";
+import { CalendarGrid } from "./CalendarGrid";
+import { DashboardPanel } from "./DashboardPanel";
+import { FreqGradient } from "@/components/common/freq/FreqGradient";
+
+export const ActivityCalendarHeatmap = () => {
+  const { byDay } = useActivityData();
+  const [duration, setDuration] = useState<DurationOption>({ type: "last365" });
+  const [filters, setFilters] =
+    useState<ActivityKindFilters>(DEFAULT_KIND_FILTERS);
+
+  const range = getDurationRange(duration);
+  const weeks = buildCalendarWeeks(range);
+  const monthLabels = monthLabelsForWeeks(weeks);
+  const maxN = maxDayTotalInRange(byDay, range, filters);
+  const windowed = summarizeActivityInRange(byDay, range, filters);
+
+  const setKind = (kind: ActivityKind, checked: boolean) => {
+    setFilters((prev) => ({ ...prev, [kind]: checked }));
+  };
+
+  return (
+    <DashboardPanel>
+      <SectionHeading
+        title="Activity Heatmap"
+        description="Daily practice events. Brighter days mean more activity relative to your busiest day in this range."
+      />
+
+      <div className="mb-4">
+        <DurationNav value={duration} onChange={setDuration} />
+      </div>
+
+      <CalendarGrid
+        weeks={weeks}
+        monthLabels={monthLabels}
+        byDay={byDay}
+        filters={filters}
+        maxN={maxN}
+      />
+
+      <div className="my-5">
+        <ActivityKindFiltersRow filters={filters} onChange={setKind} />
+      </div>
+
+      <div className="flex items-center justify-center w-full">
+        <div>
+          <FreqGradient />
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <p className="mb-3 text-xs font-extrabold tracking-wide text-center uppercase text-muted-foreground">
+          In this period
+        </p>
+        <ActivityCountsGrid stats={windowed} />
+      </div>
+    </DashboardPanel>
+  );
+};

--- a/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
@@ -1,0 +1,39 @@
+import { CalendarDays, Eye, Keyboard, PenLine } from "lucide-react";
+import { OverviewStat } from "./OverviewStat";
+
+export type ActivityCountsDisplay = {
+  daysActive: number;
+  speedKatakanaSessions: number;
+  productionRounds: number;
+  recognitionRounds: number;
+};
+
+/** Shared 2×2 (mobile) / 4-up layout for activity counters. */
+export const ActivityCountsGrid = ({
+  stats,
+}: {
+  stats: ActivityCountsDisplay;
+}) => (
+  <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4 sm:gap-3">
+    <OverviewStat
+      value={stats.daysActive}
+      label="Days active"
+      Icon={CalendarDays}
+    />
+    <OverviewStat
+      value={stats.speedKatakanaSessions}
+      label="Speed Katakana"
+      Icon={Keyboard}
+    />
+    <OverviewStat
+      value={stats.productionRounds}
+      label="Kanji Production"
+      Icon={PenLine}
+    />
+    <OverviewStat
+      value={stats.recognitionRounds}
+      label="Kanji Recognition"
+      Icon={Eye}
+    />
+  </div>
+);

--- a/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
@@ -1,4 +1,9 @@
 import { CalendarDays, Eye, Keyboard, PenLine } from "lucide-react";
+import {
+  productionPracticePageMeta,
+  recognitionPracticePageMeta,
+  speedKatakanaPageMeta,
+} from "@/components/items/practice-pages";
 import { OverviewStat } from "./OverviewStat";
 
 export type ActivityCountsDisplay = {
@@ -22,17 +27,17 @@ export const ActivityCountsGrid = ({
     />
     <OverviewStat
       value={stats.speedKatakanaSessions}
-      label="Speed Katakana"
+      label={speedKatakanaPageMeta.shortLabel}
       Icon={Keyboard}
     />
     <OverviewStat
       value={stats.productionRounds}
-      label="Kanji Production"
+      label={productionPracticePageMeta.shortLabel}
       Icon={PenLine}
     />
     <OverviewStat
       value={stats.recognitionRounds}
-      label="Kanji Recognition"
+      label={recognitionPracticePageMeta.shortLabel}
       Icon={Eye}
     />
   </div>

--- a/src/components/screens/DashboardScreen/ActivityKindFiltersRow.tsx
+++ b/src/components/screens/DashboardScreen/ActivityKindFiltersRow.tsx
@@ -1,0 +1,34 @@
+import {
+  ACTIVITY_KIND_LABELS,
+  ActivityKind,
+  ALL_ACTIVITY_KINDS,
+  ActivityKindFilters,
+} from "@/lib/activity";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+
+export const ActivityKindFiltersRow = ({
+  filters,
+  onChange,
+}: {
+  filters: ActivityKindFilters;
+  onChange: (kind: ActivityKind, checked: boolean) => void;
+}) => (
+  <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+    {ALL_ACTIVITY_KINDS.map((kind) => {
+      const id = `activity-kind-${kind}`;
+      return (
+        <div key={kind} className="flex items-center gap-2">
+          <Checkbox
+            id={id}
+            checked={filters[kind]}
+            onCheckedChange={(v) => onChange(kind, v === true)}
+          />
+          <Label htmlFor={id} className="cursor-pointer text-sm font-semibold">
+            {ACTIVITY_KIND_LABELS[kind]}
+          </Label>
+        </div>
+      );
+    })}
+  </div>
+);

--- a/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
@@ -61,13 +61,13 @@ export const BookmarksBreakdown = () => {
         </div>
       ) : (
         <>
-          <div className="flex flex-col gap-3.5">
+          <div className="flex flex-col gap-1 ">
             {JLPT_TYPE_ARR.map((jlpt) => {
               const { bookmarked: n, total } = counts[jlpt];
               const pct = total > 0 ? (n / total) * 100 : 0;
               const meta = JLPTListItems[jlpt];
               return (
-                <div key={jlpt} className="flex items-center gap-3">
+                <div key={jlpt} className="flex items-center gap-2">
                   <div className="flex items-center w-10 gap-2 text-sm font-extrabold shrink-0">
                     <span
                       className={`inline-block size-2.5 shrink-0 rounded-full ${meta.cn}`}
@@ -75,7 +75,7 @@ export const BookmarksBreakdown = () => {
                     {meta.label !== "Not in JLPT" ? meta.label : "~"}
                   </div>
                   <Progress
-                    className="h-2.5 flex-1 border border-border/60"
+                    className="flex-1 h-2.5 border border-border/60"
                     value={pct}
                     primitiveCn={meta.cn}
                   />

--- a/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from "react";
+import {
+  useGetKanjiInfoFn,
+  useIsKanjiWorkerReady,
+  useKanjiSearch,
+} from "@/kanji-worker/kanji-worker-hooks";
+import { toSearchSettings } from "@/lib/settings/search-settings-adapter";
+import { JLPT_TYPE_ARR, JLPTListItems, JLTPTtypes } from "@/lib/jlpt";
+import { useBookmarkedKanji } from "@/hooks/use-bookmarked-kanji";
+import { Progress } from "@/components/ui/progress";
+import KaomojiAnimation from "@/components/common/KaomojiLoading";
+import { SectionHeading } from "./SectionHeading";
+import { DashboardPanel } from "./DashboardPanel";
+
+const ALL_KANJI_SEARCH = toSearchSettings(new URLSearchParams());
+
+type JlptCounts = Record<JLTPTtypes, { bookmarked: number; total: number }>;
+
+const emptyCounts = (): JlptCounts =>
+  Object.fromEntries(
+    JLPT_TYPE_ARR.map((k) => [k, { bookmarked: 0, total: 0 }])
+  ) as JlptCounts;
+
+export const BookmarksBreakdown = () => {
+  const ready = useIsKanjiWorkerReady();
+  const getInfo = useGetKanjiInfoFn();
+  const search = useKanjiSearch(ALL_KANJI_SEARCH);
+  const bookmarked = useBookmarkedKanji();
+
+  const counts = useMemo(() => {
+    const next = emptyCounts();
+    if (!ready || !getInfo || !search.data) return next;
+
+    for (const kanji of search.data) {
+      const jlpt = getInfo(kanji)?.jlpt ?? "none";
+      next[jlpt].total += 1;
+    }
+
+    for (const kanji of bookmarked) {
+      const jlpt = getInfo(kanji)?.jlpt ?? "none";
+      next[jlpt].bookmarked += 1;
+    }
+
+    return next;
+  }, [ready, getInfo, search.data, bookmarked]);
+
+  const loading =
+    !ready || search.status === "loading" || search.status === "idle";
+
+  const totalBookmarked = bookmarked.length;
+
+  return (
+    <DashboardPanel>
+      <SectionHeading
+        title="Bookmarks"
+        description="How much of each JLPT band you've bookmarked."
+      />
+      {loading ? (
+        <div className="py-8">
+          <KaomojiAnimation />
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-3.5">
+            {JLPT_TYPE_ARR.map((jlpt) => {
+              const { bookmarked: n, total } = counts[jlpt];
+              const pct = total > 0 ? (n / total) * 100 : 0;
+              const meta = JLPTListItems[jlpt];
+              return (
+                <div key={jlpt} className="flex items-center gap-3">
+                  <div className="flex items-center w-10 gap-2 text-sm font-extrabold shrink-0">
+                    <span
+                      className={`inline-block size-2.5 shrink-0 rounded-full ${meta.cn}`}
+                    />
+                    {meta.label !== "Not in JLPT" ? meta.label : "~"}
+                  </div>
+                  <Progress
+                    className="h-2.5 flex-1 border border-border/60"
+                    value={pct}
+                    primitiveCn={meta.cn}
+                  />
+                  <div className="w-8 text-xs font-bold text-right shrink-0 tabular-nums text-muted-foreground">
+                    {n}/{total}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          {totalBookmarked === 0 ? (
+            <p className="mt-5 text-sm font-semibold text-center text-muted-foreground">
+              Bookmark a word from a kanji’s detail drawer to start filling
+              these bars.
+            </p>
+          ) : null}
+        </>
+      )}
+    </DashboardPanel>
+  );
+};

--- a/src/components/screens/DashboardScreen/CalendarGrid.tsx
+++ b/src/components/screens/DashboardScreen/CalendarGrid.tsx
@@ -1,0 +1,196 @@
+import {
+  ACTIVITY_KIND_LABELS,
+  ActivityByDay,
+  ActivityKindFilters,
+  dayTotalForFilters,
+  formatActivityDay,
+  getActivityLevel,
+  getDayCounts,
+} from "@/lib/activity";
+import { freqCategoryCn } from "@/lib/freq/freq-category";
+import { cn } from "@/lib/utils";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+
+/** Sun→Sat; only Mon / Wed / Fri labeled (Cursor/GitHub-style). */
+const DAY_LABELS = ["", "M", "", "W", "", "F", ""] as const;
+
+const CELL_PX = 11;
+const GAP_PX = 3;
+const EMPTY_CELL =
+  "bg-muted/50 border border-border dark:bg-muted/30 dark:border-border";
+
+type CellProps = {
+  dateKey: string | null;
+  byDay: ActivityByDay;
+  filters: ActivityKindFilters;
+  maxN: number;
+};
+
+const DayDetail = ({
+  dateKey,
+  byDay,
+  filters,
+}: {
+  dateKey: string;
+  byDay: ActivityByDay;
+  filters: ActivityKindFilters;
+}) => {
+  const day = getDayCounts(byDay, dateKey);
+  const total = dayTotalForFilters(day, filters);
+
+  return (
+    <div className="space-y-1.5 text-xs">
+      <div className="font-extrabold">{formatActivityDay(dateKey)}</div>
+      <div className="text-muted-foreground">
+        {total === 0
+          ? "No activity"
+          : `${total} event${total === 1 ? "" : "s"}`}
+      </div>
+      {(["speedKatakana", "production", "recognition"] as const).map((kind) =>
+        filters[kind] ? (
+          <div key={kind} className="flex justify-between gap-4">
+            <span>{ACTIVITY_KIND_LABELS[kind]}</span>
+            <span className="font-bold tabular-nums">{day[kind]}</span>
+          </div>
+        ) : null
+      )}
+    </div>
+  );
+};
+
+const CalendarDayCell = ({ dateKey, byDay, filters, maxN }: CellProps) => {
+  if (dateKey == null) {
+    return <div aria-hidden style={{ width: CELL_PX, height: CELL_PX }} />;
+  }
+
+  const n = dayTotalForFilters(getDayCounts(byDay, dateKey), filters);
+  const level = getActivityLevel(n, maxN);
+  const fillCn =
+    level === 0
+      ? EMPTY_CELL
+      : cn(
+          freqCategoryCn[level],
+          "border border-black/10 dark:border-white/10"
+        );
+
+  const label = `${formatActivityDay(dateKey)}: ${n} events`;
+
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          title={label}
+          style={{ width: CELL_PX, height: CELL_PX }}
+          className={cn(
+            "rounded-[2px] outline-none",
+            "hover:ring-2 hover:ring-foreground/30 hover:ring-offset-1 hover:ring-offset-background",
+            "focus-visible:ring-2 focus-visible:ring-ring",
+            fillCn
+          )}
+        />
+      </HoverCardTrigger>
+      <HoverCardContent className="w-52 p-3" side="top">
+        <DayDetail dateKey={dateKey} byDay={byDay} filters={filters} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
+/**
+ * Fixed-size contribution grid (GitHub/Cursor-style).
+ * Cells never shrink; narrow viewports get overflow-x scroll.
+ */
+export const CalendarGrid = ({
+  weeks,
+  monthLabels,
+  byDay,
+  filters,
+  maxN,
+}: {
+  weeks: (string | null)[][];
+  monthLabels: { weekIndex: number; label: string }[];
+  byDay: ActivityByDay;
+  filters: ActivityKindFilters;
+  maxN: number;
+}) => {
+  const labelByWeek = new Map(monthLabels.map((m) => [m.weekIndex, m.label]));
+  const weekCount = weeks.length;
+
+  return (
+    <div className="overflow-x-auto pb-1 [-webkit-mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] [mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] sm:[-webkit-mask-image:none] sm:[mask-image:none]">
+      <div
+        className="inline-grid"
+        style={{
+          gridTemplateAreas: `"empty months" "days squares"`,
+          gridTemplateColumns: "auto 1fr",
+          columnGap: 6,
+          rowGap: GAP_PX,
+        }}
+      >
+        {/* Month letters — one column per week, same width as cells */}
+        <div
+          className="text-[10px] leading-none text-muted-foreground"
+          style={{
+            gridArea: "months",
+            display: "grid",
+            gridTemplateColumns: `repeat(${weekCount}, ${CELL_PX}px)`,
+            columnGap: GAP_PX,
+          }}
+        >
+          {weeks.map((_, weekIndex) => (
+            <div key={weekIndex} className="h-3">
+              {labelByWeek.get(weekIndex) ?? ""}
+            </div>
+          ))}
+        </div>
+
+        {/* Weekday letters — same row height as cells so M/W/F align */}
+        <div
+          className="text-[10px] leading-none text-muted-foreground"
+          style={{
+            gridArea: "days",
+            display: "grid",
+            gridTemplateRows: `repeat(7, ${CELL_PX}px)`,
+            rowGap: GAP_PX,
+          }}
+        >
+          {DAY_LABELS.map((label, i) => (
+            <div key={i} className="flex items-center justify-end pr-0.5">
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Squares — column flow: Sun→Sat down, then next week */}
+        <div
+          style={{
+            gridArea: "squares",
+            display: "grid",
+            gridAutoFlow: "column",
+            gridAutoColumns: CELL_PX,
+            gridTemplateRows: `repeat(7, ${CELL_PX}px)`,
+            gap: GAP_PX,
+          }}
+        >
+          {weeks.map((week, weekIndex) =>
+            week.map((dateKey, dayIndex) => (
+              <CalendarDayCell
+                key={`${weekIndex}-${dayIndex}`}
+                dateKey={dateKey}
+                byDay={byDay}
+                filters={filters}
+                maxN={maxN}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/screens/DashboardScreen/DashboardPanel.tsx
+++ b/src/components/screens/DashboardScreen/DashboardPanel.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/** Dashed panel matching site chrome (Duolingo-adjacent chunky frames). */
+export const DashboardPanel = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => (
+  <section className={cn("bg-background px-4 py-6 sm:px-6", className)}>
+    {children}
+  </section>
+);

--- a/src/components/screens/DashboardScreen/DashboardScreen.tsx
+++ b/src/components/screens/DashboardScreen/DashboardScreen.tsx
@@ -1,4 +1,5 @@
 import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
+import { BottomBar } from "@/components/common/BottomBar";
 import { StatsOverview } from "./StatsOverview";
 import { ActivityCalendarHeatmap } from "./ActivityCalendarHeatmap";
 import { SpeedKatakanaBreakdown } from "./SpeedKatakanaBreakdown";
@@ -26,6 +27,9 @@ const DashboardScreen = () => {
       <ActivityCalendarHeatmap />
       <BookmarksBreakdown />
       <SpeedKatakanaBreakdown />
+      <div className="pt-4 mt-4 border-t-2 border-dotted">
+        <BottomBar />
+      </div>
     </div>
   );
 };

--- a/src/components/screens/DashboardScreen/DashboardScreen.tsx
+++ b/src/components/screens/DashboardScreen/DashboardScreen.tsx
@@ -1,0 +1,33 @@
+import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
+import { StatsOverview } from "./StatsOverview";
+import { ActivityCalendarHeatmap } from "./ActivityCalendarHeatmap";
+import { SpeedKatakanaBreakdown } from "./SpeedKatakanaBreakdown";
+import { BookmarksBreakdown } from "./BookmarksBreakdown";
+
+const showTitle = false;
+const DashboardScreen = () => {
+  useHtmlDocumentTitle("Dashboard");
+
+  return (
+    <div className="flex flex-col w-full max-w-4xl gap-6 px-1 py-5 mx-auto sm:gap-8 sm:px-3 sm:py-8">
+      <header className="text-center">
+        {showTitle && (
+          <h1 className="text-3xl font-extrabold tracking-tight">
+            Your Progress
+          </h1>
+        )}
+        <p className="mx-auto mt-2 text-sm text-muted-foreground">
+          ⚠️ Saved only on this device. No backup. Your data may be lost at any
+          time.
+        </p>
+      </header>
+
+      <StatsOverview />
+      <ActivityCalendarHeatmap />
+      <BookmarksBreakdown />
+      <SpeedKatakanaBreakdown />
+    </div>
+  );
+};
+
+export default DashboardScreen;

--- a/src/components/screens/DashboardScreen/DashboardScreen.tsx
+++ b/src/components/screens/DashboardScreen/DashboardScreen.tsx
@@ -28,7 +28,7 @@ const DashboardScreen = () => {
       <BookmarksBreakdown />
       <SpeedKatakanaBreakdown />
       <div className="pt-4 mt-4 border-t-2 border-dotted">
-        <BottomBar />
+        <BottomBar justify="center" />
       </div>
     </div>
   );

--- a/src/components/screens/DashboardScreen/DurationNav.tsx
+++ b/src/components/screens/DashboardScreen/DurationNav.tsx
@@ -39,7 +39,7 @@ export const DurationNav = ({
       >
         <ChevronLeft className="size-5" />
       </button>
-      <div className="min-w-[9.5rem] text-center text-base font-extrabold tabular-nums">
+      <div className="min-w-[7rem] text-center text-base font-extrabold tabular-nums">
         {durationOptionLabel(value)}
       </div>
       <button

--- a/src/components/screens/DashboardScreen/DurationNav.tsx
+++ b/src/components/screens/DashboardScreen/DurationNav.tsx
@@ -1,0 +1,61 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  DurationOption,
+  canGoNextDuration,
+  canGoPrevDuration,
+  durationOptionLabel,
+  shiftDuration,
+} from "@/lib/activity";
+import { cn } from "@/lib/utils";
+
+export const DurationNav = ({
+  value,
+  onChange,
+}: {
+  value: DurationOption;
+  onChange: (next: DurationOption) => void;
+}) => {
+  const canGoPrev = canGoPrevDuration(value);
+  const canGoNext = canGoNextDuration(value);
+
+  const go = (delta: -1 | 1) => {
+    const next = shiftDuration(value, delta);
+    if (next) onChange(next);
+  };
+
+  return (
+    <div className="flex items-center justify-center gap-3">
+      <button
+        type="button"
+        onClick={() => go(-1)}
+        disabled={!canGoPrev}
+        className={cn(
+          "flex size-9 items-center justify-center rounded-xl bg-background",
+          "transition-[transform,border-width] active:translate-y-[2px] active:border-b-2",
+          "hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "disabled:pointer-events-none disabled:opacity-30 disabled:active:translate-y-0"
+        )}
+        aria-label="Previous period"
+      >
+        <ChevronLeft className="size-5" />
+      </button>
+      <div className="min-w-[9.5rem] text-center text-base font-extrabold tabular-nums">
+        {durationOptionLabel(value)}
+      </div>
+      <button
+        type="button"
+        onClick={() => go(1)}
+        disabled={!canGoNext}
+        className={cn(
+          "flex size-9 items-center justify-center rounded-xl bg-background",
+          "transition-[transform,border-width] active:translate-y-[2px] active:border-b-2",
+          "hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "disabled:pointer-events-none disabled:opacity-30 disabled:active:translate-y-0"
+        )}
+        aria-label="Next period"
+      >
+        <ChevronRight className="size-5" />
+      </button>
+    </div>
+  );
+};

--- a/src/components/screens/DashboardScreen/EmptyActivityHint.tsx
+++ b/src/components/screens/DashboardScreen/EmptyActivityHint.tsx
@@ -1,0 +1,38 @@
+import { Link } from "@/components/dependent/routing";
+import {
+  productionPracticePageMeta,
+  recognitionPracticePageMeta,
+  speedKatakanaPageMeta,
+} from "@/components/items/practice-pages";
+
+const practiceLinks = [
+  { href: speedKatakanaPageMeta.href, label: "Speed Katakana" },
+  { href: productionPracticePageMeta.href, label: "Production" },
+  { href: recognitionPracticePageMeta.href, label: "Recognition" },
+] as const;
+
+export const EmptyActivityHint = ({
+  title = "Nothing here yet",
+  body = "Finish a practice round and your stats will show up on this device.",
+}: {
+  title?: string;
+  body?: string;
+}) => (
+  <div className="mt-5 rounded-2xl border-2 border-dashed border-foreground/20 bg-muted/20 px-4 py-6 text-center">
+    <p className="text-base font-extrabold">{title}</p>
+    <p className="mx-auto mt-1.5 max-w-sm text-sm text-muted-foreground">
+      {body}
+    </p>
+    <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+      {practiceLinks.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className="inline-flex h-10 items-center rounded-2xl border-2 border-b-4 border-foreground/25 bg-background px-4 text-sm font-bold transition-[transform,border-width] active:translate-y-[2px] active:border-b-2 hover:bg-accent"
+        >
+          {item.label}
+        </Link>
+      ))}
+    </div>
+  </div>
+);

--- a/src/components/screens/DashboardScreen/EmptyActivityHint.tsx
+++ b/src/components/screens/DashboardScreen/EmptyActivityHint.tsx
@@ -6,9 +6,18 @@ import {
 } from "@/components/items/practice-pages";
 
 const practiceLinks = [
-  { href: speedKatakanaPageMeta.href, label: "Speed Katakana" },
-  { href: productionPracticePageMeta.href, label: "Production" },
-  { href: recognitionPracticePageMeta.href, label: "Recognition" },
+  {
+    href: speedKatakanaPageMeta.href,
+    label: speedKatakanaPageMeta.shortLabel,
+  },
+  {
+    href: productionPracticePageMeta.href,
+    label: productionPracticePageMeta.shortLabel,
+  },
+  {
+    href: recognitionPracticePageMeta.href,
+    label: recognitionPracticePageMeta.shortLabel,
+  },
 ] as const;
 
 export const EmptyActivityHint = ({

--- a/src/components/screens/DashboardScreen/OverviewStat.tsx
+++ b/src/components/screens/DashboardScreen/OverviewStat.tsx
@@ -1,0 +1,64 @@
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export const OverviewStat0 = ({
+  value,
+  label,
+  Icon,
+  className,
+}: {
+  value: number | string;
+  label: string;
+  Icon: LucideIcon;
+  className?: string;
+}) => (
+  <div
+    className={cn(
+      "flex items-center gap-3 rounded-2xl border-2 border-b-4 border-foreground/15 bg-muted/30 px-3 py-3 text-left",
+      className
+    )}
+  >
+    <div className="flex items-center justify-center border-2 size-9 shrink-0 rounded-xl border-foreground/10 bg-background text-foreground/70">
+      <Icon className="size-4" aria-hidden />
+    </div>
+    <div className="min-w-0">
+      <div className="text-base font-extrabold leading-none tabular-nums">
+        {value}
+      </div>
+      <div className="mt-1 truncate text-[11px] font-bold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+    </div>
+  </div>
+);
+
+export const OverviewStat = ({
+  value,
+  label,
+  Icon,
+  className,
+}: {
+  value: number | string;
+  label: string;
+  Icon: LucideIcon;
+  className?: string;
+}) => (
+  <div
+    className={cn(
+      "flex items-center gap-3 rounded-2xl border-1  bg-muted/20  px-3 py-3 text-left",
+      className
+    )}
+  >
+    <div className="flex items-center justify-center size-9 shrink-0 rounded-xl border-foreground/10 bg-background text-foreground/70">
+      <Icon className="size-4" aria-hidden />
+    </div>
+    <div className="min-w-0">
+      <div className="text-base font-extrabold leading-none tabular-nums">
+        {value}
+      </div>
+      <div className="mt-1 truncate text-[11px] font-bold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/screens/DashboardScreen/SectionHeading.tsx
+++ b/src/components/screens/DashboardScreen/SectionHeading.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { GenericPopover } from "@/components/common/GenericPopover";
+import { InfoIcon } from "@/components/icons";
+
+export const SectionHeading = ({
+  title,
+  description,
+  className,
+}: {
+  title: string;
+  description?: ReactNode;
+  className?: string;
+}) => (
+  <div className={cn("mb-5 text-center border-b-2 border-dotted", className)}>
+    <h2 className="inline-flex items-center justify-center gap-1.5 mb-2 uppercase text-sm font-extrabold text-muted-foreground">
+      {title}
+      {description ? (
+        <GenericPopover
+          trigger={
+            <button
+              type="button"
+              className="inline-flex text-muted-foreground hover:text-foreground"
+              aria-label={`About ${title}`}
+            >
+              <InfoIcon className="inline-block" size={16} />
+            </button>
+          }
+          content={
+            <div className="max-w-xs px-4 py-3 text-sm text-left text-muted-foreground">
+              {description}
+            </div>
+          }
+        />
+      ) : null}
+    </h2>
+  </div>
+);

--- a/src/components/screens/DashboardScreen/SegmentedBandBar.tsx
+++ b/src/components/screens/DashboardScreen/SegmentedBandBar.tsx
@@ -1,0 +1,44 @@
+import type { FreqCategory } from "@/lib/freq/freq-category";
+import { freqCategoryCn } from "@/lib/freq/freq-category";
+import { cn } from "@/lib/utils";
+
+/**
+ * Stacked bar: contiguous blocks per band.
+ * Band 0 is omitted so the muted track shows through (empty = visible).
+ */
+export const SegmentedBandBar = ({
+  counts,
+  totalUnits,
+  className = "",
+}: {
+  counts: number[];
+  totalUnits: number;
+  className?: string;
+}) => {
+  const safeTotal = Math.max(totalUnits, 1);
+
+  return (
+    <div
+      className={cn(
+        "flex h-3 w-full overflow-hidden rounded-md border border-border bg-muted/50",
+        className
+      )}
+      role="img"
+      aria-label={counts
+        .map((c, i) => (c > 0 ? `band ${i}: ${c}` : null))
+        .filter(Boolean)
+        .join(", ")}
+    >
+      {counts.map((count, band) => {
+        if (count <= 0 || band === 0) return null;
+        return (
+          <div
+            key={band}
+            className={freqCategoryCn[band as FreqCategory]}
+            style={{ width: `${(count / safeTotal) * 100}%` }}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { speedKatakanaPageMeta } from "@/components/items/practice-pages";
 import {
   CHALLENGES_PER_LEVEL,
   LEVELS,
@@ -58,7 +59,7 @@ export const SpeedKatakanaBreakdown = () => {
   return (
     <DashboardPanel>
       <SectionHeading
-        title="Speed Katakana"
+        title={speedKatakanaPageMeta.shortLabel}
         description="Each bar is one challenge set (10 challenges), grouped by best CPM. Only attempts with accuracy > 70% count. Brighter = higher CPM. Clear a full 48-word run above 70% accuracy to fill these bars."
       />
       <div className="grid grid-cols-4 grid-rows-5 grid-flow-col gap-x-3 gap-y-2.5 sm:gap-x-4 sm:gap-y-3">

--- a/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
@@ -62,7 +62,7 @@ export const SpeedKatakanaBreakdown = () => {
         title={speedKatakanaPageMeta.shortLabel}
         description="Each bar is one challenge set (10 challenges), grouped by best CPM. Only attempts with accuracy > 70% count. Brighter = higher CPM. Clear a full 48-word run above 70% accuracy to fill these bars."
       />
-      <div className="grid grid-cols-4 grid-rows-5 grid-flow-col gap-x-3 gap-y-2.5 sm:gap-x-4 sm:gap-y-3">
+      <div className="grid grid-flow-col grid-cols-4 grid-rows-5 gap-x-2 gap-y-2 sm:gap-x-2 sm:gap-y-2">
         {Array.from({ length: LEVELS }, (_, i) => i + 1).map((level) => (
           <LevelCell key={level} level={level} />
         ))}

--- a/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import {
+  CHALLENGES_PER_LEVEL,
+  LEVELS,
+  setFromLevelAndPos,
+} from "@/components/screens/SpeedKatakanaScreen/constants";
+import {
+  readSetStats,
+  STATS_KEY_PREFIX,
+} from "@/components/screens/SpeedKatakanaScreen/storage";
+import { countBands, cpmToBand } from "@/lib/activity";
+import { SectionHeading } from "./SectionHeading";
+import { SegmentedBandBar } from "./SegmentedBandBar";
+import { DashboardPanel } from "./DashboardPanel";
+import { FreqGradient } from "@/components/common/freq/FreqGradient";
+
+const levelBandCounts = (level: number): number[] => {
+  const bands = Array.from({ length: CHALLENGES_PER_LEVEL }, (_, i) => {
+    const setNum = setFromLevelAndPos(level, i + 1);
+    const stats = readSetStats(setNum);
+    return cpmToBand(stats?.bestCpmWithAccuracyOver70);
+  });
+  return countBands(bands);
+};
+
+const LevelCell = ({ level }: { level: number }) => {
+  const counts = levelBandCounts(level);
+  const attempted = counts.slice(1).reduce((a, b) => a + b, 0);
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-5 text-xs font-extrabold text-center shrink-0 tabular-nums text-muted-foreground">
+        {level}
+      </span>
+      <div className="flex-1 min-w-0">
+        <SegmentedBandBar counts={counts} totalUnits={CHALLENGES_PER_LEVEL} />
+        <span className="sr-only">
+          Level {level}: {attempted} of {CHALLENGES_PER_LEVEL} qualified
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export const SpeedKatakanaBreakdown = () => {
+  const [, bumpRevision] = useState(0);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key == null || e.key.startsWith(STATS_KEY_PREFIX)) {
+        bumpRevision((n) => n + 1);
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return (
+    <DashboardPanel>
+      <SectionHeading
+        title="Speed Katakana"
+        description="Each bar is one challenge set (10 challenges), grouped by best CPM. Only attempts with accuracy > 70% count. Brighter = higher CPM. Clear a full 48-word run above 70% accuracy to fill these bars."
+      />
+      <div className="grid grid-cols-4 grid-rows-5 grid-flow-col gap-x-3 gap-y-2.5 sm:gap-x-4 sm:gap-y-3">
+        {Array.from({ length: LEVELS }, (_, i) => i + 1).map((level) => (
+          <LevelCell key={level} level={level} />
+        ))}
+      </div>
+      <div className="flex items-center justify-center w-full mt-5">
+        <div>
+          <FreqGradient lessLabel="Slow" moreLabel="Fast" />
+        </div>
+      </div>
+    </DashboardPanel>
+  );
+};

--- a/src/components/screens/DashboardScreen/StatsOverview.tsx
+++ b/src/components/screens/DashboardScreen/StatsOverview.tsx
@@ -1,0 +1,36 @@
+import { Cake } from "lucide-react";
+import { formatCakeDay } from "@/lib/activity";
+import { useActivityData } from "@/hooks/use-activity-data";
+import { SectionHeading } from "./SectionHeading";
+import { ActivityCountsGrid } from "./ActivityCountsGrid";
+import { DashboardPanel } from "./DashboardPanel";
+
+export const StatsOverview = () => {
+  const { allTime, daysActive } = useActivityData();
+
+  return (
+    <DashboardPanel>
+      <SectionHeading
+        title="Activity Overview"
+        description="All-time activity since your first recorded session."
+      />
+      <ActivityCountsGrid
+        stats={{
+          daysActive,
+          speedKatakanaSessions: allTime.speedKatakanaSessions,
+          productionRounds: allTime.productionRounds,
+          recognitionRounds: allTime.recognitionRounds,
+        }}
+      />
+      <div className="flex items-center justify-center gap-2 mt-4 text-sm text-muted-foreground">
+        <Cake className="size-4 shrink-0" aria-hidden />
+        <span>
+          Cake day:{" "}
+          <span className="font-bold text-foreground">
+            {allTime.cakeDay ? formatCakeDay(allTime.cakeDay) : "Not yet"}
+          </span>
+        </span>
+      </div>
+    </DashboardPanel>
+  );
+};

--- a/src/components/screens/DashboardScreen/StatsOverview.tsx
+++ b/src/components/screens/DashboardScreen/StatsOverview.tsx
@@ -11,7 +11,7 @@ export const StatsOverview = () => {
   return (
     <DashboardPanel>
       <SectionHeading
-        title="Activity Overview"
+        title="All-time Overview"
         description="All-time activity since your first recorded session."
       />
       <ActivityCountsGrid

--- a/src/components/screens/DashboardScreen/index.tsx
+++ b/src/components/screens/DashboardScreen/index.tsx
@@ -1,0 +1,12 @@
+import { lazy } from "react";
+import { PageWrapper } from "@/components/dependent/site-wide/PageWrapper";
+
+const LazyDashboardScreen = lazy(() => import("./DashboardScreen"));
+
+const DashboardScreen = () => (
+  <PageWrapper>
+    <LazyDashboardScreen />
+  </PageWrapper>
+);
+
+export { DashboardScreen };

--- a/src/components/screens/ListScreen/ControlBar/ItemCountBadge.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemCountBadge.tsx
@@ -48,17 +48,19 @@ const KnownBadge = () => {
   );
 };
 
-const ItemsCountLayout = ({ count }: { count: number }) => {
+const ItemsCountLayout = ({ count }: { count: number | null }) => {
   return (
-    <>
-      <div className="absolute top-[50px] flex flex-wrap gap-1">
+    // Always absolute so this never joins the ControlBar flex row and
+    // squeezes the sort/presentation icon buttons out of view.
+    <div className="absolute top-[50px] flex flex-wrap gap-1">
+      {count != null ? (
         <div className="px-2 text-xs font-extrabold bg-opacity-75 border rounded-lg bg-background">
           {count} {count !== 1 ? "Items" : "Item"}{" "}
           {KANJI_COUNT !== count ? "Matched" : ""}
         </div>
-        <KnownBadge />
-      </div>
-    </>
+      ) : null}
+      <KnownBadge />
+    </div>
   );
 };
 
@@ -69,7 +71,7 @@ export const ItemCountBadge = () => {
   const kanjiChars = [...new Set(text.split("").filter(isKanji))];
 
   if (result.data?.length == null) {
-    return <KnownBadge />;
+    return <ItemsCountLayout count={null} />;
   }
 
   if (type === "multi-kanji" && kanjiChars.length > 0) {

--- a/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationPopover.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationPopover.tsx
@@ -26,7 +26,7 @@ const ItemPresentationSettingsPopover = ({
         }}
         asChild
       >
-        <Button variant="outline" size="icon" className="h-9 w-9">
+        <Button variant="outline" size="icon" className="h-9 w-9 shrink-0">
           <Flower />
           <span className="sr-only">Card Presentation Settings</span>
         </Button>

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
@@ -101,8 +101,12 @@ export const SearchInput = ({
     setValue(translateValue(initialText, translateMap[initialSearchType]));
   }
 
-  // force focus input ref on mount
+  // Autofocus on fine-pointer devices only — avoids opening the soft
+  // keyboard on touch screens when landing on "/".
   useEffect(() => {
+    if (!window.matchMedia("(pointer: fine)").matches) {
+      return;
+    }
     inputRef.current?.focus?.();
   }, []);
 

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
@@ -185,7 +185,7 @@ export const SearchInput = ({
       : "kanji-font";
 
   return (
-    <section className="relative w-full">
+    <section className="relative flex-1 min-w-0">
       <input
         ref={inputRef}
         // Drawer types are click-to-open; block typing so junk doesn't land in the field.

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterButton.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterButton.tsx
@@ -26,7 +26,7 @@ export const SortAndFilterButton = forwardRef<
       ref={ref}
       variant="outline"
       size="icon"
-      className="h-9 w-9 relative"
+      className="relative h-9 w-9 shrink-0"
       onClick={onClick}
     >
       <Settings2 />

--- a/src/components/screens/ListScreen/KanjiList/LoadingKanjis.tsx
+++ b/src/components/screens/ListScreen/KanjiList/LoadingKanjis.tsx
@@ -3,23 +3,48 @@ import {
   randomCn2,
   randomCnColorful,
   randomCn2Colorful,
+  randomCnGradientAlt,
+  randomCn2GradientAlt,
 } from "@/lib/cn-fns";
 import { useVirtualListDims } from "./useVirtualDims";
-import React from "react";
+import React, { useMemo } from "react";
 import { useDeferredItemSettings } from "@/providers/item-settings-hooks";
 
 const ESTIMATE_ITEM_COUNT = 125;
 
+const getLoadingTileCn = (
+  type: "colorful" | "gradient" | "gradient-alt",
+  isCompact: boolean
+) => {
+  if (type === "colorful") {
+    return isCompact ? randomCn2Colorful() : randomCnColorful();
+  }
+  if (type === "gradient") {
+    return isCompact ? randomCn2() : randomCn();
+  }
+  return isCompact ? randomCn2GradientAlt() : randomCnGradientAlt();
+};
+
 const LoadingKanjisRaw = ({
-  type = "gradient",
+  type = "gradient-alt",
 }: {
-  type?: "colorful" | "gradient";
+  type?: "colorful" | "gradient" | "gradient-alt";
 }) => {
   const itemSettings = useDeferredItemSettings();
   const isCompact = itemSettings.cardType === "compact";
-  const { itemSize, width, cols, idealRows } = useVirtualListDims(
+  const { itemSize, width, cols, idealRows, itemNums } = useVirtualListDims(
     ESTIMATE_ITEM_COUNT,
     itemSettings.cardType
+  );
+
+  // Match the real grid size — idealRows is viewport-based and often >> 125.
+  const tileCount = Math.max(itemNums, 1);
+  const tileCns = useMemo(
+    () =>
+      Array.from({ length: tileCount }, () =>
+        getLoadingTileCn(type, isCompact)
+      ),
+    [tileCount, type, isCompact]
   );
 
   const itemStyle = isCompact
@@ -29,25 +54,24 @@ const LoadingKanjisRaw = ({
   return (
     <div role="status" className="flex flex-wrap items-start justify-start">
       <div className="sr-only">loading</div>
-      {new Array(idealRows).fill(null).map((_, i) => {
+      {new Array(idealRows).fill(null).map((_, rowIndex) => {
         return (
           <div
-            className={`flex items-center justify-center w-full px-1 ${i === 0 ? "pt-6" : ""}`}
-            key={`row-${i}`}
+            className={`flex items-center justify-center w-full px-1 ${rowIndex === 0 ? "pt-6" : ""}`}
+            key={`row-${rowIndex}`}
           >
-            {new Array(cols).fill(null).map((_, i) => {
-              const colorCn = isCompact
-                ? type === "colorful"
-                  ? randomCn2Colorful()
-                  : randomCn2()
-                : type === "colorful"
-                  ? randomCnColorful()
-                  : randomCn();
+            {new Array(cols).fill(null).map((_, colIndex) => {
+              const index = rowIndex * cols + colIndex;
+              const colorCn = tileCns[index] ?? tileCns[0];
               return (
                 <div
-                  key={i}
-                  style={itemStyle}
-                  className={`animate-pulse transition-all transition-discrete  mr-1 mb-1 grow ${colorCn}`}
+                  key={colIndex}
+                  style={{
+                    ...itemStyle,
+                    // Stagger so every tile clearly pulses (not just the first wave).
+                    animationDelay: `${(index % 16) * 0.12}s`,
+                  }}
+                  className={`animate-pulse [animation-duration:2.4s] mr-1 mb-1 grow ${colorCn}`}
                 />
               );
             })}

--- a/src/components/screens/ListScreen/KanjiList/VirtualKanjiList.tsx
+++ b/src/components/screens/ListScreen/KanjiList/VirtualKanjiList.tsx
@@ -14,7 +14,7 @@ const KanjiListRaw = ({
   const { cols, rows } = useVirtualListDims(kanjiKeys.length, size);
 
   return (
-    <>
+    <div className="w-full animate-fade-in">
       <WindowVirtualizer>
         {Array.from({ length: rows }).map((_, rowIndex) => {
           const isNotLast = rowIndex < rows - 1;
@@ -23,7 +23,7 @@ const KanjiListRaw = ({
           return (
             <div
               key={rowIndex}
-              className={`flex items-center justify-center w-full pr-1 ${rowIndex === 0 ? "pt-6 pb-1" : isNotLast ? "pb-1" : "pb-16"}`}
+              className={`flex items-center justify-center w-full pr-1 ${rowIndex === 0 ? "pt-6 pb-1" : isNotLast ? "pb-1" : "pb-28"}`}
             >
               {new Array(items).fill(null).map((_, colIndex: number) => {
                 const index = cols * rowIndex + colIndex;
@@ -41,7 +41,7 @@ const KanjiListRaw = ({
           );
         })}
       </WindowVirtualizer>
-    </>
+    </div>
   );
 };
 

--- a/src/components/screens/ListScreen/ListScreen.tsx
+++ b/src/components/screens/ListScreen/ListScreen.tsx
@@ -18,7 +18,7 @@ const Layout = ({
 }) => {
   return (
     <>
-      <div className="fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
+      <div className="fixed-viewport-layer fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
         <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 sticky pt-1 pl-2 pr-1 w-full ">
           <ErrorBoundary fallback={<LinksOutItems />}>
             <ControlBar />

--- a/src/components/screens/ListScreen/ListScreen.tsx
+++ b/src/components/screens/ListScreen/ListScreen.tsx
@@ -8,7 +8,6 @@ import LoadingKanjis from "./KanjiList/LoadingKanjis";
 import { LinksOutItems } from "@/components/common/LinksOutItems";
 import { SuspendedKanjiList } from "./KanjiList/LazyKanjiList";
 import { ItemCountBadge } from "./ControlBar/ItemCountBadge";
-import { PracticeFab } from "./PracticeFab";
 
 const Layout = ({
   children,
@@ -30,7 +29,6 @@ const Layout = ({
       <div className="relative pt-24 -z-0 flex flex-wrap items-center justify-center overflow-x-hidden">
         {children}
       </div>
-      <PracticeFab />
     </>
   );
 };

--- a/src/components/screens/ListScreen/ListScreen.tsx
+++ b/src/components/screens/ListScreen/ListScreen.tsx
@@ -38,17 +38,9 @@ const Layout = ({
 export const ListScreen = () => {
   const ready = useIsKanjiWorkerReady();
 
-  if (!ready) {
-    return (
-      <Layout>
-        <LoadingKanjis />;
-      </Layout>
-    );
-  }
-
   return (
     <Layout badge={<ItemCountBadge />}>
-      <SuspendedKanjiList />
+      {ready ? <SuspendedKanjiList /> : <LoadingKanjis />}
     </Layout>
   );
 };

--- a/src/components/screens/ListScreen/PracticeFab.tsx
+++ b/src/components/screens/ListScreen/PracticeFab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { NotebookPen } from "lucide-react";
 import {
   Popover,
@@ -9,6 +9,7 @@ import { PracticeButton } from "@/components/ui/practice-button";
 import { DashedNavLinkList } from "@/components/common/DashedNavLinkList";
 import { practiceNavLinks } from "@/components/items/nav-links";
 import { useBgSrc } from "@/components/dependent/routing/routing-hooks";
+import { useScrollLockSettleRef } from "@/hooks/use-scroll-lock-fade-tick";
 import { cn } from "@/lib/utils";
 
 const prefetchPracticeRoutes = () => {
@@ -17,65 +18,11 @@ const prefetchPracticeRoutes = () => {
   void import("@/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen");
 };
 
-/** True when radix/remove-scroll has locked the body (modals, selects, etc.). */
-const isBodyScrollLocked = () => {
-  const { body } = document;
-  return (
-    body.style.overflow === "hidden" ||
-    body.style.paddingRight !== "" ||
-    body.hasAttribute("data-scroll-locked") ||
-    getComputedStyle(body)
-      .getPropertyValue("--removed-body-scroll-bar-size")
-      .trim() !== ""
-  );
-};
-
-/** Bumps whenever scroll-lock toggles so the FAB can fade instead of hard-jumping. */
-const useScrollLockFadeTick = () => {
-  const [tick, setTick] = useState(0);
-
-  useEffect(() => {
-    let prev = isBodyScrollLocked();
-
-    const onChange = () => {
-      const next = isBodyScrollLocked();
-      if (next === prev) return;
-      prev = next;
-      setTick((n) => n + 1);
-    };
-
-    const observer = new MutationObserver(onChange);
-    observer.observe(document.body, {
-      attributes: true,
-      attributeFilter: ["style", "class", "data-scroll-locked"],
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["style", "class"],
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  return tick;
-};
-
 export const PracticeFab = () => {
   const [open, setOpen] = useState(false);
   const bgSrc = useBgSrc();
   const hasBgMeaning = bgSrc !== "none";
-  const fadeTick = useScrollLockFadeTick();
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (fadeTick === 0) return;
-    const el = buttonRef.current;
-    if (!el) return;
-    el.classList.remove("animate-practice-fab-settle");
-    // Force reflow so the animation can restart.
-    void el.offsetWidth;
-    el.classList.add("animate-practice-fab-settle");
-  }, [fadeTick]);
+  const buttonRef = useScrollLockSettleRef<HTMLButtonElement>();
 
   return (
     <Popover

--- a/src/components/screens/ListScreen/index.tsx
+++ b/src/components/screens/ListScreen/index.tsx
@@ -4,14 +4,31 @@ const LazyListScreen = lazy(() =>
   import("./ListScreen").then((m) => ({ default: m.ListScreen }))
 );
 
-// Keep this shell light — LoadingKanjis pulls item-settings/virtual-list hooks
-// that belong in the ListScreen chunk, not the app entry.
+/** Reserves ControlBar space so nav from other routes doesn't flash empty. */
 const ListScreenFallback = () => (
-  <div
-    className="relative pt-24 -z-0 flex min-h-48 items-center justify-center overflow-x-hidden"
-    role="status"
-    aria-label="Loading"
-  />
+  <>
+    <div className="fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
+      <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 sticky pt-1 pl-2 pr-1 w-full">
+        <div
+          className="h-9 flex-1 min-w-0 rounded-md border bg-muted/40"
+          aria-hidden
+        />
+        <div
+          className="h-9 w-9 shrink-0 rounded-md border bg-muted/40 animate-pulse"
+          aria-hidden
+        />
+        <div
+          className="h-9 w-9 shrink-0 rounded-md border bg-muted/40 animate-pulse"
+          aria-hidden
+        />
+      </section>
+    </div>
+    <div
+      className="relative pt-24 -z-0 flex min-h-48 items-center justify-center overflow-x-hidden"
+      role="status"
+      aria-label="Loading"
+    />
+  </>
 );
 
 const ListScreen = () => (

--- a/src/components/screens/ListScreen/index.tsx
+++ b/src/components/screens/ListScreen/index.tsx
@@ -7,7 +7,7 @@ const LazyListScreen = lazy(() =>
 /** Reserves ControlBar space so nav from other routes doesn't flash empty. */
 const ListScreenFallback = () => (
   <>
-    <div className="fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
+    <div className="fixed-viewport-layer fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
       <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 sticky pt-1 pl-2 pr-1 w-full">
         <div
           className="h-9 flex-1 min-w-0 rounded-md border bg-muted/40"

--- a/src/components/screens/MasteryScreen/MasteryScreen.tsx
+++ b/src/components/screens/MasteryScreen/MasteryScreen.tsx
@@ -1,0 +1,42 @@
+import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
+import { BottomBar } from "@/components/common/BottomBar";
+import { DashedNavLinkList } from "@/components/common/DashedNavLinkList";
+import { practiceNavLinks } from "@/components/items/nav-links";
+import { GraduationCap } from "lucide-react";
+
+const MasteryScreen = () => {
+  useHtmlDocumentTitle("Mastery");
+
+  return (
+    <div className="flex flex-col w-full max-w-4xl gap-6 px-1 py-5 mx-auto sm:gap-8 sm:px-3 sm:py-8">
+      <div className="flex flex-col items-center justify-center flex-1 gap-5  text-center min-h-[50vh]">
+        <div
+          className="flex items-center justify-center size-14 rounded-full background-theme-color-with-opacity-100 border-2 border-b-[4px] border-theme-color-darker"
+          aria-hidden="true"
+        >
+          <GraduationCap className="text-white size-6" strokeWidth={2.25} />
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-extrabold tracking-wide uppercase text-muted-foreground">
+            Coming soon
+          </p>
+          <p className="max-w-md mx-auto text-sm text-muted-foreground">
+            This page isn’t ready yet — keep practicing for now.
+          </p>
+        </div>
+
+        <DashedNavLinkList
+          items={practiceNavLinks}
+          className="grid w-full max-w-2xl grid-cols-1 gap-2 sm:grid-cols-3"
+        />
+      </div>
+
+      <div className="pt-4 mt-4 border-t-2 border-dotted">
+        <BottomBar justify="center" />
+      </div>
+    </div>
+  );
+};
+
+export default MasteryScreen;

--- a/src/components/screens/MasteryScreen/index.tsx
+++ b/src/components/screens/MasteryScreen/index.tsx
@@ -1,0 +1,12 @@
+import { lazy } from "react";
+import { PageWrapper } from "@/components/dependent/site-wide/PageWrapper";
+
+const LazyMasteryScreen = lazy(() => import("./MasteryScreen"));
+
+const MasteryScreen = () => (
+  <PageWrapper>
+    <LazyMasteryScreen />
+  </PageWrapper>
+);
+
+export { MasteryScreen };

--- a/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
@@ -8,6 +8,7 @@ import { InitialScreen } from "./InitialScreen";
 import { Game } from "./Game";
 import { EndSession } from "./EndSession";
 import { SessionStats, SpeedKatakanaSettings } from "./types";
+import { recordActivity } from "@/lib/activity";
 import { recordSetResult } from "./storage";
 import { useCompletedSetsCount } from "./use-completed-sets-count";
 import {
@@ -63,6 +64,7 @@ const SpeedKatakanaScreen = () => {
   const finishGame = (sessionStats: SessionStats) => {
     if (settings.wordCount === 48) {
       recordSetResult(settings.challengeSet, sessionStats);
+      recordActivity("speedKatakana");
     }
     setStats(sessionStats);
     setPhase("ended");

--- a/src/components/screens/SpeedKatakanaScreen/storage.ts
+++ b/src/components/screens/SpeedKatakanaScreen/storage.ts
@@ -8,6 +8,11 @@ export type ChallengeSetStats = {
   latestCpm: number;
   bestCpm: number;
   timesTaken: number;
+  /**
+   * Best CPM among attempts with accuracy > 70%.
+   * Missing/0 means no qualifying attempt yet (dashboard treats as not attempted).
+   */
+  bestCpmWithAccuracyOver70?: number;
 };
 
 export const STATS_KEY_PREFIX = "speed-katakana-stats-";
@@ -49,6 +54,10 @@ export const recordSetResult = (
     latestCpm: charsPerMinute,
     bestCpm: Math.max(charsPerMinute, prev?.bestCpm ?? 0),
     timesTaken: (prev?.timesTaken ?? 0) + 1,
+    bestCpmWithAccuracyOver70:
+      accuracy > 70
+        ? Math.max(charsPerMinute, prev?.bestCpmWithAccuracyOver70 ?? 0)
+        : prev?.bestCpmWithAccuracyOver70,
   };
   try {
     localStorage.setItem(statsKey(setNumber), JSON.stringify(next));

--- a/src/components/screens/index.tsx
+++ b/src/components/screens/index.tsx
@@ -2,6 +2,7 @@ import { ListScreen } from "./ListScreen";
 import { CumUseScreen } from "./CumUseScreen";
 import { AboutScreen, TermsScreen, PrivacyScreen } from "./DocsScreen";
 import { SpeedKatakanaScreen } from "./SpeedKatakanaScreen";
+import { DashboardScreen } from "./DashboardScreen";
 
 export {
   CumUseScreen,
@@ -10,4 +11,5 @@ export {
   TermsScreen,
   PrivacyScreen,
   SpeedKatakanaScreen,
+  DashboardScreen,
 };

--- a/src/components/screens/index.tsx
+++ b/src/components/screens/index.tsx
@@ -3,6 +3,7 @@ import { CumUseScreen } from "./CumUseScreen";
 import { AboutScreen, TermsScreen, PrivacyScreen } from "./DocsScreen";
 import { SpeedKatakanaScreen } from "./SpeedKatakanaScreen";
 import { DashboardScreen } from "./DashboardScreen";
+import { MasteryScreen } from "./MasteryScreen";
 
 export {
   CumUseScreen,
@@ -12,4 +13,5 @@ export {
   PrivacyScreen,
   SpeedKatakanaScreen,
   DashboardScreen,
+  MasteryScreen,
 };

--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -3,7 +3,6 @@ import { useGetKanjiInfoFn } from "@/kanji-worker/kanji-worker-hooks";
 import { ErrorBoundary } from "@/components/error";
 import SimpleAccordion from "@/components/common/SimpleAccordion";
 import { BasicLoading } from "@/components/common/BasicLoading";
-import { LinksOutItems } from "@/components/common/LinksOutItems";
 import { FrequencyInfo } from "./FrequencyInfo";
 import { General } from "./General";
 import { KanjiKeyboardShortcuts } from "./KanjiKeyboardShortcuts";
@@ -13,13 +12,9 @@ import { Badge } from "@/components/ui/badge";
 import { outLinks } from "@/lib/external-links";
 import { ExternalKanjiLinks } from "@/components/common/ExternalKanjiLinks";
 import { ExternalTextLink } from "@/components/common/ExternalTextLink";
-import { ModeToggle } from "@/components/dependent/site-wide/ModeToggle";
 import { StructureInfo } from "./StructureInfo";
 import { RepresentativeStudyWord } from "./RepresentativeStudyWord";
-import { PikaPikaLinks } from "@/components/common/PikaPikaLinks";
-import { DotIcon } from "@/components/icons";
-import { DebugInfo } from "@/components/common/DebugInfo";
-import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
+import { BottomBar } from "@/components/common/BottomBar";
 import { useKanjiRepresentativeWord } from "@/providers/kanji-representative-word-provider";
 import { KanjiWordStatusActions } from "./KanjiWordStatusActions";
 import { StrokeAnimationLoadingScreen } from "./StrokeAnimationLoadingScreen";
@@ -60,18 +55,7 @@ export const KanjiDetailsBottom = ({ kanji }: { kanji: string }) => {
         devices.
       </p>
 
-      <div className="my-4 w-fit">
-        <PikaPikaLinks />
-      </div>
-
-      <div className="flex items-center justify-start w-full mt-4 mb-8 space-x-1">
-        <LinksOutItems />
-        <DotIcon className="w-2 m-0" />
-        <DebugInfo />
-        <RefreshPageBtn />
-        <KanjiKeyboardShortcuts kanji={kanji} />
-        <ModeToggle />
-      </div>
+      <BottomBar includeNode={<KanjiKeyboardShortcuts kanji={kanji} />} />
     </>
   );
 };

--- a/src/components/site-layout/FloatingIsland.tsx
+++ b/src/components/site-layout/FloatingIsland.tsx
@@ -22,7 +22,7 @@ export const FloatingIsland = () => {
     <nav
       ref={settleRef}
       aria-label="Primary"
-      className="fixed z-40 left-[calc(0.75rem+env(safe-area-inset-left))] bottom-[calc(0.75rem+env(safe-area-inset-bottom))]"
+      className="fixed-viewport-layer fixed z-40 left-[calc(0.75rem+env(safe-area-inset-left))] bottom-[calc(0.75rem+env(safe-area-inset-bottom))]"
     >
       <div
         className={cn(

--- a/src/components/site-layout/FloatingIsland.tsx
+++ b/src/components/site-layout/FloatingIsland.tsx
@@ -1,0 +1,82 @@
+import { Link } from "@/components/dependent/routing";
+import { useLocation } from "@/components/dependent/routing/router-adapter";
+import { floatingIslandNavLinks } from "@/components/items/nav-links";
+import { useScrollLockSettleRef } from "@/hooks/use-scroll-lock-fade-tick";
+import { cn } from "@/lib/utils";
+
+const islandHrefs = new Set(floatingIslandNavLinks.map((link) => link.href));
+
+export const FloatingIsland = () => {
+  const [location] = useLocation();
+  const settleRef = useScrollLockSettleRef<HTMLElement>();
+
+  if (!islandHrefs.has(location)) {
+    return null;
+  }
+
+  const activeIndex = floatingIslandNavLinks.findIndex(
+    (link) => link.href === location
+  );
+
+  return (
+    <nav
+      ref={settleRef}
+      aria-label="Primary"
+      className="fixed z-40 left-[calc(0.75rem+env(safe-area-inset-left))] bottom-[calc(0.75rem+env(safe-area-inset-bottom))]"
+    >
+      <div
+        className={cn(
+          "relative flex items-center gap-0.5 p-1 rounded-full",
+          "bg-background",
+          "border-2 border-b-[5px] border-foreground/20",
+          "shadow-md"
+        )}
+      >
+        <div className="absolute inset-1 pointer-events-none">
+          <div
+            aria-hidden="true"
+            className={cn(
+              "h-full w-1/3 rounded-full",
+              "background-theme-color-with-opacity-100",
+              "border-2 border-b-[4px] border-theme-color-darker",
+              "transition-transform duration-300 ease-out"
+            )}
+            style={{
+              transform: `translateX(${activeIndex * 100}%)`,
+            }}
+          />
+        </div>
+        {floatingIslandNavLinks.map((link) => {
+          const isActive = link.href === location;
+          const Icon = link.Icon;
+
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              aria-label={link.title}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "relative z-10 flex items-center justify-center",
+                "size-9 rounded-full select-none",
+                "outline-none [-webkit-tap-highlight-color:transparent]",
+                "transition-[transform,colors,filter] duration-75 ease-out",
+                "active:translate-y-[2px]",
+                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                isActive
+                  ? "text-white"
+                  : "text-muted-foreground hover:text-foreground hover:brightness-105"
+              )}
+            >
+              <Icon
+                className="size-3.5"
+                strokeWidth={2.25}
+                aria-hidden="true"
+              />
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};

--- a/src/components/site-layout/Header/Header.tsx
+++ b/src/components/site-layout/Header/Header.tsx
@@ -6,7 +6,7 @@ import { HeaderTitle } from "./HeaderTitle";
 
 const Header = () => {
   return (
-    <header className="fixed top-0 left-0 z-50 flex items-center justify-between w-full px-2 border-b-4 border-dashed fix-scroll-layout-shift-right bg-background backdrop-blur-sm">
+    <header className="fixed-viewport-layer fixed top-0 left-0 z-50 flex items-center justify-between w-full px-2 border-b-4 border-dashed fix-scroll-layout-shift-right bg-background backdrop-blur-sm">
       <HeaderTitle />
       <section className="flex items-center pr-1 space-x-1">
         <ErrorBoundary fallback={null}>

--- a/src/components/site-layout/PracticeFab.tsx
+++ b/src/components/site-layout/PracticeFab.tsx
@@ -7,10 +7,16 @@ import {
 } from "@/components/ui/popover";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { DashedNavLinkList } from "@/components/common/DashedNavLinkList";
-import { practiceNavLinks } from "@/components/items/nav-links";
+import {
+  floatingIslandNavLinks,
+  practiceNavLinks,
+} from "@/components/items/nav-links";
 import { useBgSrc } from "@/components/dependent/routing/routing-hooks";
+import { useLocation } from "@/components/dependent/routing/router-adapter";
 import { useScrollLockSettleRef } from "@/hooks/use-scroll-lock-fade-tick";
 import { cn } from "@/lib/utils";
+
+const fabHrefs = new Set(floatingIslandNavLinks.map((link) => link.href));
 
 const prefetchPracticeRoutes = () => {
   void import("@/components/recognition-practice-v1/RecognitionPracticeV1");
@@ -19,10 +25,15 @@ const prefetchPracticeRoutes = () => {
 };
 
 export const PracticeFab = () => {
+  const [location] = useLocation();
   const [open, setOpen] = useState(false);
   const bgSrc = useBgSrc();
   const hasBgMeaning = bgSrc !== "none";
   const buttonRef = useScrollLockSettleRef<HTMLButtonElement>();
+
+  if (!fabHrefs.has(location)) {
+    return null;
+  }
 
   return (
     <Popover

--- a/src/components/site-layout/PracticeFab.tsx
+++ b/src/components/site-layout/PracticeFab.tsx
@@ -50,7 +50,7 @@ export const PracticeFab = () => {
           size="icon"
           variant={hasBgMeaning ? "secondary" : "primary"}
           className={cn(
-            "fixed z-40 rounded-full h-[5rem] w-[5rem] p-6 border-b-[8px] active:translate-y-[5px] active:border-b-[3px] [&_svg]:size-10 right-[calc(0.35rem+5px)] bottom-[calc(1rem+env(safe-area-inset-bottom))]",
+            "fixed-viewport-layer fixed z-40 rounded-full h-[5rem] w-[5rem] p-6 border-b-[8px] active:translate-y-[5px] active:border-b-[3px] [&_svg]:size-10 right-[calc(0.35rem+5px)] bottom-[calc(1rem+env(safe-area-inset-bottom))]",
             hasBgMeaning && "border-foreground/40"
           )}
           aria-label="Open practice menu"

--- a/src/components/site-layout/index.tsx
+++ b/src/components/site-layout/index.tsx
@@ -1,4 +1,5 @@
 import BottomBanner from "./BottomBanner";
 import Header from "./Header/Header";
+import { FloatingIsland } from "./FloatingIsland";
 
-export { BottomBanner, Header };
+export { BottomBanner, Header, FloatingIsland };

--- a/src/components/site-layout/index.tsx
+++ b/src/components/site-layout/index.tsx
@@ -1,5 +1,6 @@
 import BottomBanner from "./BottomBanner";
 import Header from "./Header/Header";
 import { FloatingIsland } from "./FloatingIsland";
+import { PracticeFab } from "./PracticeFab";
 
-export { BottomBanner, Header, FloatingIsland };
+export { BottomBanner, Header, FloatingIsland, PracticeFab };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -19,7 +19,10 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className={`h-full w-full flex-1 bg-primary transition-all rounded-full ${primitiveCn}`}
+      className={cn(
+        "h-full w-full flex-1 transition-all rounded-full",
+        primitiveCn ?? "bg-primary"
+      )}
       style={{
         transform: `translateX(-${100 - (value || 0)}%)`,
         ...primitiveStyle,

--- a/src/hooks/use-activity-data.ts
+++ b/src/hooks/use-activity-data.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import {
+  ACTIVITY_ALL_TIME_KEY,
+  ACTIVITY_BY_DAY_KEY,
+  ActivityByDay,
+  AllTimeActivity,
+  countAllDaysActive,
+  readActivityByDay,
+  readAllTimeActivity,
+} from "@/lib/activity";
+
+const readSnapshot = () => ({
+  allTime: readAllTimeActivity(),
+  byDay: readActivityByDay(),
+  daysActive: countAllDaysActive(readActivityByDay()),
+});
+
+/**
+ * Reactive all-time + by-day activity. Re-reads on storage events for the
+ * activity keys (same-tab via notifyStorage, cross-tab via the browser).
+ */
+export const useActivityData = () => {
+  const [data, setData] = useState(() => readSnapshot());
+
+  useEffect(() => {
+    const refresh = () => setData(readSnapshot());
+    refresh();
+
+    const onStorage = (e: StorageEvent) => {
+      if (
+        e.key === ACTIVITY_ALL_TIME_KEY ||
+        e.key === ACTIVITY_BY_DAY_KEY ||
+        e.key == null
+      ) {
+        refresh();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return data as {
+    allTime: AllTimeActivity;
+    byDay: ActivityByDay;
+    daysActive: number;
+  };
+};

--- a/src/hooks/use-bookmarked-kanji.ts
+++ b/src/hooks/use-bookmarked-kanji.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { BOOKMARK_KEY_PREFIX } from "@/lib/bookmarks";
+
+/** Parse `b:{kanji}:{word}` → kanji character, or null if malformed. */
+export const kanjiFromBookmarkKey = (key: string): string | null => {
+  if (!key.startsWith(BOOKMARK_KEY_PREFIX)) return null;
+  const rest = key.slice(BOOKMARK_KEY_PREFIX.length);
+  const colon = rest.indexOf(":");
+  if (colon <= 0) return null;
+  return rest.slice(0, colon);
+};
+
+const readBookmarkedKanji = (): string[] => {
+  const kanji: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key?.startsWith(BOOKMARK_KEY_PREFIX)) continue;
+    if (localStorage.getItem(key) !== "true") continue;
+    const k = kanjiFromBookmarkKey(key);
+    if (k) kanji.push(k);
+  }
+  return kanji;
+};
+
+/** Reactive list of bookmarked kanji (1:1 with representative words). */
+export const useBookmarkedKanji = () => {
+  const [kanji, setKanji] = useState<string[]>(() => readBookmarkedKanji());
+
+  useEffect(() => {
+    const refresh = () => setKanji(readBookmarkedKanji());
+    refresh();
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key?.startsWith(BOOKMARK_KEY_PREFIX) || e.key == null) {
+        refresh();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return kanji;
+};

--- a/src/hooks/use-scroll-lock-fade-tick.ts
+++ b/src/hooks/use-scroll-lock-fade-tick.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from "react";
+
+/** True when radix/remove-scroll has locked the body (modals, selects, etc.). */
+const isBodyScrollLocked = () => {
+  const { body } = document;
+  return (
+    body.style.overflow === "hidden" ||
+    body.style.paddingRight !== "" ||
+    body.hasAttribute("data-scroll-locked") ||
+    getComputedStyle(body)
+      .getPropertyValue("--removed-body-scroll-bar-size")
+      .trim() !== ""
+  );
+};
+
+/** Bumps whenever scroll-lock toggles so fixed UI can fade instead of hard-jumping. */
+export const useScrollLockFadeTick = () => {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    let prev = isBodyScrollLocked();
+
+    const onChange = () => {
+      const next = isBodyScrollLocked();
+      if (next === prev) return;
+      prev = next;
+      setTick((n) => n + 1);
+    };
+
+    const observer = new MutationObserver(onChange);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["style", "class", "data-scroll-locked"],
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["style", "class"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return tick;
+};
+
+const SETTLE_CN = "animate-scroll-lock-settle";
+
+/** Ref that restarts a soft fade whenever body scroll-lock toggles. */
+export const useScrollLockSettleRef = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null);
+  const fadeTick = useScrollLockFadeTick();
+
+  useEffect(() => {
+    if (fadeTick === 0) return;
+    const el = ref.current;
+    if (!el) return;
+    el.classList.remove(SETTLE_CN);
+    // Force reflow so the animation can restart.
+    void el.offsetWidth;
+    el.classList.add(SETTLE_CN);
+  }, [fadeTick]);
+
+  return ref;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -250,12 +250,12 @@ button {
   animation: practice-cheer-bloom 1.35s ease-out both;
 }
 
-/* Soft settle when scroll-lock shifts the practice FAB */
-.animate-practice-fab-settle {
-  animation: practice-fab-settle 0.85s ease-out both;
+/* Soft settle when scroll-lock shifts fixed UI (FAB, island, etc.) */
+.animate-scroll-lock-settle {
+  animation: scroll-lock-settle 0.85s ease-out both;
 }
 
-@keyframes practice-fab-settle {
+@keyframes scroll-lock-settle {
   from {
     opacity: 0;
   }

--- a/src/index.css
+++ b/src/index.css
@@ -175,8 +175,10 @@ button {
  * iOS standalone PWAs can paint fixed elements at stale scroll coordinates.
  * A dedicated compositor layer keeps persistent viewport UI visually pinned.
  */
-.fixed-viewport-layer {
-  transform: translateZ(0);
+@media (display-mode: standalone) {
+  .fixed-viewport-layer {
+    transform: translateZ(0);
+  }
 }
 
 .animate-fade-in {

--- a/src/index.css
+++ b/src/index.css
@@ -171,6 +171,14 @@ button {
   padding-left: var(--removed-body-scroll-bar-size);
 }
 
+/*
+ * iOS standalone PWAs can paint fixed elements at stale scroll coordinates.
+ * A dedicated compositor layer keeps persistent viewport UI visually pinned.
+ */
+.fixed-viewport-layer {
+  transform: translateZ(0);
+}
+
 .animate-fade-in {
   animation: fade-in 0.5s ease-out;
 }

--- a/src/lib/activity/cpm-band.ts
+++ b/src/lib/activity/cpm-band.ts
@@ -1,0 +1,30 @@
+import type { FreqCategory } from "@/lib/freq/freq-category";
+
+/** Map qualified CPM to opacity band 0–4 (0 = never qualified). */
+export const cpmToBand = (
+  bestCpmWithAccuracyOver70: number | null | undefined
+): FreqCategory => {
+  const cpm = bestCpmWithAccuracyOver70 ?? 0;
+  if (cpm <= 0) return 0;
+  if (cpm < 30) return 1;
+  if (cpm < 70) return 2;
+  if (cpm < 120) return 3;
+  return 4;
+};
+
+export const CPM_BAND_LABELS: Record<FreqCategory, string> = {
+  0: "Not attempted",
+  1: ">0–29 CPM",
+  2: "30–69 CPM",
+  3: "70–119 CPM",
+  4: "120+ CPM",
+};
+
+/** Count of challenges per CPM band (bands 0–4). */
+export const countBands = (bands: FreqCategory[]): number[] => {
+  const counts = [0, 0, 0, 0, 0];
+  for (const band of bands) {
+    counts[band] += 1;
+  }
+  return counts;
+};

--- a/src/lib/activity/dates.ts
+++ b/src/lib/activity/dates.ts
@@ -1,0 +1,179 @@
+import type { DateRange, DurationOption } from "./types";
+
+/** Local calendar date as YYYY-MM-DD. */
+export const toLocalDateKey = (date: Date = new Date()): string => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+};
+
+/** Parse YYYY-MM-DD as a local midnight Date. */
+export const parseLocalDateKey = (key: string): Date => {
+  const [y, m, d] = key.split("-").map(Number);
+  return new Date(y, m - 1, d);
+};
+
+export const addDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+export const compareDateKeys = (a: string, b: string): number =>
+  a < b ? -1 : a > b ? 1 : 0;
+
+export const isDateKeyInRange = (key: string, range: DateRange): boolean =>
+  key >= range.start && key <= range.end;
+
+export const getDurationRange = (
+  option: DurationOption,
+  today: Date = new Date()
+): DateRange => {
+  if (option.type === "year") {
+    return {
+      start: `${option.year}-01-01`,
+      end: `${option.year}-12-31`,
+    };
+  }
+  const end = toLocalDateKey(today);
+  const startDate = addDays(today, -364);
+  return { start: toLocalDateKey(startDate), end };
+};
+
+/** Older → newer periods for the duration picker (prev/next do not wrap). */
+export const getDurationOptions = (
+  today: Date = new Date()
+): DurationOption[] => {
+  const year = today.getFullYear();
+  return [
+    { type: "year", year: year - 1 },
+    { type: "year", year },
+    { type: "last365" },
+  ];
+};
+
+const sameDurationOption = (a: DurationOption, b: DurationOption): boolean => {
+  if (a.type === "last365" && b.type === "last365") return true;
+  if (a.type === "year" && b.type === "year") return a.year === b.year;
+  return false;
+};
+
+const durationOptionIndex = (
+  option: DurationOption,
+  today: Date = new Date()
+): number => {
+  const index = getDurationOptions(today).findIndex((opt) =>
+    sameDurationOption(opt, option)
+  );
+  return Math.max(0, index);
+};
+
+export const canGoPrevDuration = (
+  option: DurationOption,
+  today: Date = new Date()
+): boolean => durationOptionIndex(option, today) > 0;
+
+export const canGoNextDuration = (
+  option: DurationOption,
+  today: Date = new Date()
+): boolean => {
+  const options = getDurationOptions(today);
+  return durationOptionIndex(option, today) < options.length - 1;
+};
+
+/** Move one step older (-1) or newer (1). Returns null at the ends. */
+export const shiftDuration = (
+  option: DurationOption,
+  delta: -1 | 1,
+  today: Date = new Date()
+): DurationOption | null => {
+  const options = getDurationOptions(today);
+  const next = durationOptionIndex(option, today) + delta;
+  if (next < 0 || next >= options.length) return null;
+  return options[next];
+};
+
+export const durationOptionLabel = (option: DurationOption): string => {
+  if (option.type === "last365") return "Last 365 days";
+  return String(option.year);
+};
+
+export const durationOptionKey = (option: DurationOption): string => {
+  if (option.type === "last365") return "last365";
+  return `year-${option.year}`;
+};
+
+export const parseDurationOptionKey = (key: string): DurationOption => {
+  if (key === "last365") return { type: "last365" };
+  const year = Number(key.replace("year-", ""));
+  return {
+    type: "year",
+    year: Number.isFinite(year) ? year : new Date().getFullYear(),
+  };
+};
+
+/** Format YYYY-MM-DD like "May 2, 2026". */
+export const formatCakeDay = (key: string): string => {
+  const date = parseLocalDateKey(key);
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+};
+
+/** Short date for calendar tooltips, e.g. "May 2, 2026". */
+export const formatActivityDay = (key: string): string => formatCakeDay(key);
+
+/**
+ * Build Sunday-start week columns covering `range`.
+ * Each column is 7 slots (Sun→Sat); null = outside the selected range.
+ */
+export const buildCalendarWeeks = (range: DateRange): (string | null)[][] => {
+  const start = parseLocalDateKey(range.start);
+  const end = parseLocalDateKey(range.end);
+
+  // Align to Sunday on or before start.
+  const gridStart = addDays(start, -start.getDay());
+  // Align to Saturday on or after end.
+  const gridEnd = addDays(end, 6 - end.getDay());
+
+  const weeks: (string | null)[][] = [];
+  let cursor = gridStart;
+
+  while (cursor <= gridEnd) {
+    const week: (string | null)[] = [];
+    for (let i = 0; i < 7; i++) {
+      const key = toLocalDateKey(cursor);
+      week.push(isDateKeyInRange(key, range) ? key : null);
+      cursor = addDays(cursor, 1);
+    }
+    weeks.push(week);
+  }
+
+  return weeks;
+};
+
+/** Month label positions for calendar header (week index → single letter). */
+export const monthLabelsForWeeks = (
+  weeks: (string | null)[][]
+): { weekIndex: number; label: string }[] => {
+  const labels: { weekIndex: number; label: string }[] = [];
+  let lastMonth = -1;
+
+  weeks.forEach((week, weekIndex) => {
+    const firstInRange = week.find((d) => d != null);
+    if (!firstInRange) return;
+    const date = parseLocalDateKey(firstInRange);
+    const month = date.getMonth();
+    if (month !== lastMonth) {
+      // Cursor/GitHub-compact: single letter (J F M A M J J A S O N D)
+      const letter = date.toLocaleDateString("en-US", { month: "short" })[0];
+      labels.push({ weekIndex, label: letter });
+      lastMonth = month;
+    }
+  });
+
+  return labels;
+};

--- a/src/lib/activity/index.ts
+++ b/src/lib/activity/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./dates";
+export * from "./storage";
+export * from "./queries";
+export * from "./cpm-band";

--- a/src/lib/activity/queries.ts
+++ b/src/lib/activity/queries.ts
@@ -1,0 +1,110 @@
+import type { FreqCategory } from "@/lib/freq/freq-category";
+import { isDateKeyInRange } from "./dates";
+import {
+  ActivityByDay,
+  ActivityKind,
+  ActivityKindFilters,
+  ALL_ACTIVITY_KINDS,
+  DateRange,
+  DayCounts,
+  EMPTY_DAY_COUNTS,
+  WindowedActivityStats,
+} from "./types";
+
+export const dayTotalForFilters = (
+  day: DayCounts | undefined,
+  filters: ActivityKindFilters
+): number => {
+  if (!day) return 0;
+  let total = 0;
+  for (const kind of ALL_ACTIVITY_KINDS) {
+    if (filters[kind]) total += day[kind] ?? 0;
+  }
+  return total;
+};
+
+export const summarizeActivityInRange = (
+  byDay: ActivityByDay,
+  range: DateRange,
+  filters: ActivityKindFilters
+): WindowedActivityStats => {
+  let daysActive = 0;
+  let speedKatakanaSessions = 0;
+  let productionRounds = 0;
+  let recognitionRounds = 0;
+
+  for (const [key, day] of Object.entries(byDay)) {
+    if (!isDateKeyInRange(key, range)) continue;
+
+    if (filters.speedKatakana) {
+      speedKatakanaSessions += day.speedKatakana ?? 0;
+    }
+    if (filters.production) {
+      productionRounds += day.production ?? 0;
+    }
+    if (filters.recognition) {
+      recognitionRounds += day.recognition ?? 0;
+    }
+
+    if (dayTotalForFilters(day, filters) > 0) daysActive += 1;
+  }
+
+  return {
+    daysActive,
+    speedKatakanaSessions,
+    productionRounds,
+    recognitionRounds,
+  };
+};
+
+/** Distinct days with any activity (all kinds), for all-time overview. */
+export const countAllDaysActive = (byDay: ActivityByDay): number => {
+  let n = 0;
+  for (const day of Object.values(byDay)) {
+    if (
+      (day.speedKatakana ?? 0) +
+        (day.production ?? 0) +
+        (day.recognition ?? 0) >
+      0
+    ) {
+      n += 1;
+    }
+  }
+  return n;
+};
+
+export const maxDayTotalInRange = (
+  byDay: ActivityByDay,
+  range: DateRange,
+  filters: ActivityKindFilters
+): number => {
+  let max = 0;
+  for (const [key, day] of Object.entries(byDay)) {
+    if (!isDateKeyInRange(key, range)) continue;
+    max = Math.max(max, dayTotalForFilters(day, filters));
+  }
+  return max;
+};
+
+const INTENSITY_FLOOR = 4;
+
+/**
+ * GitHub-like relative intensity. Floors maxN so a lone single-event day
+ * is not always painted at maximum brightness.
+ */
+export const getActivityLevel = (n: number, maxN: number): FreqCategory => {
+  if (n <= 0) return 0;
+  const scale = Math.max(maxN, INTENSITY_FLOOR);
+  if (n <= scale * 0.25) return 1;
+  if (n <= scale * 0.5) return 2;
+  if (n <= scale * 0.75) return 3;
+  return 4;
+};
+
+export const getDayCounts = (
+  byDay: ActivityByDay,
+  dateKey: string
+): DayCounts => byDay[dateKey] ?? EMPTY_DAY_COUNTS;
+
+export const enabledKinds = (filters: ActivityKindFilters): ActivityKind[] =>
+  ALL_ACTIVITY_KINDS.filter((k) => filters[k]);

--- a/src/lib/activity/storage.ts
+++ b/src/lib/activity/storage.ts
@@ -1,0 +1,62 @@
+import { notifyStorage, safeReadJson } from "@/lib/storage";
+import {
+  ActivityByDay,
+  ActivityKind,
+  AllTimeActivity,
+  DayCounts,
+  EMPTY_ALL_TIME,
+  EMPTY_DAY_COUNTS,
+} from "./types";
+import { toLocalDateKey } from "./dates";
+
+export const ACTIVITY_ALL_TIME_KEY = "activity-all-time";
+export const ACTIVITY_BY_DAY_KEY = "activity-by-day";
+
+const kindToAllTimeField: Record<
+  ActivityKind,
+  keyof Omit<AllTimeActivity, "cakeDay">
+> = {
+  speedKatakana: "speedKatakanaSessions",
+  production: "productionRounds",
+  recognition: "recognitionRounds",
+};
+
+export const readAllTimeActivity = (): AllTimeActivity =>
+  safeReadJson(ACTIVITY_ALL_TIME_KEY, EMPTY_ALL_TIME);
+
+export const readActivityByDay = (): ActivityByDay =>
+  safeReadJson(ACTIVITY_BY_DAY_KEY, {});
+
+const writeJson = (key: string, value: unknown) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+    notifyStorage(key);
+  } catch {
+    // ignore storage write failures (e.g. private mode quota)
+  }
+};
+
+/** Record one finished game event for today (local date). */
+export const recordActivity = (
+  kind: ActivityKind,
+  at: Date = new Date()
+): void => {
+  const dateKey = toLocalDateKey(at);
+
+  const allTime = readAllTimeActivity();
+  const field = kindToAllTimeField[kind];
+  const nextAllTime: AllTimeActivity = {
+    ...allTime,
+    cakeDay: allTime.cakeDay ?? dateKey,
+    [field]: (allTime[field] ?? 0) + 1,
+  };
+  writeJson(ACTIVITY_ALL_TIME_KEY, nextAllTime);
+
+  const byDay = readActivityByDay();
+  const prevDay: DayCounts = byDay[dateKey] ?? { ...EMPTY_DAY_COUNTS };
+  byDay[dateKey] = {
+    ...prevDay,
+    [kind]: (prevDay[kind] ?? 0) + 1,
+  };
+  writeJson(ACTIVITY_BY_DAY_KEY, byDay);
+};

--- a/src/lib/activity/types.ts
+++ b/src/lib/activity/types.ts
@@ -1,0 +1,67 @@
+export type ActivityKind = "speedKatakana" | "production" | "recognition";
+
+export type AllTimeActivity = {
+  /** YYYY-MM-DD of first recorded event (local). */
+  cakeDay: string | null;
+  speedKatakanaSessions: number;
+  productionRounds: number;
+  recognitionRounds: number;
+};
+
+export type DayCounts = {
+  speedKatakana: number;
+  production: number;
+  recognition: number;
+};
+
+/** Map of local YYYY-MM-DD → per-kind event counts. */
+export type ActivityByDay = Record<string, DayCounts>;
+
+export type DateRange = {
+  start: string; // inclusive YYYY-MM-DD
+  end: string; // inclusive YYYY-MM-DD
+};
+
+export type DurationOption =
+  | { type: "last365" }
+  | { type: "year"; year: number };
+
+export type ActivityKindFilters = Record<ActivityKind, boolean>;
+
+export type WindowedActivityStats = {
+  daysActive: number;
+  speedKatakanaSessions: number;
+  productionRounds: number;
+  recognitionRounds: number;
+};
+
+export const EMPTY_DAY_COUNTS: DayCounts = {
+  speedKatakana: 0,
+  production: 0,
+  recognition: 0,
+};
+
+export const EMPTY_ALL_TIME: AllTimeActivity = {
+  cakeDay: null,
+  speedKatakanaSessions: 0,
+  productionRounds: 0,
+  recognitionRounds: 0,
+};
+
+export const DEFAULT_KIND_FILTERS: ActivityKindFilters = {
+  speedKatakana: true,
+  production: true,
+  recognition: true,
+};
+
+export const ACTIVITY_KIND_LABELS: Record<ActivityKind, string> = {
+  speedKatakana: "Speed Katakana",
+  production: "Kanji Production",
+  recognition: "Kanji Recognition",
+};
+
+export const ALL_ACTIVITY_KINDS: ActivityKind[] = [
+  "speedKatakana",
+  "production",
+  "recognition",
+];

--- a/src/lib/activity/types.ts
+++ b/src/lib/activity/types.ts
@@ -1,3 +1,9 @@
+import {
+  productionPracticePageMeta,
+  recognitionPracticePageMeta,
+  speedKatakanaPageMeta,
+} from "@/components/items/practice-pages";
+
 export type ActivityKind = "speedKatakana" | "production" | "recognition";
 
 export type AllTimeActivity = {
@@ -55,9 +61,9 @@ export const DEFAULT_KIND_FILTERS: ActivityKindFilters = {
 };
 
 export const ACTIVITY_KIND_LABELS: Record<ActivityKind, string> = {
-  speedKatakana: "Speed Katakana",
-  production: "Kanji Production",
-  recognition: "Kanji Recognition",
+  speedKatakana: speedKatakanaPageMeta.shortLabel,
+  production: productionPracticePageMeta.shortLabel,
+  recognition: recognitionPracticePageMeta.shortLabel,
 };
 
 export const ALL_ACTIVITY_KINDS: ActivityKind[] = [

--- a/src/lib/cn-fns.ts
+++ b/src/lib/cn-fns.ts
@@ -40,3 +40,27 @@ export const randomCn = () => {
 export const randomCn2 = () => {
   return `${cnNormal()}  background-theme-color-with-opacity-100 ${SMALL_TILE_CN}`;
 };
+
+const ALT_BORDER_CN = [
+  "border-theme-color-with-opacity-25",
+  "border-theme-color-with-opacity-50",
+  "border-theme-color-with-opacity-75",
+] as const;
+
+const ALT_BIG_TILE_CN = "!border-8 !rounded-xl motion-reduce:transition-none";
+const ALT_SMALL_TILE_CN = "!border-4 !rounded-lg motion-reduce:transition-none";
+
+const cnGradientAlt = () => {
+  // Skip 0/100 so tiles stay mid-opacity — pulse reads on every tile.
+  const bg = freqCategoryCn[selectRandom([1, 2, 3] as const)] ?? 0;
+  const border = selectRandom([...ALT_BORDER_CN]);
+  return `${bg} ${border}`;
+};
+
+export const randomCnGradientAlt = () => {
+  return `${cnGradientAlt()} ${ALT_BIG_TILE_CN}`;
+};
+
+export const randomCn2GradientAlt = () => {
+  return `${cnGradientAlt()} ${ALT_SMALL_TILE_CN}`;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- promote persistent fixed viewport controls to dedicated compositor layers in standalone PWA mode only
- cover the header, search/control bar, floating navigation island, and practice FAB
- leave regular Safari/Chrome rendering unchanged
- retain the existing document scrolling model and safe-area positioning

## Context
Recent iOS standalone PWA versions can paint `position: fixed` elements at stale scroll coordinates. A `translateZ(0)` compositor layer keeps those controls visually pinned without changing document scrolling or viewport sizing. The workaround is gated by `@media (display-mode: standalone)`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c73-124d-77ca-a238-62a6f9a35670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c73-124d-77ca-a238-62a6f9a35670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

