### PR TITLE
Preserve home query across navigation

### DIFF
--- a/src/components/dependent/routing/remembered-home-link.tsx
+++ b/src/components/dependent/routing/remembered-home-link.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, useSyncExternalStore } from "react";
+import { Link as WouterLink, LinkProps } from "wouter";
+import {
+  getRememberedHomeHref,
+  subscribeToRememberedHomeSearch,
+} from "@/lib/home-search-memory";
+
+export const RememberedHomeLink = forwardRef<HTMLAnchorElement, LinkProps>(
+  (props, ref) => {
+    const rememberedHomeHref = useSyncExternalStore(
+      subscribeToRememberedHomeSearch,
+      getRememberedHomeHref,
+      getRememberedHomeHref
+    );
+
+    const resolvedProps =
+      "to" in props && props.to !== undefined
+        ? {
+            ...props,
+            to: props.to === "/" ? rememberedHomeHref : props.to,
+          }
+        : {
+            ...props,
+            href: props.href === "/" ? rememberedHomeHref : props.href,
+          };
+
+    if (resolvedProps.asChild) {
+      return <WouterLink {...resolvedProps} />;
+    }
+
+    return <WouterLink {...resolvedProps} ref={ref} />;
+  }
+);
+RememberedHomeLink.displayName = "RememberedHomeLink";

--- a/src/components/dependent/routing/router-adapter.tsx
+++ b/src/components/dependent/routing/router-adapter.tsx
@@ -1,11 +1,7 @@
-import {
-  ComponentPropsWithoutRef,
-  ComponentRef,
-  forwardRef,
-  useSyncExternalStore,
-} from "react";
+import { forwardRef, useSyncExternalStore } from "react";
 import {
   Link as WouterLink,
+  LinkProps,
   Route,
   Switch,
   useLocation,
@@ -17,26 +13,30 @@ import {
   subscribeToRememberedHomeSearch,
 } from "@/lib/home-search-memory";
 
-type LinkProps = ComponentPropsWithoutRef<typeof WouterLink>;
+const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  const rememberedHomeHref = useSyncExternalStore(
+    subscribeToRememberedHomeSearch,
+    getRememberedHomeHref,
+    getRememberedHomeHref
+  );
 
-const Link = forwardRef<ComponentRef<typeof WouterLink>, LinkProps>(
-  ({ href, to, ...props }, ref) => {
-    const rememberedHomeHref = useSyncExternalStore(
-      subscribeToRememberedHomeSearch,
-      getRememberedHomeHref,
-      getRememberedHomeHref
-    );
+  const resolvedProps =
+    "to" in props && props.to !== undefined
+      ? {
+          ...props,
+          to: props.to === "/" ? rememberedHomeHref : props.to,
+        }
+      : {
+          ...props,
+          href: props.href === "/" ? rememberedHomeHref : props.href,
+        };
 
-    return (
-      <WouterLink
-        {...props}
-        ref={ref}
-        href={href === "/" ? rememberedHomeHref : href}
-        to={to === "/" ? rememberedHomeHref : to}
-      />
-    );
+  if (resolvedProps.asChild) {
+    return <WouterLink {...resolvedProps} />;
   }
-);
+
+  return <WouterLink {...resolvedProps} ref={ref} />;
+});
 Link.displayName = "Link";
 
 export { Route, Switch, Link, useLocation, useSearch, useSearchParams };

