### PR TITLE
Polish Dashboard and Mastery pages

### DIFF
--- a/src/components/items/nav-links.ts
+++ b/src/components/items/nav-links.ts
@@ -45,8 +45,8 @@ export const dashboardPageMeta = {
 
 export const masteryPageMeta = {
   href: "/mastery",
-  title: "Mastery",
-  description: "Track mastery progress — coming soon",
+  title: "Visualize Mastery",
+  description: "See how well you know each kanji — coming soon",
 } as const;
 
 /** Practice destinations shown in the FAB menu. */

--- a/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
@@ -58,17 +58,16 @@ export const ActivityCalendarHeatmap = () => {
         <ActivityKindFiltersRow filters={filters} onChange={setKind} />
       </div>
 
-      <div className="flex items-center justify-center w-full">
-        <div>
-          <FreqGradient />
-        </div>
-      </div>
-
       <div className="mt-6">
-        <p className="mb-3 text-xs font-extrabold tracking-wide text-center uppercase text-muted-foreground">
+        <p className="mb-3 text-xs tracking-wide text-center text-muted-foreground">
           In this period
         </p>
         <ActivityCountsGrid stats={windowed} />
+      </div>
+      <div className="flex items-center justify-center w-full mt-6">
+        <div>
+          <FreqGradient />
+        </div>
       </div>
     </DashboardPanel>
   );

--- a/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
@@ -52,8 +52,9 @@ export const ActivityCalendarHeatmap = () => {
         maxN={maxN}
       />
 
-      <ActivityKindFiltersRow filters={filters} onChange={setKind} />
-
+      <div className="mt-2">
+        <ActivityKindFiltersRow filters={filters} onChange={setKind} />
+      </div>
       <div className="mt-6">
         <p className="mb-3 text-xs tracking-wide text-center text-muted-foreground">
           In this period

--- a/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
@@ -27,7 +27,7 @@ export const ActivityCalendarHeatmap = () => {
 
   const range = getDurationRange(duration);
   const weeks = buildCalendarWeeks(range);
-  const monthLabels = monthLabelsForWeeks(weeks);
+  const monthLabels = monthLabelsForWeeks(weeks, "japanese-numbers");
   const maxN = maxDayTotalInRange(byDay, range, filters);
   const windowed = summarizeActivityInRange(byDay, range, filters);
 
@@ -42,9 +42,7 @@ export const ActivityCalendarHeatmap = () => {
         description="Daily practice events. Brighter days mean more activity relative to your busiest day in this range."
       />
 
-      <div className="mb-4">
-        <DurationNav value={duration} onChange={setDuration} />
-      </div>
+      <DurationNav value={duration} onChange={setDuration} />
 
       <CalendarGrid
         weeks={weeks}
@@ -54,9 +52,7 @@ export const ActivityCalendarHeatmap = () => {
         maxN={maxN}
       />
 
-      <div className="my-5">
-        <ActivityKindFiltersRow filters={filters} onChange={setKind} />
-      </div>
+      <ActivityKindFiltersRow filters={filters} onChange={setKind} />
 
       <div className="mt-6">
         <p className="mb-3 text-xs tracking-wide text-center text-muted-foreground">

--- a/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
@@ -8,37 +8,62 @@ import { OverviewStat } from "./OverviewStat";
 
 export type ActivityCountsDisplay = {
   daysActive: number;
+  speedKatakanaDays: number;
+  productionDays: number;
+  recognitionDays: number;
   speedKatakanaSessions: number;
   productionRounds: number;
   recognitionRounds: number;
 };
 
-/** Shared 2×2 (mobile) / 4-up layout for activity counters. */
+/** Day totals (2×2 / 4-up) + session/round totals (stacked / 3-up). */
 export const ActivityCountsGrid = ({
   stats,
 }: {
   stats: ActivityCountsDisplay;
 }) => (
-  <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-3">
-    <OverviewStat
-      value={stats.daysActive}
-      label="Days active"
-      Icon={CalendarDays}
-    />
-    <OverviewStat
-      value={stats.productionRounds}
-      label={productionPracticePageMeta.shortLabel}
-      Icon={PenLine}
-    />
-    <OverviewStat
-      value={stats.recognitionRounds}
-      label={recognitionPracticePageMeta.shortLabel}
-      Icon={Eye}
-    />
-    <OverviewStat
-      value={stats.speedKatakanaSessions}
-      label={speedKatakanaPageMeta.shortLabel}
-      Icon={Keyboard}
-    />
+  <div className="flex flex-col gap-2 sm:gap-3">
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-3">
+      <OverviewStat
+        value={stats.daysActive}
+        label="Total Days"
+        Icon={CalendarDays}
+      />
+      <OverviewStat
+        value={stats.speedKatakanaDays}
+        label={`${speedKatakanaPageMeta.shortLabel} Days`}
+        Icon={Keyboard}
+      />
+      <OverviewStat
+        value={stats.productionDays}
+        label={`${productionPracticePageMeta.shortLabel} Days`}
+        Icon={PenLine}
+      />
+      <OverviewStat
+        value={stats.recognitionDays}
+        label={`${recognitionPracticePageMeta.shortLabel} Days`}
+        Icon={Eye}
+      />
+    </div>
+    <div className="grid grid-cols-3 gap-2 sm:gap-3">
+      <OverviewStat
+        value={stats.speedKatakanaSessions}
+        label={`${speedKatakanaPageMeta.shortLabel} Sessions`}
+        Icon={Keyboard}
+        compact
+      />
+      <OverviewStat
+        value={stats.productionRounds}
+        label={`${productionPracticePageMeta.shortLabel} Rounds`}
+        Icon={PenLine}
+        compact
+      />
+      <OverviewStat
+        value={stats.recognitionRounds}
+        label={`${recognitionPracticePageMeta.shortLabel} Rounds`}
+        Icon={Eye}
+        compact
+      />
+    </div>
   </div>
 );

--- a/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
@@ -19,16 +19,11 @@ export const ActivityCountsGrid = ({
 }: {
   stats: ActivityCountsDisplay;
 }) => (
-  <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4 sm:gap-3">
+  <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 sm:gap-3">
     <OverviewStat
       value={stats.daysActive}
       label="Days active"
       Icon={CalendarDays}
-    />
-    <OverviewStat
-      value={stats.speedKatakanaSessions}
-      label={speedKatakanaPageMeta.shortLabel}
-      Icon={Keyboard}
     />
     <OverviewStat
       value={stats.productionRounds}
@@ -39,6 +34,11 @@ export const ActivityCountsGrid = ({
       value={stats.recognitionRounds}
       label={recognitionPracticePageMeta.shortLabel}
       Icon={Eye}
+    />
+    <OverviewStat
+      value={stats.speedKatakanaSessions}
+      label={speedKatakanaPageMeta.shortLabel}
+      Icon={Keyboard}
     />
   </div>
 );

--- a/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
@@ -8,6 +8,7 @@ import { toSearchSettings } from "@/lib/settings/search-settings-adapter";
 import { JLPT_TYPE_ARR, JLPTListItems, JLTPTtypes } from "@/lib/jlpt";
 import { useBookmarkedKanji } from "@/hooks/use-bookmarked-kanji";
 import { Progress } from "@/components/ui/progress";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import KaomojiAnimation from "@/components/common/KaomojiLoading";
 import { SectionHeading } from "./SectionHeading";
 import { DashboardPanel } from "./DashboardPanel";
@@ -47,52 +48,52 @@ export const BookmarksBreakdown = () => {
   const loading =
     !ready || search.status === "loading" || search.status === "idle";
 
-  const totalBookmarked = bookmarked.length;
-
   return (
     <DashboardPanel>
       <SectionHeading
         title="Bookmarks"
-        description="How much of each JLPT band you've bookmarked."
+        description="How much of each JLPT band you've bookmarked.  Bookmark a word from a kanji’s detail drawer to start filling these bars."
       />
       {loading ? (
         <div className="py-8">
           <KaomojiAnimation />
         </div>
       ) : (
-        <>
-          <div className="flex flex-col gap-1 ">
+        <Table className="my-4">
+          <TableBody>
             {JLPT_TYPE_ARR.map((jlpt) => {
               const { bookmarked: n, total } = counts[jlpt];
               const pct = total > 0 ? (n / total) * 100 : 0;
               const meta = JLPTListItems[jlpt];
               return (
-                <div key={jlpt} className="flex items-center gap-2">
-                  <div className="flex items-center w-10 gap-2 text-sm font-extrabold shrink-0">
-                    <span
-                      className={`inline-block size-2.5 shrink-0 rounded-full ${meta.cn}`}
+                <TableRow key={jlpt} className="p-0 my-1 text-left">
+                  <TableCell className="p-0">
+                    <div className="flex items-center justify-between py-1 pl-2 text-xs text-left ">
+                      <span
+                        className={`h-3 w-3 inline-block ${meta.cn} rounded-full`}
+                      />
+                      <span className="mx-2 font-extrabold ">
+                        {meta.label !== "Not in JLPT" ? meta.label : "~"}
+                      </span>{" "}
+                    </div>
+                  </TableCell>
+                  <TableCell className="w-full px-0 py-2">
+                    <Progress
+                      className="h-1"
+                      value={pct}
+                      primitiveCn="background-theme-color-with-opacity-100"
                     />
-                    {meta.label !== "Not in JLPT" ? meta.label : "~"}
-                  </div>
-                  <Progress
-                    className="flex-1 h-2.5 border border-border/60"
-                    value={pct}
-                    primitiveCn={meta.cn}
-                  />
-                  <div className="w-8 text-xs font-bold text-right shrink-0 tabular-nums text-muted-foreground">
-                    {n}/{total}
-                  </div>
-                </div>
+                  </TableCell>
+                  <TableCell className="p-0 text-[10px]">
+                    <span className="inline-block w-12 -mb-0_5 grow text-end">
+                      {n} / {total}
+                    </span>
+                  </TableCell>
+                </TableRow>
               );
             })}
-          </div>
-          {totalBookmarked === 0 ? (
-            <p className="mt-5 text-sm font-semibold text-center text-muted-foreground">
-              Bookmark a word from a kanji’s detail drawer to start filling
-              these bars.
-            </p>
-          ) : null}
-        </>
+          </TableBody>
+        </Table>
       )}
     </DashboardPanel>
   );

--- a/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
@@ -59,7 +59,7 @@ export const BookmarksBreakdown = () => {
           <KaomojiAnimation />
         </div>
       ) : (
-        <Table className="my-4">
+        <Table>
           <TableBody>
             {JLPT_TYPE_ARR.map((jlpt) => {
               const { bookmarked: n, total } = counts[jlpt];

--- a/src/components/screens/DashboardScreen/CalendarGrid.tsx
+++ b/src/components/screens/DashboardScreen/CalendarGrid.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/hover-card";
 
 /** Sun→Sat; only Mon / Wed / Fri labeled (Cursor/GitHub-style). */
-const DAY_LABELS = ["", "M", "", "W", "", "F", ""] as const;
+const DAY_LABELS = ["", "月", "", "水", "", "金", ""] as const;
 
 const CELL_PX = 12;
 const GAP_PX = 3;
@@ -178,6 +178,7 @@ export const CalendarGrid = ({
             gap: GAP_PX,
           }}
         >
+          {/** TODO: When the grid is "today" */}
           {weeks.map((week, weekIndex) =>
             week.map((dateKey, dayIndex) => (
               <CalendarDayCell

--- a/src/components/screens/DashboardScreen/CalendarGrid.tsx
+++ b/src/components/screens/DashboardScreen/CalendarGrid.tsx
@@ -18,7 +18,7 @@ import {
 /** Sun→Sat; only Mon / Wed / Fri labeled (Cursor/GitHub-style). */
 const DAY_LABELS = ["", "M", "", "W", "", "F", ""] as const;
 
-const CELL_PX = 11;
+const CELL_PX = 12;
 const GAP_PX = 3;
 const EMPTY_CELL =
   "bg-muted/50 border border-border dark:bg-muted/30 dark:border-border";
@@ -95,7 +95,7 @@ const CalendarDayCell = ({ dateKey, byDay, filters, maxN }: CellProps) => {
           )}
         />
       </HoverCardTrigger>
-      <HoverCardContent className="w-52 p-3" side="top">
+      <HoverCardContent className="p-3 w-52" side="top">
         <DayDetail dateKey={dateKey} byDay={byDay} filters={filters} />
       </HoverCardContent>
     </HoverCard>
@@ -123,7 +123,7 @@ export const CalendarGrid = ({
   const weekCount = weeks.length;
 
   return (
-    <div className="overflow-x-auto pb-1 [-webkit-mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] [mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] sm:[-webkit-mask-image:none] sm:[mask-image:none]">
+    <div className="overflow-x-auto pb-4 px-1 [-webkit-mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] [mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] sm:[-webkit-mask-image:none] sm:[mask-image:none]">
       <div
         className="inline-grid"
         style={{

--- a/src/components/screens/DashboardScreen/CalendarGrid.tsx
+++ b/src/components/screens/DashboardScreen/CalendarGrid.tsx
@@ -6,6 +6,7 @@ import {
   formatActivityDay,
   getActivityLevel,
   getDayCounts,
+  toLocalDateKey,
 } from "@/lib/activity";
 import { freqCategoryCn } from "@/lib/freq/freq-category";
 import { cn } from "@/lib/utils";
@@ -20,30 +21,35 @@ const DAY_LABELS = ["", "月", "", "水", "", "金", ""] as const;
 
 const CELL_PX = 12;
 const GAP_PX = 3;
-const EMPTY_CELL =
-  "bg-muted/50 border border-border dark:bg-muted/30 dark:border-border";
+
+const TODAY_BORDER =
+  "border border-solid border-foreground dark:border-foreground";
 
 type CellProps = {
   dateKey: string | null;
   byDay: ActivityByDay;
   filters: ActivityKindFilters;
   maxN: number;
+  todayKey: string;
 };
 
 const DayDetail = ({
   dateKey,
   byDay,
   filters,
+  isToday,
 }: {
   dateKey: string;
   byDay: ActivityByDay;
   filters: ActivityKindFilters;
+  isToday: boolean;
 }) => {
   const day = getDayCounts(byDay, dateKey);
   const total = dayTotalForFilters(day, filters);
 
   return (
     <div className="space-y-1.5 text-xs">
+      {isToday ? <div className="font-extrabold">Today</div> : null}
       <div className="font-extrabold">{formatActivityDay(dateKey)}</div>
       <div className="text-muted-foreground">
         {total === 0
@@ -62,22 +68,34 @@ const DayDetail = ({
   );
 };
 
-const CalendarDayCell = ({ dateKey, byDay, filters, maxN }: CellProps) => {
+const CalendarDayCell = ({
+  dateKey,
+  byDay,
+  filters,
+  maxN,
+  todayKey,
+}: CellProps) => {
   if (dateKey == null) {
     return <div aria-hidden style={{ width: CELL_PX, height: CELL_PX }} />;
   }
 
+  const isToday = dateKey === todayKey;
   const n = dayTotalForFilters(getDayCounts(byDay, dateKey), filters);
   const level = getActivityLevel(n, maxN);
   const fillCn =
     level === 0
-      ? EMPTY_CELL
+      ? cn(
+          "bg-muted/50 dark:bg-muted/30",
+          isToday ? TODAY_BORDER : "border border-border dark:border-border"
+        )
       : cn(
           freqCategoryCn[level],
-          "border border-black/10 dark:border-white/10"
+          isToday ? TODAY_BORDER : "border border-black/10 dark:border-white/10"
         );
 
-  const label = `${formatActivityDay(dateKey)}: ${n} events`;
+  const label = isToday
+    ? `Today, ${formatActivityDay(dateKey)}: ${n} events`
+    : `${formatActivityDay(dateKey)}: ${n} events`;
 
   return (
     <HoverCard openDelay={200} closeDelay={100}>
@@ -96,7 +114,12 @@ const CalendarDayCell = ({ dateKey, byDay, filters, maxN }: CellProps) => {
         />
       </HoverCardTrigger>
       <HoverCardContent className="p-3 w-52" side="top">
-        <DayDetail dateKey={dateKey} byDay={byDay} filters={filters} />
+        <DayDetail
+          dateKey={dateKey}
+          byDay={byDay}
+          filters={filters}
+          isToday={isToday}
+        />
       </HoverCardContent>
     </HoverCard>
   );
@@ -121,9 +144,10 @@ export const CalendarGrid = ({
 }) => {
   const labelByWeek = new Map(monthLabels.map((m) => [m.weekIndex, m.label]));
   const weekCount = weeks.length;
+  const todayKey = toLocalDateKey();
 
   return (
-    <div className="overflow-x-auto pb-4 px-1 [-webkit-mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] [mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] sm:[-webkit-mask-image:none] sm:[mask-image:none]">
+    <div className="overflow-x-auto pb-2 mb-4 px-1 [-webkit-mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] [mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] sm:[-webkit-mask-image:none] sm:[mask-image:none]">
       <div
         className="inline-grid"
         style={{
@@ -178,7 +202,6 @@ export const CalendarGrid = ({
             gap: GAP_PX,
           }}
         >
-          {/** TODO: When the grid is "today" */}
           {weeks.map((week, weekIndex) =>
             week.map((dateKey, dayIndex) => (
               <CalendarDayCell
@@ -187,6 +210,7 @@ export const CalendarGrid = ({
                 byDay={byDay}
                 filters={filters}
                 maxN={maxN}
+                todayKey={todayKey}
               />
             ))
           )}

--- a/src/components/screens/DashboardScreen/DashboardScreen.tsx
+++ b/src/components/screens/DashboardScreen/DashboardScreen.tsx
@@ -2,7 +2,7 @@ import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
 import { BottomBar } from "@/components/common/BottomBar";
 import { StatsOverview } from "./StatsOverview";
 import { ActivityCalendarHeatmap } from "./ActivityCalendarHeatmap";
-import { SpeedKatakanaBreakdown } from "./SpeedKatakanaBreakdown";
+import { SpeedKatakanaHeatmap } from "./SpeedKatakanaHeatmap";
 import { BookmarksBreakdown } from "./BookmarksBreakdown";
 
 const showTitle = false;
@@ -26,7 +26,7 @@ const DashboardScreen = () => {
       <StatsOverview />
       <ActivityCalendarHeatmap />
       <BookmarksBreakdown />
-      <SpeedKatakanaBreakdown />
+      <SpeedKatakanaHeatmap />
       <div className="pt-4 mt-4 border-t-2 border-dotted">
         <BottomBar justify="center" />
       </div>

--- a/src/components/screens/DashboardScreen/DashboardScreen.tsx
+++ b/src/components/screens/DashboardScreen/DashboardScreen.tsx
@@ -25,8 +25,8 @@ const DashboardScreen = () => {
 
       <StatsOverview />
       <ActivityCalendarHeatmap />
-      <BookmarksBreakdown />
       <SpeedKatakanaHeatmap />
+      <BookmarksBreakdown />
       <div className="pt-4 mt-4 border-t-2 border-dotted">
         <BottomBar justify="center" />
       </div>

--- a/src/components/screens/DashboardScreen/OverviewStat.tsx
+++ b/src/components/screens/DashboardScreen/OverviewStat.tsx
@@ -62,13 +62,17 @@ const StatValue = ({
   display,
   raw,
   abbreviated,
+  className,
 }: {
   display: string;
   raw: string;
   abbreviated: boolean;
+  className?: string;
 }) => {
-  const valueClassName =
-    "text-sm font-extrabold leading-none tabular-nums sm:text-base";
+  const valueClassName = cn(
+    "text-sm font-extrabold leading-none tabular-nums sm:text-base",
+    className
+  );
 
   if (!abbreviated) {
     return <div className={valueClassName}>{display}</div>;
@@ -106,11 +110,14 @@ export const OverviewStat = ({
   label,
   Icon,
   className,
+  /** Tighter 3-up cells: hide icon on small screens, show from `sm` up. */
+  compact = false,
 }: {
   value: number | string;
   label: string;
   Icon: LucideIcon;
   className?: string;
+  compact?: boolean;
 }) => {
   const isNumber = typeof value === "number";
   const raw = isNumber ? formatRawCount(value) : value;
@@ -120,16 +127,28 @@ export const OverviewStat = ({
   return (
     <div
       className={cn(
-        "flex min-w-0 items-center gap-2 rounded-2xl border border-foreground/10 bg-muted/20 px-2.5 py-2.5 text-left sm:gap-3 sm:px-3 sm:py-3",
+        "flex h-full min-w-0 items-start gap-2 rounded-2xl border border-foreground/10 bg-muted/20 px-2.5 py-2.5 text-left sm:gap-3 sm:px-3 sm:py-3",
+        compact &&
+          "flex-col items-center gap-1 px-2 text-center sm:flex-row sm:items-start sm:gap-3 sm:text-left",
         className
       )}
     >
-      <div className="flex items-center justify-center border size-8 shrink-0 rounded-xl border-foreground/10 bg-background text-foreground/70 sm:size-9">
+      <div
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-xl border border-foreground/10 bg-background text-foreground/70 sm:size-9",
+          compact && "hidden sm:flex"
+        )}
+      >
         <Icon className="size-3.5 sm:size-4" aria-hidden />
       </div>
-      <div className="min-w-0">
+      <div
+        className={cn(
+          "min-w-0",
+          compact && "flex w-full flex-col items-center sm:items-start"
+        )}
+      >
         <StatValue display={display} raw={raw} abbreviated={abbreviated} />
-        <div className="mt-0.5 text-[10px] font-bold uppercase leading-tight tracking-wide text-muted-foreground sm:mt-1 sm:text-[11px]">
+        <div className="mt-0.5 text-[10px] font-bold uppercase leading-snug tracking-wide text-muted-foreground sm:mt-1 sm:text-[11px]">
           {label}
         </div>
       </div>

--- a/src/components/screens/DashboardScreen/OverviewStat.tsx
+++ b/src/components/screens/DashboardScreen/OverviewStat.tsx
@@ -1,5 +1,31 @@
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+
+/** Full count with grouping separators, e.g. 7434 → "7,434". */
+const formatRawCount = (n: number) => n.toLocaleString("en-US");
+
+/**
+ * Abbreviated counts for tight layouts:
+ * 7434 → "~7.4k", 10100 → "~10.1k", 101234 → "~101k".
+ * Values under 1000 stay as the raw locale string.
+ */
+const formatCompactCount = (n: number) => {
+  if (n < 1000) return formatRawCount(n);
+
+  const thousands = n / 1000;
+  if (n >= 100_000) {
+    return `~${Math.round(thousands)}k`;
+  }
+
+  const rounded = Math.round(thousands * 10) / 10;
+  const body = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+  return `~${body}k`;
+};
 
 export const OverviewStat0 = ({
   value,
@@ -32,6 +58,49 @@ export const OverviewStat0 = ({
   </div>
 );
 
+const StatValue = ({
+  display,
+  raw,
+  abbreviated,
+}: {
+  display: string;
+  raw: string;
+  abbreviated: boolean;
+}) => {
+  const valueClassName =
+    "text-sm font-extrabold leading-none tabular-nums sm:text-base";
+
+  if (!abbreviated) {
+    return <div className={valueClassName}>{display}</div>;
+  }
+
+  return (
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            valueClassName,
+            "cursor-help rounded-sm outline-none",
+            "underline decoration-dotted decoration-foreground/30 underline-offset-2",
+            "hover:decoration-foreground/60",
+            "focus-visible:ring-2 focus-visible:ring-ring"
+          )}
+          aria-label={`${raw} (${display})`}
+        >
+          {display}
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="top"
+        className="w-auto px-3 py-1.5 text-sm font-extrabold tabular-nums"
+      >
+        {raw}
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
 export const OverviewStat = ({
   value,
   label,
@@ -42,23 +111,28 @@ export const OverviewStat = ({
   label: string;
   Icon: LucideIcon;
   className?: string;
-}) => (
-  <div
-    className={cn(
-      "flex items-center gap-3 rounded-2xl border-1  bg-muted/20  px-3 py-3 text-left",
-      className
-    )}
-  >
-    <div className="flex items-center justify-center size-9 shrink-0 rounded-xl border-foreground/10 bg-background text-foreground/70">
-      <Icon className="size-4" aria-hidden />
-    </div>
-    <div className="min-w-0">
-      <div className="text-base font-extrabold leading-none tabular-nums">
-        {value}
+}) => {
+  const isNumber = typeof value === "number";
+  const raw = isNumber ? formatRawCount(value) : value;
+  const display = isNumber ? formatCompactCount(value) : value;
+  const abbreviated = isNumber && value >= 1000;
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 items-center gap-2 rounded-2xl border border-foreground/10 bg-muted/20 px-2.5 py-2.5 text-left sm:gap-3 sm:px-3 sm:py-3",
+        className
+      )}
+    >
+      <div className="flex items-center justify-center border size-8 shrink-0 rounded-xl border-foreground/10 bg-background text-foreground/70 sm:size-9">
+        <Icon className="size-3.5 sm:size-4" aria-hidden />
       </div>
-      <div className="mt-1 truncate text-[11px] font-bold uppercase tracking-wide text-muted-foreground">
-        {label}
+      <div className="min-w-0">
+        <StatValue display={display} raw={raw} abbreviated={abbreviated} />
+        <div className="mt-0.5 text-[10px] font-bold uppercase leading-tight tracking-wide text-muted-foreground sm:mt-1 sm:text-[11px]">
+          {label}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/components/screens/DashboardScreen/SectionHeading.tsx
+++ b/src/components/screens/DashboardScreen/SectionHeading.tsx
@@ -9,30 +9,28 @@ export const SectionHeading = ({
   className,
 }: {
   title: string;
-  description?: ReactNode;
+  description: ReactNode;
   className?: string;
 }) => (
   <div className={cn("mb-5 text-center border-b-2 border-dotted", className)}>
     <h2 className="inline-flex items-center justify-center gap-1.5 mb-2 uppercase text-sm font-extrabold text-muted-foreground">
-      {title}
-      {description ? (
-        <GenericPopover
-          trigger={
-            <button
-              type="button"
-              className="inline-flex text-muted-foreground hover:text-foreground"
-              aria-label={`About ${title}`}
-            >
-              <InfoIcon className="inline-block" size={16} />
-            </button>
-          }
-          content={
-            <div className="max-w-xs px-4 py-3 text-sm text-left text-muted-foreground">
-              {description}
-            </div>
-          }
-        />
-      ) : null}
+      <GenericPopover
+        trigger={
+          <button
+            type="button"
+            className="inline-flex text-xs tracking-widest uppercase text-muted-foreground hover:text-foreground"
+            aria-label={`About ${title}`}
+          >
+            {title}
+            <InfoIcon className="inline-block ml-2" size={14} />
+          </button>
+        }
+        content={
+          <div className="max-w-xs px-4 py-3 text-sm text-left text-muted-foreground">
+            {description}
+          </div>
+        }
+      />
     </h2>
   </div>
 );

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmap.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { speedKatakanaPageMeta } from "@/components/items/practice-pages";
+import { STATS_KEY_PREFIX } from "@/components/screens/SpeedKatakanaScreen/storage";
+import { FreqGradient } from "@/components/common/freq/FreqGradient";
+import { SectionHeading } from "./SectionHeading";
+import { DashboardPanel } from "./DashboardPanel";
+import { SpeedKatakanaHeatmapGrid } from "./SpeedKatakanaHeatmapGrid";
+
+export const SpeedKatakanaHeatmap = () => {
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key == null || e.key.startsWith(STATS_KEY_PREFIX)) {
+        setRevision((n) => n + 1);
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return (
+    <DashboardPanel>
+      <SectionHeading
+        title={speedKatakanaPageMeta.shortLabel}
+        description="Each cell is one challenge set (10 katakana words). Brighter cells mean a higher best CPM at over 70% accuracy. Columns are levels 1–20; rows are sets within each level."
+      />
+      <SpeedKatakanaHeatmapGrid key={revision} />
+      <div className="flex items-center justify-center w-full">
+        <div>
+          <FreqGradient lessLabel="Slow" moreLabel="Fast" />
+        </div>
+      </div>
+    </DashboardPanel>
+  );
+};

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
@@ -1,0 +1,194 @@
+import {
+  CHALLENGES_PER_LEVEL,
+  LEVELS,
+  levelOf,
+  positionInLevel,
+  setFromLevelAndPos,
+} from "@/components/screens/SpeedKatakanaScreen/constants";
+import {
+  ChallengeSetStats,
+  readSetStats,
+} from "@/components/screens/SpeedKatakanaScreen/storage";
+import { CPM_BAND_LABELS, cpmToBand } from "@/lib/activity";
+import { freqCategoryCn } from "@/lib/freq/freq-category";
+import { cn } from "@/lib/utils";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+
+const CELL_PX = 20;
+const GAP_PX = 3;
+
+const SetDetail = ({
+  setNumber,
+  stats,
+  band,
+}: {
+  setNumber: number;
+  stats: ChallengeSetStats | null;
+  band: ReturnType<typeof cpmToBand>;
+}) => {
+  const level = levelOf(setNumber);
+  const position = positionInLevel(setNumber);
+
+  return (
+    <div className="space-y-1.5 text-xs">
+      <div className="font-extrabold">
+        Set {setNumber} · Level {level}, #{position}
+      </div>
+      {stats ? (
+        <>
+          {band > 0 ? (
+            <div className="text-muted-foreground">{CPM_BAND_LABELS[band]}</div>
+          ) : (
+            <div className="text-muted-foreground">
+              No run above 70% accuracy
+            </div>
+          )}
+          <div className="flex justify-between gap-4">
+            <span>Best CPM</span>
+            <span className="font-bold tabular-nums">{stats.bestCpm}</span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span>Best CPM (&gt;70%)</span>
+            <span className="font-bold tabular-nums">
+              {stats.bestCpmWithAccuracyOver70 ?? "—"}
+            </span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span>Best accuracy</span>
+            <span className="font-bold tabular-nums">
+              {stats.bestAccuracy}%
+            </span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span>Latest CPM</span>
+            <span className="font-bold tabular-nums">{stats.latestCpm}</span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span>Attempts</span>
+            <span className="font-bold tabular-nums">{stats.timesTaken}</span>
+          </div>
+        </>
+      ) : (
+        <div className="text-muted-foreground">Not attempted yet</div>
+      )}
+    </div>
+  );
+};
+
+const ChallengeSetCell = ({ setNumber }: { setNumber: number }) => {
+  const stats = readSetStats(setNumber);
+  const band = cpmToBand(stats?.bestCpmWithAccuracyOver70);
+  const fillCn =
+    band === 0
+      ? cn(
+          "bg-muted/50 dark:bg-muted/30",
+          "border border-border dark:border-border"
+        )
+      : cn(freqCategoryCn[band], "border border-black/10 dark:border-white/10");
+
+  const label = stats?.bestCpmWithAccuracyOver70
+    ? `Set ${setNumber}: ${stats.bestCpmWithAccuracyOver70} CPM`
+    : `Set ${setNumber}: not attempted`;
+
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          title={label}
+          style={{ width: CELL_PX, height: CELL_PX }}
+          className={cn(
+            "rounded-[2px] outline-none",
+            "hover:ring-2 hover:ring-foreground/30 hover:ring-offset-1 hover:ring-offset-background",
+            "focus-visible:ring-2 focus-visible:ring-ring",
+            fillCn
+          )}
+        />
+      </HoverCardTrigger>
+      <HoverCardContent className="p-3 w-52" side="top">
+        <SetDetail setNumber={setNumber} stats={stats} band={band} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
+/**
+ * Fixed-size grid: 20 columns (levels) × 10 rows (sets per level).
+ * Column flow fills each level top-to-bottom, then the next level.
+ */
+export const SpeedKatakanaHeatmapGrid = () => {
+  return (
+    <div className="overflow-x-auto pb-2 mb-4 px-1 [-webkit-mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] [mask-image:linear-gradient(to_right,transparent,black_8px,black_calc(100%-8px),transparent)] sm:[-webkit-mask-image:none] sm:[mask-image:none]">
+      <div
+        className="inline-grid"
+        style={{
+          gridTemplateAreas: `"empty levels" "rows squares"`,
+          gridTemplateColumns: "auto 1fr",
+          columnGap: 6,
+          rowGap: GAP_PX,
+        }}
+      >
+        <div
+          className="text-[10px] leading-none text-muted-foreground"
+          style={{
+            gridArea: "levels",
+            display: "grid",
+            gridTemplateColumns: `repeat(${LEVELS}, ${CELL_PX}px)`,
+            columnGap: GAP_PX,
+          }}
+        >
+          {Array.from({ length: LEVELS }, (_, i) => (
+            <div
+              key={i}
+              className="flex items-end justify-center h-3 tabular-nums"
+            >
+              {i + 1}
+            </div>
+          ))}
+        </div>
+
+        <div
+          className="text-[10px] leading-none text-muted-foreground"
+          style={{
+            gridArea: "rows",
+            display: "grid",
+            gridTemplateRows: `repeat(${CHALLENGES_PER_LEVEL}, ${CELL_PX}px)`,
+            rowGap: GAP_PX,
+          }}
+        >
+          {Array.from({ length: CHALLENGES_PER_LEVEL }, (_, i) => (
+            <div key={i} className="flex items-center justify-end pr-0.5">
+              {i === 0 || i === 4 || i === 9 ? i + 1 : ""}
+            </div>
+          ))}
+        </div>
+
+        <div
+          style={{
+            gridArea: "squares",
+            display: "grid",
+            gridAutoFlow: "column",
+            gridAutoColumns: CELL_PX,
+            gridTemplateRows: `repeat(${CHALLENGES_PER_LEVEL}, ${CELL_PX}px)`,
+            gap: GAP_PX,
+          }}
+        >
+          {Array.from({ length: LEVELS }, (_, levelIndex) =>
+            Array.from({ length: CHALLENGES_PER_LEVEL }, (_, posIndex) => {
+              const setNumber = setFromLevelAndPos(
+                levelIndex + 1,
+                posIndex + 1
+              );
+              return <ChallengeSetCell key={setNumber} setNumber={setNumber} />;
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/screens/DashboardScreen/StatsOverview.tsx
+++ b/src/components/screens/DashboardScreen/StatsOverview.tsx
@@ -6,7 +6,13 @@ import { ActivityCountsGrid } from "./ActivityCountsGrid";
 import { DashboardPanel } from "./DashboardPanel";
 
 export const StatsOverview = () => {
-  const { allTime, daysActive } = useActivityData();
+  const {
+    allTime,
+    daysActive,
+    speedKatakanaDays,
+    productionDays,
+    recognitionDays,
+  } = useActivityData();
 
   return (
     <DashboardPanel>
@@ -17,6 +23,9 @@ export const StatsOverview = () => {
       <ActivityCountsGrid
         stats={{
           daysActive,
+          speedKatakanaDays,
+          productionDays,
+          recognitionDays,
           speedKatakanaSessions: allTime.speedKatakanaSessions,
           productionRounds: allTime.productionRounds,
           recognitionRounds: allTime.recognitionRounds,

--- a/src/components/screens/MasteryScreen/MasteryScreen.tsx
+++ b/src/components/screens/MasteryScreen/MasteryScreen.tsx
@@ -2,20 +2,13 @@ import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
 import { BottomBar } from "@/components/common/BottomBar";
 import { DashedNavLinkList } from "@/components/common/DashedNavLinkList";
 import { practiceNavLinks } from "@/components/items/nav-links";
-import { GraduationCap } from "lucide-react";
-
 const MasteryScreen = () => {
   useHtmlDocumentTitle("Mastery");
 
   return (
     <div className="flex flex-col w-full max-w-4xl gap-6 px-1 py-5 mx-auto sm:gap-8 sm:px-3 sm:py-8">
       <div className="flex flex-col items-center justify-center flex-1 gap-5  text-center min-h-[50vh]">
-        <div
-          className="flex items-center justify-center size-14 rounded-full background-theme-color-with-opacity-100 border-2 border-b-[4px] border-theme-color-darker"
-          aria-hidden="true"
-        >
-          <GraduationCap className="text-white size-6" strokeWidth={2.25} />
-        </div>
+        <div className="text-3xl">{"🙇🏽‍♀️ 🙇"}</div>
 
         <div className="space-y-2">
           <p className="text-xs font-extrabold tracking-wide uppercase text-muted-foreground">

--- a/src/components/sections/KanjiDetails/General.tsx
+++ b/src/components/sections/KanjiDetails/General.tsx
@@ -94,6 +94,7 @@ export const General = ({ kanji }: { kanji: string }) => {
   return (
     <>
       <div className="mt-6 text-left">
+        <JLPTBadge jlpt={data.jlpt} />
         {hasData(data.jouyouGrade) && (
           <PrimaryBadgeWithPopover
             label="Grade"
@@ -136,7 +137,6 @@ export const General = ({ kanji }: { kanji: string }) => {
             description={orderDisclaimer}
           />
         )}
-        <JLPTBadge jlpt={data.jlpt} />
       </div>
       <DottedSeparator className="my-4 border-b-2" />
       <Table>

--- a/src/components/sections/KanjiInfoCard/ResponsiveKanjiCard.tsx
+++ b/src/components/sections/KanjiInfoCard/ResponsiveKanjiCard.tsx
@@ -5,7 +5,7 @@ import { SmallKanjiCard } from "./SmallCard";
 export const ResponsiveKanjiCard = ({ kanji }: { kanji: string }) => {
   return (
     <>
-      <div className="hidden [@media(min-height:900px)]:[@media(min-width:400px)]:block w-96">
+      <div className="hidden [@media(min-height:725px)]:[@media(min-width:400px)]:block w-96">
         <ErrorBoundary details="KanjiCard in ResponsiveKanjiCard">
           <KanjiCard kanji={kanji} />
         </ErrorBoundary>

--- a/src/components/sections/KanjiInfoCard/SmallCard.tsx
+++ b/src/components/sections/KanjiInfoCard/SmallCard.tsx
@@ -12,11 +12,11 @@ import { ReactNode } from "react";
 
 const Wrapper = ({ kanji, badges }: { kanji: string; badges: ReactNode }) => {
   return (
-    <div className="m-1 border border-dashed p-2">
+    <div className="p-2 m-1 border border-dashed rounded-xl">
       <div className="flex flex-wrap items-center justify-center mx-1">
         {badges}
       </div>
-      <div className="kanji-font text-8xl mb-2">{kanji}</div>
+      <div className="mb-2 kanji-font text-8xl">{kanji}</div>
     </div>
   );
 };
@@ -34,8 +34,8 @@ export const SmallKanjiCard = ({ kanji }: { kanji: string }) => {
         kanji={kanji}
         badges={
           <>
-            <Badge className="animate-pulse m-1">......</Badge>
-            <Badge className="animate-pulse m-1" variant={"outline"}>
+            <Badge className="m-1 animate-pulse">......</Badge>
+            <Badge className="m-1 animate-pulse" variant={"outline"}>
               ......
             </Badge>
           </>
@@ -51,7 +51,7 @@ export const SmallKanjiCard = ({ kanji }: { kanji: string }) => {
       kanji={kanji}
       badges={
         <>
-          <Badge className="text-nowrap m-1">
+          <Badge className="m-1 text-nowrap">
             {info.keyword.toUpperCase()}
           </Badge>
           <JLPTBadge jlpt={info.jlpt} />

--- a/src/hooks/use-activity-data.ts
+++ b/src/hooks/use-activity-data.ts
@@ -9,11 +9,14 @@ import {
   readAllTimeActivity,
 } from "@/lib/activity";
 
-const readSnapshot = () => ({
-  allTime: readAllTimeActivity(),
-  byDay: readActivityByDay(),
-  daysActive: countAllDaysActive(readActivityByDay()),
-});
+const readSnapshot = () => {
+  const byDay = readActivityByDay();
+  return {
+    allTime: readAllTimeActivity(),
+    byDay,
+    ...countAllDaysActive(byDay),
+  };
+};
 
 /**
  * Reactive all-time + by-day activity. Re-reads on storage events for the
@@ -43,5 +46,8 @@ export const useActivityData = () => {
     allTime: AllTimeActivity;
     byDay: ActivityByDay;
     daysActive: number;
+    speedKatakanaDays: number;
+    productionDays: number;
+    recognitionDays: number;
   };
 };

--- a/src/lib/activity/dates.ts
+++ b/src/lib/activity/dates.ts
@@ -155,9 +155,34 @@ export const buildCalendarWeeks = (range: DateRange): (string | null)[][] => {
   return weeks;
 };
 
-/** Month label positions for calendar header (week index → single letter). */
+export type MonthLabelType = "short" | "japanese-numbers";
+
+const JAPANESE_MONTH_LABELS = [
+  "一",
+  "二",
+  "三",
+  "四",
+  "五",
+  "六",
+  "七",
+  "八",
+  "九",
+  "十",
+  "霜", // 霜月 (November)
+  "師", // 師走 (December)
+] as const;
+
+const monthLabelFor = (month: number, labelType: MonthLabelType): string => {
+  if (labelType === "japanese-numbers") return JAPANESE_MONTH_LABELS[month];
+  return new Date(2000, month, 1).toLocaleDateString("en-US", {
+    month: "short",
+  })[0];
+};
+
+/** Month label positions for calendar header (week index → label). */
 export const monthLabelsForWeeks = (
-  weeks: (string | null)[][]
+  weeks: (string | null)[][],
+  labelType: MonthLabelType = "short"
 ): { weekIndex: number; label: string }[] => {
   const labels: { weekIndex: number; label: string }[] = [];
   let lastMonth = -1;
@@ -168,9 +193,7 @@ export const monthLabelsForWeeks = (
     const date = parseLocalDateKey(firstInRange);
     const month = date.getMonth();
     if (month !== lastMonth) {
-      // Cursor/GitHub-compact: single letter (J F M A M J J A S O N D)
-      const letter = date.toLocaleDateString("en-US", { month: "short" })[0];
-      labels.push({ weekIndex, label: letter });
+      labels.push({ weekIndex, label: monthLabelFor(month, labelType) });
       lastMonth = month;
     }
   });

--- a/src/lib/activity/queries.ts
+++ b/src/lib/activity/queries.ts
@@ -29,6 +29,9 @@ export const summarizeActivityInRange = (
   filters: ActivityKindFilters
 ): WindowedActivityStats => {
   let daysActive = 0;
+  let speedKatakanaDays = 0;
+  let productionDays = 0;
+  let recognitionDays = 0;
   let speedKatakanaSessions = 0;
   let productionRounds = 0;
   let recognitionRounds = 0;
@@ -36,14 +39,21 @@ export const summarizeActivityInRange = (
   for (const [key, day] of Object.entries(byDay)) {
     if (!isDateKeyInRange(key, range)) continue;
 
+    const speedKatakana = day.speedKatakana ?? 0;
+    const production = day.production ?? 0;
+    const recognition = day.recognition ?? 0;
+
     if (filters.speedKatakana) {
-      speedKatakanaSessions += day.speedKatakana ?? 0;
+      speedKatakanaSessions += speedKatakana;
+      if (speedKatakana > 0) speedKatakanaDays += 1;
     }
     if (filters.production) {
-      productionRounds += day.production ?? 0;
+      productionRounds += production;
+      if (production > 0) productionDays += 1;
     }
     if (filters.recognition) {
-      recognitionRounds += day.recognition ?? 0;
+      recognitionRounds += recognition;
+      if (recognition > 0) recognitionDays += 1;
     }
 
     if (dayTotalForFilters(day, filters) > 0) daysActive += 1;
@@ -51,26 +61,46 @@ export const summarizeActivityInRange = (
 
   return {
     daysActive,
+    speedKatakanaDays,
+    productionDays,
+    recognitionDays,
     speedKatakanaSessions,
     productionRounds,
     recognitionRounds,
   };
 };
 
-/** Distinct days with any activity (all kinds), for all-time overview. */
-export const countAllDaysActive = (byDay: ActivityByDay): number => {
-  let n = 0;
+/**
+ * Distinct days with activity (all-time overview): total + per kind.
+ */
+export const countAllDaysActive = (
+  byDay: ActivityByDay
+): Pick<
+  WindowedActivityStats,
+  "daysActive" | "speedKatakanaDays" | "productionDays" | "recognitionDays"
+> => {
+  let daysActive = 0;
+  let speedKatakanaDays = 0;
+  let productionDays = 0;
+  let recognitionDays = 0;
+
   for (const day of Object.values(byDay)) {
-    if (
-      (day.speedKatakana ?? 0) +
-        (day.production ?? 0) +
-        (day.recognition ?? 0) >
-      0
-    ) {
-      n += 1;
-    }
+    const speedKatakana = day.speedKatakana ?? 0;
+    const production = day.production ?? 0;
+    const recognition = day.recognition ?? 0;
+
+    if (speedKatakana > 0) speedKatakanaDays += 1;
+    if (production > 0) productionDays += 1;
+    if (recognition > 0) recognitionDays += 1;
+    if (speedKatakana + production + recognition > 0) daysActive += 1;
   }
-  return n;
+
+  return {
+    daysActive,
+    speedKatakanaDays,
+    productionDays,
+    recognitionDays,
+  };
 };
 
 export const maxDayTotalInRange = (
@@ -86,18 +116,15 @@ export const maxDayTotalInRange = (
   return max;
 };
 
-const INTENSITY_FLOOR = 4;
-
 /**
- * GitHub-like relative intensity. Floors maxN so a lone single-event day
- * is not always painted at maximum brightness.
+ * Relative intensity vs the busiest day in range (maxN).
+ * A day with n === maxN is always painted at maximum brightness.
  */
 export const getActivityLevel = (n: number, maxN: number): FreqCategory => {
-  if (n <= 0) return 0;
-  const scale = Math.max(maxN, INTENSITY_FLOOR);
-  if (n <= scale * 0.25) return 1;
-  if (n <= scale * 0.5) return 2;
-  if (n <= scale * 0.75) return 3;
+  if (n <= 0 || maxN <= 0) return 0;
+  if (n <= maxN * 0.25) return 1;
+  if (n <= maxN * 0.5) return 2;
+  if (n <= maxN * 0.75) return 3;
   return 4;
 };
 

--- a/src/lib/activity/types.ts
+++ b/src/lib/activity/types.ts
@@ -67,7 +67,7 @@ export const ACTIVITY_KIND_LABELS: Record<ActivityKind, string> = {
 };
 
 export const ALL_ACTIVITY_KINDS: ActivityKind[] = [
-  "speedKatakana",
   "production",
   "recognition",
+  "speedKatakana",
 ];

--- a/src/lib/activity/types.ts
+++ b/src/lib/activity/types.ts
@@ -36,6 +36,9 @@ export type ActivityKindFilters = Record<ActivityKind, boolean>;
 
 export type WindowedActivityStats = {
   daysActive: number;
+  speedKatakanaDays: number;
+  productionDays: number;
+  recognitionDays: number;
   speedKatakanaSessions: number;
   productionRounds: number;
   recognitionRounds: number;


### PR DESCRIPTION
## Summary
- Polish Mastery and Dashboard UI: popover section titles, JLPT-first kanji details, Japanese calendar labels, and bookmarks as a compact progress table.
- Expand activity overview with per-kind active days plus session/round totals, and add a speed katakana CPM heatmap.
- Tweak activity calendar intensity, today highlighting, layout, and section ordering.

## Test plan
- [ ] Open Dashboard and confirm stats show total days, per-kind days, and session/round counts
- [ ] Confirm activity calendar highlights today and uses Japanese day/month labels
- [ ] Confirm speed katakana CPM heatmap renders with practiced data
- [ ] Confirm bookmarks breakdown JLPT table and section title popovers work
- [ ] Spot-check Mastery page copy and kanji hover card layout on mobile and desktop


Made with [Cursor](https://cursor.com)