### PR TITLE
Persist home search params across in-app navigation

### DIFF
--- a/src/components/common/DashedNavLinkList.tsx
+++ b/src/components/common/DashedNavLinkList.tsx
@@ -1,5 +1,6 @@
 import { Fragment, type ReactNode } from "react";
 import { DashedNavLink } from "@/components/common/DashedNavLink";
+import { useHomeHref } from "@/components/dependent/routing";
 import type { NavLinkItem } from "@/components/items/nav-links";
 import { cn } from "@/lib/utils";
 
@@ -22,12 +23,15 @@ export const DashedNavLinkList = ({
   onItemPointerDown,
   wrapItem,
 }: DashedNavLinkListProps) => {
+  const homeHref = useHomeHref();
+
   return (
     <div className={cn(className)}>
       {items.map((item) => {
+        const href = item.href === "/" ? homeHref : item.href;
         const link = (
           <DashedNavLink
-            href={item.href}
+            href={href}
             title={item.title}
             description={item.description}
             Icon={item.Icon}

--- a/src/components/dependent/routing/global-links.tsx
+++ b/src/components/dependent/routing/global-links.tsx
@@ -1,6 +1,7 @@
 import { cnTextLink } from "@/lib/generic-cn";
 import { Badge } from "@/components/ui/badge";
 import { useKanjiFromUrl, useUrlLocation } from "./routing-hooks";
+import { useHomeHref } from "./use-home-href";
 import { Link } from "./router-adapter";
 import { radicalFalseFriends } from "@/lib/radicals";
 
@@ -71,8 +72,9 @@ const JPCardInner = ({
 );
 
 export const GlobalHomeLink = () => {
+  const homeHref = useHomeHref();
   return (
-    <Link to={"/"} className={cnTextLink}>
+    <Link to={homeHref} className={cnTextLink}>
       home.
     </Link>
   );
@@ -148,5 +150,6 @@ export const GlobalKanjiLink = ({
 };
 
 export const GlobalHomeHeaderLink = () => {
-  return <Link to={"/"}>Kanji Heatmap</Link>;
+  const homeHref = useHomeHref();
+  return <Link to={homeHref}>Kanji Heatmap</Link>;
 };

--- a/src/components/dependent/routing/index.tsx
+++ b/src/components/dependent/routing/index.tsx
@@ -4,6 +4,7 @@ import {
   GlobalHomeLink,
   GlobalKanjiLink,
 } from "./global-links";
+export { useHomeHref } from "./use-home-href";
 export {
   Route,
   Switch,

--- a/src/components/dependent/routing/use-home-href.tsx
+++ b/src/components/dependent/routing/use-home-href.tsx
@@ -1,0 +1,28 @@
+import { URL_PARAMS } from "@/lib/settings/url-params";
+import { getLastHomeSearchParams } from "@/lib/settings/last-home-search-params";
+import { useSearchParams, useUrlLocation } from "./routing-hooks";
+
+const homeHrefFromSearch = (search: string) => {
+  return search ? `/?${search}` : "/";
+};
+
+/**
+ * Href for navigating to the kanji explore home route, preserving the last
+ * session search/filter/sort/bg-src query string.
+ *
+ * On `/`, uses the live URL (minus `open`). Elsewhere, uses the in-memory
+ * cache from the last time the user was on home.
+ */
+export const useHomeHref = () => {
+  const location = useUrlLocation();
+  const [searchParams] = useSearchParams();
+
+  if (location === "/") {
+    const current = new URLSearchParams(searchParams);
+    current.delete(URL_PARAMS.openKanji);
+    return homeHrefFromSearch(current.toString());
+  }
+
+  const cached = getLastHomeSearchParams();
+  return homeHrefFromSearch(cached ?? "");
+};

--- a/src/components/site-layout/FloatingIsland.tsx
+++ b/src/components/site-layout/FloatingIsland.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@/components/dependent/routing";
+import { Link, useHomeHref } from "@/components/dependent/routing";
 import { useLocation } from "@/components/dependent/routing/router-adapter";
 import { floatingIslandNavLinks } from "@/components/items/nav-links";
 import { useScrollLockSettleRef } from "@/hooks/use-scroll-lock-fade-tick";
@@ -8,6 +8,7 @@ const islandHrefs = new Set(floatingIslandNavLinks.map((link) => link.href));
 
 export const FloatingIsland = () => {
   const [location] = useLocation();
+  const homeHref = useHomeHref();
   const settleRef = useScrollLockSettleRef<HTMLElement>();
 
   if (!islandHrefs.has(location)) {
@@ -49,11 +50,12 @@ export const FloatingIsland = () => {
         {floatingIslandNavLinks.map((link) => {
           const isActive = link.href === location;
           const Icon = link.Icon;
+          const href = link.href === "/" ? homeHref : link.href;
 
           return (
             <Link
               key={link.href}
-              href={link.href}
+              href={href}
               aria-label={link.title}
               aria-current={isActive ? "page" : undefined}
               className={cn(

--- a/src/components/site-layout/Header/HeaderTitle.tsx
+++ b/src/components/site-layout/Header/HeaderTitle.tsx
@@ -1,10 +1,11 @@
-import { Link } from "@/components/dependent/routing";
+import { Link, useHomeHref } from "@/components/dependent/routing";
 import assetsPaths from "@/lib/assets-paths";
 
 export const HeaderTitle = () => {
+  const homeHref = useHomeHref();
   return (
     <Link
-      to="/"
+      to={homeHref}
       className="flex items-center gap-2 py-1.5 hover:opacity-80 transition-opacity"
     >
       <img

--- a/src/components/site-layout/PracticeHeader.tsx
+++ b/src/components/site-layout/PracticeHeader.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@/components/dependent/routing";
+import { Link, useHomeHref } from "@/components/dependent/routing";
 import { ErrorBoundary } from "@/components/error";
 import { Progress } from "@/components/ui/progress";
 import ChangeFontButton from "@/components/dependent/site-wide/ChangeFontButton";
@@ -10,10 +10,11 @@ import assetsPaths from "@/lib/assets-paths";
  * Slim header for practice routes: logo, progress bar, font/color controls, sidebar.
  */
 export const PracticeHeader = ({ progress }: { progress: number }) => {
+  const homeHref = useHomeHref();
   return (
     <header className="flex items-center justify-between w-full gap-3 px-2 border-b-4 border-dashed shrink-0 fix-scroll-layout-shift-right bg-background">
       <Link
-        to="/"
+        to={homeHref}
         className="flex items-center py-1.5 shrink-0 hover:opacity-80 transition-opacity"
         aria-label="Kanji Heatmap home"
       >

--- a/src/lib/settings/last-home-search-params.ts
+++ b/src/lib/settings/last-home-search-params.ts
@@ -1,0 +1,24 @@
+import { URL_PARAMS } from "./url-params";
+
+/**
+ * In-memory cache of the last home (`/`) search string for the current
+ * session. Survives client-side navigations away from `/` (and provider
+ * remounts) so bare `/` links can restore filters, sort, bg-src, etc.
+ *
+ * `null` means home has not been visited yet this session.
+ */
+let lastHomeSearchParams: string | null = null;
+
+const withoutOpenKanji = (params: URLSearchParams) => {
+  const next = new URLSearchParams(params);
+  next.delete(URL_PARAMS.openKanji);
+  return next;
+};
+
+export const getLastHomeSearchParams = (): string | null => {
+  return lastHomeSearchParams;
+};
+
+export const rememberHomeSearchParams = (params: URLSearchParams) => {
+  lastHomeSearchParams = withoutOpenKanji(params).toString();
+};

--- a/src/providers/search-settings-provider.tsx
+++ b/src/providers/search-settings-provider.tsx
@@ -1,4 +1,10 @@
-import { ReactNode, useCallback, useLayoutEffect, useMemo } from "react";
+import {
+  ReactNode,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 
 import {
   FilterSettings,
@@ -12,6 +18,10 @@ import {
   toSearchSettings,
 } from "@/lib/settings/search-settings-adapter";
 import {
+  getLastHomeSearchParams,
+  rememberHomeSearchParams,
+} from "@/lib/settings/last-home-search-params";
+import {
   useSearchParams,
   useUrlLocation,
 } from "@/components/dependent/routing/routing-hooks";
@@ -20,9 +30,32 @@ import { URL_PARAMS } from "@/lib/settings/url-params";
 
 const ALLOWED_LOCATIONS = ["/"];
 
+const isEmptySearchParams = (params: URLSearchParams) => {
+  return [...params.keys()].length === 0;
+};
+
+const normalizeSearchParams = (params: URLSearchParams) => {
+  const searchSettings = toSearchSettings(params);
+  const partial1 = toSearchParams(
+    params,
+    "textSearch",
+    searchSettings.textSearch
+  );
+  const partial2 = toSearchParams(
+    partial1,
+    "filterSettings",
+    searchSettings.filterSettings
+  );
+  return toSearchParams(partial2, "sortSettings", searchSettings.sortSettings);
+};
+
 export function SearchSettingsProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useUrlLocation();
+  // When landing on bare `/`, the restore write and the "remember" sync can
+  // run in the same commit while searchParams is still empty. Skip that one
+  // empty remember so we do not clobber the session cache mid-restore.
+  const skipEmptyRememberRef = useRef(false);
 
   const updateItem = useCallback(
     (
@@ -63,28 +96,36 @@ export function SearchSettingsProvider({ children }: { children: ReactNode }) {
     }
     setSearchParams(
       (prev) => {
-        const searchSettings = toSearchSettings(prev);
-        const partial1 = toSearchParams(
-          prev,
-          "textSearch",
-          searchSettings.textSearch
-        );
-        const partial2 = toSearchParams(
-          partial1,
-          "filterSettings",
-          searchSettings.filterSettings
-        );
-        const final = toSearchParams(
-          partial2,
-          "sortSettings",
-          searchSettings.sortSettings
-        );
+        // Bare `/` links drop the query string. Rehydrate the last home search
+        // from this session so filters/sort/bg-src/search survive navigation.
+        const cached = getLastHomeSearchParams();
+        const shouldRestore = isEmptySearchParams(prev) && Boolean(cached);
+        if (shouldRestore) {
+          skipEmptyRememberRef.current = true;
+        }
 
+        const base = shouldRestore
+          ? new URLSearchParams(cached as string)
+          : prev;
+        const final = normalizeSearchParams(base);
+        rememberHomeSearchParams(final);
         return final;
       },
       { replace: true }
     );
   }, [setSearchParams, location]);
+
+  useLayoutEffect(() => {
+    if (!ALLOWED_LOCATIONS.includes(location)) {
+      return;
+    }
+    if (skipEmptyRememberRef.current && isEmptySearchParams(searchParams)) {
+      skipEmptyRememberRef.current = false;
+      return;
+    }
+    skipEmptyRememberRef.current = false;
+    rememberHomeSearchParams(searchParams);
+  }, [location, searchParams]);
 
   const storageData: SearchSettings = useMemo(() => {
     return toSearchSettings(searchParams);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Home links (logo, floating island Explore, header nav, practice header, etc.) were pointing at bare `/`, which dropped the current query string. Settings like `bg-src=none`, filters, sort, and search text were lost whenever you left Explore and came back.

## Approach
- Keep the last home (`/`) query string in **session memory** (not localStorage), excluding the `open` kanji drawer param.
- `SearchSettingsProvider` remembers params while on `/`, and restores them if you land on bare `/`.
- `useHomeHref()` makes home links carry the last query string so navigation itself preserves state.

## Test plan
- Open `/?bg-src=none` (or a fuller filter/sort/search URL).
- Navigate to Dashboard, Mastery, docs, or a practice page.
- Return via logo, floating island Explore, or header “Explore Kanji”.
- Confirm the previous query string is restored (including `bg-src`).
- Confirm opening a kanji drawer (`open=…`) is not restored after leaving and returning.
- Confirm intentional links like radical search (`/?search-type=radicals&search-text=…`) still replace the query as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f715c-bb3e-7276-949b-c84c56fa2164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f715c-bb3e-7276-949b-c84c56fa2164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