--- a/src/components/dependent/routing/router-adapter.tsx
+++ b/src/components/dependent/routing/router-adapter.tsx
@@ -1,42 +1,4 @@
-import { forwardRef, useSyncExternalStore } from "react";
-import {
-  Link as WouterLink,
-  LinkProps,
-  Route,
-  Switch,
-  useLocation,
-  useSearch,
-  useSearchParams,
-} from "wouter";
-import {
-  getRememberedHomeHref,
-  subscribeToRememberedHomeSearch,
-} from "@/lib/home-search-memory";
-
-const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const rememberedHomeHref = useSyncExternalStore(
-    subscribeToRememberedHomeSearch,
-    getRememberedHomeHref,
-    getRememberedHomeHref
-  );
-
-  const resolvedProps =
-    "to" in props && props.to !== undefined
-      ? {
-          ...props,
-          to: props.to === "/" ? rememberedHomeHref : props.to,
-        }
-      : {
-          ...props,
-          href: props.href === "/" ? rememberedHomeHref : props.href,
-        };
-
-  if (resolvedProps.asChild) {
-    return <WouterLink {...resolvedProps} />;
-  }
-
-  return <WouterLink {...resolvedProps} ref={ref} />;
-});
-Link.displayName = "Link";
+import { Route, Switch, useLocation, useSearch, useSearchParams } from "wouter";
+import { RememberedHomeLink as Link } from "./remembered-home-link";
 
 export { Route, Switch, Link, useLocation, useSearch, useSearchParams };

--- a/src/components/dependent/routing/router-adapter.tsx
+++ b/src/components/dependent/routing/router-adapter.tsx
@@ -1,10 +1,42 @@
 import {
-  Link,
+  ComponentPropsWithoutRef,
+  ComponentRef,
+  forwardRef,
+  useSyncExternalStore,
+} from "react";
+import {
+  Link as WouterLink,
   Route,
   Switch,
   useLocation,
   useSearch,
   useSearchParams,
 } from "wouter";
+import {
+  getRememberedHomeHref,
+  subscribeToRememberedHomeSearch,
+} from "@/lib/home-search-memory";
+
+type LinkProps = ComponentPropsWithoutRef<typeof WouterLink>;
+
+const Link = forwardRef<ComponentRef<typeof WouterLink>, LinkProps>(
+  ({ href, to, ...props }, ref) => {
+    const rememberedHomeHref = useSyncExternalStore(
+      subscribeToRememberedHomeSearch,
+      getRememberedHomeHref,
+      getRememberedHomeHref
+    );
+
+    return (
+      <WouterLink
+        {...props}
+        ref={ref}
+        href={href === "/" ? rememberedHomeHref : href}
+        to={to === "/" ? rememberedHomeHref : to}
+      />
+    );
+  }
+);
+Link.displayName = "Link";
 
 export { Route, Switch, Link, useLocation, useSearch, useSearchParams };

--- a/src/lib/home-search-memory.ts
+++ b/src/lib/home-search-memory.ts
@@ -1,0 +1,20 @@
+let rememberedHomeSearch = "";
+const listeners = new Set<() => void>();
+
+export const getRememberedHomeHref = () => {
+  return rememberedHomeSearch === "" ? "/" : `/?${rememberedHomeSearch}`;
+};
+
+export const rememberHomeSearch = (search: string) => {
+  if (search === rememberedHomeSearch) {
+    return;
+  }
+
+  rememberedHomeSearch = search;
+  listeners.forEach((listener) => listener());
+};
+
+export const subscribeToRememberedHomeSearch = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};

--- a/src/providers/search-settings-provider.tsx
+++ b/src/providers/search-settings-provider.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/dependent/routing/routing-hooks";
 import { searchSettings } from "./search-settings-hooks";
 import { URL_PARAMS } from "@/lib/settings/url-params";
+import { rememberHomeSearch } from "@/lib/home-search-memory";
 
 const ALLOWED_LOCATIONS = ["/"];
 
@@ -85,6 +86,12 @@ export function SearchSettingsProvider({ children }: { children: ReactNode }) {
       { replace: true }
     );
   }, [setSearchParams, location]);
+
+  useLayoutEffect(() => {
+    if (ALLOWED_LOCATIONS.includes(location)) {
+      rememberHomeSearch(searchParams.toString());
+    }
+  }, [location, searchParams]);
 
   const storageData: SearchSettings = useMemo(() => {
     return toSearchSettings(searchParams);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remember the latest query string used on the home route in module memory
- resolve bare home links to the remembered query while leaving explicit query links unchanged
- preserve anchor refs and Wouter's `asChild` behavior

## Testing
- `pnpm exec tsc -b`
- ESLint on all modified files
- `pnpm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f715e-5824-739a-bc87-b2cee0766e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f715e-5824-739a-bc87-b2cee0766e12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

