### PR TITLE
Fix fixed-position chrome drifting while scrolling in iOS PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,10 +45,11 @@
       property="twitter:image"
       content="https://kanjiheatmap.com/img/social-preview.png"
     />
+    <!-- `viewport-fit=cover` must live inside `content`; as a separate HTML
+         attribute it is ignored and env(safe-area-inset-*) resolves to 0. -->
     <meta
       name="viewport"
-      viewport-fit="cover"
-      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <title>Kanji Heatmap</title>
     <style>

--- a/src/components/screens/ListScreen/KanjiList/VirtualKanjiList.tsx
+++ b/src/components/screens/ListScreen/KanjiList/VirtualKanjiList.tsx
@@ -1,7 +1,55 @@
-import { WindowVirtualizer } from "virtua";
-import React, { useState } from "react";
+import { Virtualizer, WindowVirtualizer } from "virtua";
+import React, { ReactNode, useLayoutEffect, useRef, useState } from "react";
 import { HoverKanji } from "@/components/sections/KanjiHoverItem";
 import { useVirtualListDims } from "./useVirtualDims";
+
+/**
+ * In installed PWAs the <body> is the scroll container instead of the window
+ * (see the `display-mode: standalone` rules in index.css that work around iOS
+ * standalone fixed-position drift), so window-based virtualization would never
+ * see any scrolling there. Display mode cannot change within a session, so a
+ * one-time check is enough. Must stay in sync with the media query gating the
+ * CSS scroller switch.
+ */
+const isStandaloneDisplay =
+  typeof window !== "undefined" &&
+  window.matchMedia("(display-mode: standalone)").matches;
+
+/** Virtualizes against the <body> scroller used in standalone display mode. */
+const BodyScrollVirtualizer = ({ children }: { children: ReactNode }) => {
+  const scrollRef = useRef<HTMLElement | null>(null);
+  const outerRef = useRef<HTMLDivElement>(null);
+  const [startMargin, setStartMargin] = useState(0);
+
+  useLayoutEffect(() => {
+    scrollRef.current = document.body;
+    const outer = outerRef.current;
+    if (!outer) return;
+    // Distance from the top of the body's scrollable content to the
+    // virtualizer (e.g. the pt-24 clearing the fixed header + control bar).
+    setStartMargin(
+      Math.max(
+        0,
+        Math.round(outer.getBoundingClientRect().top + document.body.scrollTop)
+      )
+    );
+  }, []);
+
+  return (
+    <div ref={outerRef}>
+      <Virtualizer scrollRef={scrollRef} startMargin={startMargin}>
+        {children}
+      </Virtualizer>
+    </div>
+  );
+};
+
+const ListVirtualizer = ({ children }: { children: ReactNode }) =>
+  isStandaloneDisplay ? (
+    <BodyScrollVirtualizer>{children}</BodyScrollVirtualizer>
+  ) : (
+    <WindowVirtualizer>{children}</WindowVirtualizer>
+  );
 
 const KanjiListRaw = ({
   kanjiKeys = [],
@@ -15,7 +63,7 @@ const KanjiListRaw = ({
 
   return (
     <div className="w-full animate-fade-in">
-      <WindowVirtualizer>
+      <ListVirtualizer>
         {Array.from({ length: rows }).map((_, rowIndex) => {
           const isNotLast = rowIndex < rows - 1;
           const hasCompleteRows = isNotLast || kanjiKeys.length % cols === 0;
@@ -40,7 +88,7 @@ const KanjiListRaw = ({
             </div>
           );
         })}
-      </WindowVirtualizer>
+      </ListVirtualizer>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -79,6 +79,30 @@ body {
   overflow-y: scroll;
 }
 
+/*
+ * Installed PWAs (iOS "Add to Home Screen" in particular): scroll the <body>
+ * instead of the document. When the document itself scrolls, iOS standalone
+ * mode drifts position:fixed/sticky chrome (header, control bar, island, FAB)
+ * away from the viewport edges while scrolling — a long-standing WebKit issue
+ * (bugs.webkit.org/show_bug.cgi?id=297779 and friends). With `overflow: hidden`
+ * on <html>, the layout viewport never moves, so fixed elements stay pinned.
+ * The usual trade-offs of this technique (no shrinking address bar, broken
+ * window.scrollTo) don't matter in standalone mode. The kanji list virtualizer
+ * follows this scroller switch — see VirtualKanjiList.tsx.
+ */
+@media (display-mode: standalone) {
+  html {
+    overflow: hidden;
+    height: 100%;
+  }
+
+  body {
+    height: 100%;
+    min-height: 100%;
+    overflow-y: auto;
+  }
+}
+
 p,
 h1,
 h2,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the installed PWA on recent iOS, everything that is `position: fixed` — the header, the search/control bar, the bottom-left island, and the practice FAB — drifts away from the viewport edges while scrolling instead of staying pinned.

This is a WebKit issue with `position: fixed`/`sticky` in iOS standalone web apps when the *document* is the scroll container (the [bug 297779](https://bugs.webkit.org/show_bug.cgi?id=297779) family — partially fixed in Safari 26.1 but still reported in standalone/home-screen apps): the layout viewport gets displaced during scroll, and every fixed element shifts with it.

## Fix

**1. Scroll the `<body>` instead of the document, only in standalone display mode** (`src/index.css`)

```css
@media (display-mode: standalone) {
  html { overflow: hidden; height: 100%; }
  body { height: 100%; min-height: 100%; overflow-y: auto; }
}
```

With `overflow: hidden` on `<html>`, the layout viewport never moves, so fixed elements stay glued to the screen edges. The known trade-offs of this technique (no shrinking address bar, `window.scrollTo` on the window no longer scrolls) don't apply in standalone mode. Browser-mode behavior is completely unchanged.

**2. Follow the scroller switch in the kanji list virtualizer** (`VirtualKanjiList.tsx`)

`WindowVirtualizer` only observes window scrolling, which no longer happens in standalone mode. When `(display-mode: standalone)` matches, the list now uses virtua's element-based `Virtualizer` with `scrollRef` pointing at `document.body` and a measured `startMargin`. All other modes keep `WindowVirtualizer` as before.

**3. Fix a malformed viewport meta tag** (`index.html`)

`viewport-fit=cover` was written as a separate HTML attribute instead of inside `content`, so it was silently ignored and `env(safe-area-inset-*)` always resolved to `0` — the island, FAB, and practice footers all position themselves with safe-area insets that never took effect on notch/home-indicator devices.

## Verification

- `pnpm run build` (eslint + tsc + vite build) passes.
- Headless Chromium at iPhone-like viewport (390×844), with `display-mode: standalone` emulated (matchMedia shim + the same CSS the media query applies):
  - Body becomes the scroller; touch-drag, mouse wheel (including over the fixed header), keyboard (PageDown), and programmatic scrolling all work.
  - The virtualized list keeps rendering rows at deep scroll offsets and back at the top; header stays at `top: 0` and the island/FAB stay at the bottom edge while scrolled.
  - The kanji drawer opens/closes normally; body scroll lock engages/releases and scroll position is preserved (3500 → 3500).
- Browser (non-standalone) mode re-tested with the same script: unchanged behavior.

Standalone emulation, scrolled ~6000px into the list — header, search bar, island, and FAB all pinned:

[Standalone mode scrolled with pinned chrome](https://cursor.com/agents/bc-019f6c73-c507-73e3-bc8f-a76955182bcb/artifacts?path=%2Ftmp%2Fpwtest%2Fstandalone-scrolled.png)

Not tested on a physical iOS device — worth a quick check in the installed PWA after deploy.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6c73-c507-73e3-bc8f-a76955182bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6c73-c507-73e3-bc8f-a76955182bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

