### PR TITLE
Improve mobile interactions and route navigation

### DIFF
--- a/src/components/dependent/site-wide/PageFadeIn.tsx
+++ b/src/components/dependent/site-wide/PageFadeIn.tsx
@@ -1,9 +1,18 @@
-import { ReactNode } from "react";
+import { ReactNode, useLayoutEffect } from "react";
 import { useLocation } from "@/components/dependent/routing/router-adapter";
 
 /** Remounts children on route change so `animate-fade-in` plays. */
 export const PageFadeIn = ({ children }: { children: ReactNode }) => {
   const [location] = useLocation();
+
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+
+    if (document.scrollingElement) {
+      document.scrollingElement.scrollTop = 0;
+    }
+    document.body.scrollTop = 0;
+  }, [location]);
 
   return (
     <div key={location} className="animate-fade-in">

--- a/src/components/production-practice-v1/index.tsx
+++ b/src/components/production-practice-v1/index.tsx
@@ -1,16 +1,15 @@
 import { lazy, Suspense } from "react";
 import { ErrorBoundary } from "@/components/error";
+import { PracticeRouteLoadingFallback } from "@/components/shared-practice/PracticeRouteLoadingFallback";
 
 const LazyProductionPracticeV1 = lazy(() => import("./ProductionPracticeV1"));
-
-const PracticeRouteFallback = () => (
-  <div className="fixed inset-0 bg-background animate-fade-in" aria-hidden />
-);
 
 const ProductionPracticeV1Screen = () => {
   return (
     <ErrorBoundary>
-      <Suspense fallback={<PracticeRouteFallback />}>
+      <Suspense
+        fallback={<PracticeRouteLoadingFallback label="writing practice" />}
+      >
         <LazyProductionPracticeV1 />
       </Suspense>
     </ErrorBoundary>

--- a/src/components/recognition-practice-v1/index.tsx
+++ b/src/components/recognition-practice-v1/index.tsx
@@ -1,16 +1,15 @@
 import { lazy, Suspense } from "react";
 import { ErrorBoundary } from "@/components/error";
+import { PracticeRouteLoadingFallback } from "@/components/shared-practice/PracticeRouteLoadingFallback";
 
 const LazyRecognitionPracticeV1 = lazy(() => import("./RecognitionPracticeV1"));
-
-const PracticeRouteFallback = () => (
-  <div className="fixed inset-0 bg-background animate-fade-in" aria-hidden />
-);
 
 const RecognitionPracticeV1Screen = () => {
   return (
     <ErrorBoundary>
-      <Suspense fallback={<PracticeRouteFallback />}>
+      <Suspense
+        fallback={<PracticeRouteLoadingFallback label="recognition practice" />}
+      >
         <LazyRecognitionPracticeV1 />
       </Suspense>
     </ErrorBoundary>

--- a/src/components/screens/DashboardScreen/CalendarGrid.tsx
+++ b/src/components/screens/DashboardScreen/CalendarGrid.tsx
@@ -11,10 +11,10 @@ import {
 import { freqCategoryCn } from "@/lib/freq/freq-category";
 import { cn } from "@/lib/utils";
 import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 /** Sun→Sat; only Mon / Wed / Fri labeled (Cursor/GitHub-style). */
 const DAY_LABELS = ["", "月", "", "水", "", "金", ""] as const;
@@ -98,8 +98,8 @@ const CalendarDayCell = ({
     : `${formatActivityDay(dateKey)}: ${n} events`;
 
   return (
-    <HoverCard openDelay={200} closeDelay={100}>
-      <HoverCardTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
         <button
           type="button"
           aria-label={label}
@@ -112,16 +112,16 @@ const CalendarDayCell = ({
             fillCn
           )}
         />
-      </HoverCardTrigger>
-      <HoverCardContent className="p-3 w-52" side="top">
+      </PopoverTrigger>
+      <PopoverContent className="p-3 w-52" side="top">
         <DayDetail
           dateKey={dateKey}
           byDay={byDay}
           filters={filters}
           isToday={isToday}
         />
-      </HoverCardContent>
-    </HoverCard>
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/src/components/screens/DashboardScreen/CalendarGrid.tsx
+++ b/src/components/screens/DashboardScreen/CalendarGrid.tsx
@@ -106,7 +106,8 @@ const CalendarDayCell = ({
           title={label}
           style={{ width: CELL_PX, height: CELL_PX }}
           className={cn(
-            "rounded-[2px] outline-none",
+            "cursor-pointer rounded-[2px] outline-none transition-colors",
+            "hover:bg-cyan-400 hover:border-foreground",
             "hover:ring-2 hover:ring-foreground/30 hover:ring-offset-1 hover:ring-offset-background",
             "focus-visible:ring-2 focus-visible:ring-ring",
             fillCn

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
@@ -13,10 +13,10 @@ import { CPM_BAND_LABELS, cpmToBand } from "@/lib/activity";
 import { freqCategoryCn } from "@/lib/freq/freq-category";
 import { cn } from "@/lib/utils";
 import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 const CELL_PX = 20;
 const GAP_PX = 3;
@@ -95,8 +95,8 @@ const ChallengeSetCell = ({ setNumber }: { setNumber: number }) => {
     : `Set ${setNumber}: not attempted`;
 
   return (
-    <HoverCard openDelay={200} closeDelay={100}>
-      <HoverCardTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
         <button
           type="button"
           aria-label={label}
@@ -109,11 +109,11 @@ const ChallengeSetCell = ({ setNumber }: { setNumber: number }) => {
             fillCn
           )}
         />
-      </HoverCardTrigger>
-      <HoverCardContent className="p-3 w-52" side="top">
+      </PopoverTrigger>
+      <PopoverContent className="p-3 w-52" side="top">
         <SetDetail setNumber={setNumber} stats={stats} band={band} />
-      </HoverCardContent>
-    </HoverCard>
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
@@ -103,7 +103,8 @@ const ChallengeSetCell = ({ setNumber }: { setNumber: number }) => {
           title={label}
           style={{ width: CELL_PX, height: CELL_PX }}
           className={cn(
-            "rounded-[2px] outline-none",
+            "cursor-pointer rounded-[2px] outline-none transition-colors",
+            "hover:bg-cyan-400 hover:border-foreground",
             "hover:ring-2 hover:ring-foreground/30 hover:ring-offset-1 hover:ring-offset-background",
             "focus-visible:ring-2 focus-visible:ring-ring",
             fillCn

--- a/src/components/screens/ListScreen/ControlBar/ControlBar.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ControlBar.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import KaoMojiLoadingSpinner from "@/components/common/KaomojiLoading";
 import { ReportBugIconBtn } from "@/components/common/ReportBugIconBtn";
 
 import ItemPresentationSettingsPopover from "./ItemPresentation/ItemPresentationPopover";
@@ -45,7 +46,17 @@ export const ControlBar = () => {
       >
         <ItemPresentationSettingsPopover>
           <ErrorBoundary details="ItemPresentationSettingsContent in ControlBar">
-            <Suspense fallback={null}>
+            <Suspense
+              fallback={
+                <div
+                  className="py-8 text-sm text-center text-muted-foreground"
+                  role="status"
+                >
+                  <KaoMojiLoadingSpinner />
+                  Loading...
+                </div>
+              }
+            >
               <ItemPresentationSettingsContent />
             </Suspense>
           </ErrorBoundary>

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/HandwritingLoadingFallback.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/HandwritingLoadingFallback.tsx
@@ -1,0 +1,55 @@
+import { Loader2 } from "lucide-react";
+import { SearchDialogLoadingShell } from "../SearchDialogLoadingShell";
+
+export const HandwritingLoadingFallback = ({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <SearchDialogLoadingShell title="Handwriting Search" onClose={onClose}>
+      <div className="relative w-full px-1 mx-auto">
+        <div className="absolute z-[51] w-full -top-1">
+          <span className="px-2 text-sm font-bold rounded-full bg-background">
+            Draw a Kanji
+          </span>
+        </div>
+        <div className="flex items-center justify-center py-4 mt-2 overflow-hidden border-2 border-dotted rounded-md border-foreground/30">
+          <div className="relative aspect-square w-[min(300px,calc(100vw-56px))] overflow-hidden rounded-xl border-2 border-dashed border-foreground/30 bg-muted/30">
+            <div className="absolute inset-x-0 top-1/2 border-t border-dashed border-foreground/20" />
+            <div className="absolute inset-y-0 left-1/2 border-l border-dashed border-foreground/20" />
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-sm font-semibold text-muted-foreground">
+              <Loader2 className="w-7 h-7 animate-spin" />
+              Loading drawing pad...
+            </div>
+            <div className="absolute flex gap-2 bottom-3 right-3">
+              <div className="w-10 h-10 rounded-xl bg-muted animate-pulse" />
+              <div className="w-10 h-10 rounded-xl bg-muted animate-pulse" />
+            </div>
+          </div>
+        </div>
+
+        <div className="relative h-44 pt-4 pb-2 mt-2 mb-2 overflow-hidden border-2 border-dotted rounded-md border-foreground/30">
+          <span className="absolute left-0 right-0 px-2 mx-auto -top-2 w-max text-sm font-bold rounded-full bg-background">
+            Results Preview
+          </span>
+          <div className="flex items-center justify-center h-full gap-2">
+            {Array.from({ length: 5 }, (_, index) => (
+              <div
+                key={index}
+                className="w-14 h-14 rounded-xl bg-muted/60 animate-pulse"
+                style={{ animationDelay: `${index * 100}ms` }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </SearchDialogLoadingShell>
+  );
+};

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/RadicalScreen/RadicalsLoadingFallback.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/RadicalScreen/RadicalsLoadingFallback.tsx
@@ -1,0 +1,39 @@
+import { Loader2 } from "lucide-react";
+import { SearchDialogLoadingShell } from "../SearchDialogLoadingShell";
+
+export const RadicalsLoadingFallback = ({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <SearchDialogLoadingShell title="Radical Search" onClose={onClose}>
+      <div className="relative w-full px-1 mx-auto">
+        <div className="absolute z-[51] w-full -top-1">
+          <span className="px-2 text-sm font-bold rounded-full bg-background">
+            Select Radicals
+          </span>
+        </div>
+        <div className="flex max-h-[calc(100dvh-30px)] flex-wrap items-start justify-center overflow-hidden rounded-md border-2 border-dotted border-foreground/40 px-2 py-3 mt-2">
+          {Array.from({ length: 42 }, (_, index) => (
+            <div
+              key={index}
+              className="w-[47px] h-[45px] ml-1 mb-1 rounded-sm border border-dotted border-foreground/40 bg-muted/50 animate-pulse"
+              style={{ animationDelay: `${(index % 12) * 80}ms` }}
+            />
+          ))}
+        </div>
+        <div className="flex items-center justify-center gap-2 py-2 text-xs font-semibold text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Loading radicals...
+        </div>
+      </div>
+    </SearchDialogLoadingShell>
+  );
+};

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchDialogLoadingShell.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchDialogLoadingShell.tsx
@@ -1,0 +1,42 @@
+import { ReactNode } from "react";
+import { CircleX } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+
+export const SearchDialogLoadingShell = ({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) => {
+  return (
+    <>
+      <button
+        type="button"
+        className="fixed inset-0 z-50 bg-black/80"
+        onClick={onClose}
+        aria-label={`Close ${title}`}
+      />
+      <section
+        className="fixed inset-x-0 bottom-0 z-50 max-h-[100dvh] overflow-hidden rounded-t-3xl border-2 border-t-4 border-dashed bg-background px-2 pb-3 pt-5 shadow-lg animate-in slide-in-from-bottom-4 duration-200"
+        role="status"
+        aria-label={`Loading ${title}`}
+      >
+        <h2 className="sr-only">{title}</h2>
+        {children}
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute top-2 right-2 z-[51] p-4 border-2 border-dashed rounded-xl bg-background"
+          onClick={onClose}
+          aria-label={`Close ${title}`}
+        >
+          <CircleX className="size-8" />
+        </Button>
+      </section>
+    </>
+  );
+};

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import BasicSelect from "@/components/common/BasicSelect";
 import { defaultSearchType } from "@/lib/settings/search-settings-adapter";
 import { RadicalsLoadingFallback } from "./RadicalScreen/RadicalsLoadingFallback";
+import { HandwritingLoadingFallback } from "./HandwritingScreen/HandwritingLoadingFallback";
 
 const RadicalsControl = lazy(() =>
   import("./RadicalScreen/RadicalsControl").then((m) => ({
@@ -454,7 +455,14 @@ export const SearchInput = ({
         // Keyed by search type + reset counter so switching variants or clearing
         // the input starts the drawing pad fresh. Mounted regardless of the
         // drawer's open state so the drawing survives closing/reopening it.
-        <Suspense fallback={null}>
+        <Suspense
+          fallback={
+            <HandwritingLoadingFallback
+              isOpen={openDialogType === searchType}
+              onClose={() => setOpenDialogType("none")}
+            />
+          }
+        >
           <HandwritingControl
             key={`${searchType}-${handwritingResetKey}`}
             variant={

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInput.tsx
@@ -18,6 +18,7 @@ import { CircleX, Search } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import BasicSelect from "@/components/common/BasicSelect";
 import { defaultSearchType } from "@/lib/settings/search-settings-adapter";
+import { RadicalsLoadingFallback } from "./RadicalScreen/RadicalsLoadingFallback";
 
 const RadicalsControl = lazy(() =>
   import("./RadicalScreen/RadicalsControl").then((m) => ({
@@ -430,7 +431,14 @@ export const SearchInput = ({
       )}
 
       {(openDialogType === "radicals" || searchType === "radicals") && (
-        <Suspense fallback={null}>
+        <Suspense
+          fallback={
+            <RadicalsLoadingFallback
+              isOpen={openDialogType === "radicals"}
+              onClose={() => setOpenDialogType("none")}
+            />
+          }
+        >
           <RadicalsControl
             isOpen={openDialogType === "radicals"}
             onClose={() => setOpenDialogType("none")}

--- a/src/components/screens/ListScreen/index.tsx
+++ b/src/components/screens/ListScreen/index.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import LoadingKanjis from "./KanjiList/LoadingKanjis";
 
 const LazyListScreen = lazy(() =>
   import("./ListScreen").then((m) => ({ default: m.ListScreen }))
@@ -10,7 +11,7 @@ const ListScreenFallback = () => (
     <div className="fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
       <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 sticky pt-1 pl-2 pr-1 w-full">
         <div
-          className="h-9 flex-1 min-w-0 rounded-md border bg-muted/40"
+          className="h-9 flex-1 min-w-0 rounded-md border bg-muted/40 animate-pulse"
           aria-hidden
         />
         <div
@@ -23,11 +24,9 @@ const ListScreenFallback = () => (
         />
       </section>
     </div>
-    <div
-      className="relative pt-24 -z-0 flex min-h-48 items-center justify-center overflow-x-hidden"
-      role="status"
-      aria-label="Loading"
-    />
+    <div className="relative pt-24 -z-0 min-h-48 overflow-x-hidden">
+      <LoadingKanjis />
+    </div>
   </>
 );
 

--- a/src/components/screens/SpeedKatakanaScreen/index.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/index.tsx
@@ -1,16 +1,15 @@
 import { lazy, Suspense } from "react";
 import { ErrorBoundary } from "@/components/error";
+import { PracticeRouteLoadingFallback } from "@/components/shared-practice/PracticeRouteLoadingFallback";
 
 const LazySpeedKatakanaScreen = lazy(() => import("./SpeedKatakanaScreen"));
-
-const PracticeRouteFallback = () => (
-  <div className="fixed inset-0 bg-background animate-fade-in" aria-hidden />
-);
 
 const SpeedKatakanaScreen = () => {
   return (
     <ErrorBoundary>
-      <Suspense fallback={<PracticeRouteFallback />}>
+      <Suspense
+        fallback={<PracticeRouteLoadingFallback label="speed katakana" />}
+      >
         <LazySpeedKatakanaScreen />
       </Suspense>
     </ErrorBoundary>

--- a/src/components/shared-practice/PracticeRouteLoadingFallback.tsx
+++ b/src/components/shared-practice/PracticeRouteLoadingFallback.tsx
@@ -1,0 +1,50 @@
+import { Loader2 } from "lucide-react";
+import assetsPaths from "@/lib/assets-paths";
+
+export const PracticeRouteLoadingFallback = ({ label }: { label: string }) => {
+  return (
+    <div
+      className="fixed inset-0 flex flex-col overflow-hidden bg-background animate-fade-in"
+      role="status"
+      aria-label={`Loading ${label}`}
+    >
+      <header className="flex items-center w-full gap-3 px-2 border-b-4 border-dashed shrink-0">
+        <img
+          src={assetsPaths.ICON_SVG}
+          alt=""
+          className="h-7 w-7 my-1.5 opacity-70"
+        />
+        <div className="flex-1 h-2 overflow-hidden rounded-full bg-muted">
+          <div className="w-1/3 h-full rounded-full bg-theme animate-pulse" />
+        </div>
+        {Array.from({ length: 3 }, (_, index) => (
+          <div
+            key={index}
+            className="w-10 h-10 border rounded-xl bg-muted/40 animate-pulse"
+            style={{ animationDelay: `${index * 100}ms` }}
+          />
+        ))}
+      </header>
+
+      <main className="flex flex-col items-center justify-center flex-1 min-h-0 gap-5 px-4">
+        <div className="relative flex items-center justify-center w-full max-w-xl border-2 border-dashed aspect-[4/3] max-h-[55dvh] rounded-3xl bg-muted/20">
+          <div className="absolute w-2/3 h-8 -translate-x-1/2 rounded-lg left-1/2 top-6 bg-muted/60 animate-pulse" />
+          <div className="w-28 h-28 rounded-3xl bg-muted/60 animate-pulse" />
+          <div className="absolute flex gap-3 -translate-x-1/2 bottom-6 left-1/2">
+            {Array.from({ length: 3 }, (_, index) => (
+              <div
+                key={index}
+                className="w-16 h-10 rounded-xl bg-muted/60 animate-pulse"
+                style={{ animationDelay: `${index * 120}ms` }}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+          <Loader2 className="w-5 h-5 animate-spin" />
+          Loading {label}...
+        </div>
+      </main>
+    </div>
+  );
+};

--- a/src/components/site-layout/Header/Header.tsx
+++ b/src/components/site-layout/Header/Header.tsx
@@ -1,8 +1,11 @@
+import { Suspense } from "react";
 import ChangeFontButton from "@/components/dependent/site-wide/ChangeFontButton";
 import { ChangeThemeColorBtn } from "@/components/dependent/site-wide/ChangeThemeColorBtn";
 import { ErrorBoundary } from "@/components/error";
 import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
-import LazyHeaderDrawer from "./LazyHeaderDrawer";
+import LazyHeaderDrawer, {
+  HeaderDrawerLoadingFallback,
+} from "./LazyHeaderDrawer";
 import { HeaderTitle } from "./HeaderTitle";
 
 const Header = () => {
@@ -17,7 +20,9 @@ const Header = () => {
             details="LazyHeaderDrawer in Header"
             fallback={<RefreshPageBtn />}
           >
-            <LazyHeaderDrawer />
+            <Suspense fallback={<HeaderDrawerLoadingFallback />}>
+              <LazyHeaderDrawer />
+            </Suspense>
           </ErrorBoundary>
         </ErrorBoundary>
       </section>

--- a/src/components/site-layout/Header/Header.tsx
+++ b/src/components/site-layout/Header/Header.tsx
@@ -1,6 +1,7 @@
 import ChangeFontButton from "@/components/dependent/site-wide/ChangeFontButton";
 import { ChangeThemeColorBtn } from "@/components/dependent/site-wide/ChangeThemeColorBtn";
 import { ErrorBoundary } from "@/components/error";
+import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
 import LazyHeaderDrawer from "./LazyHeaderDrawer";
 import { HeaderTitle } from "./HeaderTitle";
 
@@ -12,7 +13,12 @@ const Header = () => {
         <ErrorBoundary fallback={null}>
           <ChangeFontButton />
           <ChangeThemeColorBtn />
-          <LazyHeaderDrawer />
+          <ErrorBoundary
+            details="LazyHeaderDrawer in Header"
+            fallback={<RefreshPageBtn />}
+          >
+            <LazyHeaderDrawer />
+          </ErrorBoundary>
         </ErrorBoundary>
       </section>
     </header>

--- a/src/components/site-layout/Header/LazyHeaderDrawer.tsx
+++ b/src/components/site-layout/Header/LazyHeaderDrawer.tsx
@@ -1,18 +1,57 @@
-import { lazy, Suspense, useState } from "react";
-import { Menu } from "lucide-react";
+import { lazy, useState } from "react";
+import { Loader2, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const HeaderDrawer = lazy(() => import("./HeaderDrawer"));
 
-const MenuTriggerFallback = ({ disabled = false }: { disabled?: boolean }) => (
-  <Button
-    variant="outline"
-    size="iconXl"
-    aria-label="Open menu"
-    disabled={disabled}
-  >
-    <Menu className="w-7 h-7" />
-  </Button>
+export const HeaderDrawerLoadingFallback = () => (
+  <>
+    <div className="fixed inset-0 z-50 bg-black/80" aria-hidden="true" />
+    <aside
+      className="fixed top-0 bottom-0 right-0 z-50 flex w-72 flex-col border-l-4 border-dashed bg-background p-4 shadow-lg sm:w-80"
+      role="status"
+      aria-label="Loading navigation menu"
+    >
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 rounded-full bg-muted animate-pulse" />
+          <div className="w-32 h-5 rounded bg-muted animate-pulse" />
+        </div>
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 5 }, (_, index) => (
+          <div
+            key={index}
+            className="h-11 border-2 border-dashed rounded-xl bg-muted/40 animate-pulse"
+          />
+        ))}
+      </div>
+
+      <div className="flex justify-center gap-2 mt-6">
+        {Array.from({ length: 3 }, (_, index) => (
+          <div
+            key={index}
+            className="w-16 h-4 rounded bg-muted animate-pulse"
+          />
+        ))}
+      </div>
+
+      <div className="flex justify-center gap-2 mt-6">
+        {Array.from({ length: 4 }, (_, index) => (
+          <div
+            key={index}
+            className="w-10 h-10 rounded-xl bg-muted animate-pulse"
+          />
+        ))}
+      </div>
+
+      <span className="mt-auto text-xs text-center text-muted-foreground">
+        Loading menu...
+      </span>
+    </aside>
+  </>
 );
 
 /**
@@ -34,11 +73,7 @@ const LazyHeaderDrawer = () => {
     );
   }
 
-  return (
-    <Suspense fallback={<MenuTriggerFallback disabled />}>
-      <HeaderDrawer initiallyOpen />
-    </Suspense>
-  );
+  return <HeaderDrawer initiallyOpen />;
 };
 
 export default LazyHeaderDrawer;

--- a/src/components/site-layout/PracticeHeader.tsx
+++ b/src/components/site-layout/PracticeHeader.tsx
@@ -1,10 +1,13 @@
+import { Suspense } from "react";
 import { Link } from "@/components/dependent/routing";
 import { ErrorBoundary } from "@/components/error";
 import { Progress } from "@/components/ui/progress";
 import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
 import ChangeFontButton from "@/components/dependent/site-wide/ChangeFontButton";
 import { ChangeThemeColorBtn } from "@/components/dependent/site-wide/ChangeThemeColorBtn";
-import LazyHeaderDrawer from "@/components/site-layout/Header/LazyHeaderDrawer";
+import LazyHeaderDrawer, {
+  HeaderDrawerLoadingFallback,
+} from "@/components/site-layout/Header/LazyHeaderDrawer";
 import assetsPaths from "@/lib/assets-paths";
 
 /**
@@ -39,7 +42,9 @@ export const PracticeHeader = ({ progress }: { progress: number }) => {
             details="LazyHeaderDrawer in PracticeHeader"
             fallback={<RefreshPageBtn />}
           >
-            <LazyHeaderDrawer />
+            <Suspense fallback={<HeaderDrawerLoadingFallback />}>
+              <LazyHeaderDrawer />
+            </Suspense>
           </ErrorBoundary>
         </ErrorBoundary>
       </section>

--- a/src/components/site-layout/PracticeHeader.tsx
+++ b/src/components/site-layout/PracticeHeader.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@/components/dependent/routing";
 import { ErrorBoundary } from "@/components/error";
 import { Progress } from "@/components/ui/progress";
+import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
 import ChangeFontButton from "@/components/dependent/site-wide/ChangeFontButton";
 import { ChangeThemeColorBtn } from "@/components/dependent/site-wide/ChangeThemeColorBtn";
 import LazyHeaderDrawer from "@/components/site-layout/Header/LazyHeaderDrawer";
@@ -34,7 +35,12 @@ export const PracticeHeader = ({ progress }: { progress: number }) => {
         <ErrorBoundary fallback={null}>
           <ChangeFontButton />
           <ChangeThemeColorBtn />
-          <LazyHeaderDrawer />
+          <ErrorBoundary
+            details="LazyHeaderDrawer in PracticeHeader"
+            fallback={<RefreshPageBtn />}
+          >
+            <LazyHeaderDrawer />
+          </ErrorBoundary>
         </ErrorBoundary>
       </section>
     </header>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- replace dashboard heatmap hover cards with touch-friendly popovers while retaining clear cyan hover and foreground-border affordances
- add a visible loading state for lazy Item Presentation Settings content
- add a refresh recovery fallback around the lazy header drawer
- wrap header drawers in Suspense with a drawer-shaped loading skeleton
- add interactive, content-shaped loading fallbacks for Radical Search and Handwriting Search
- replace blank recognition, writing, and Speed Katakana route loads with a shared practice-shell skeleton
- populate the initial kanji-list fallback with the existing animated kanji grid
- reset the document scroll position whenever the primary route changes

## Validation

- `pnpm run build`
  - ESLint
  - generated-data scripts
  - TypeScript compilation
  - Vite production build
- confirmed no `Suspense fallback={null}` remains under `src`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7185-1caa-7de6-88e7-9e9b40b791e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7185-1caa-7de6-88e7-9e9b40b791e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

