### PR TITLE
Center page-level loading spinner vertically

### DIFF
--- a/src/components/dependent/site-wide/PageWrapper.tsx
+++ b/src/components/dependent/site-wide/PageWrapper.tsx
@@ -1,12 +1,23 @@
 import { ReactNode, Suspense } from "react";
-import KaomojiAnimation from "@/components/common/KaomojiLoading";
+import { Loader2 } from "lucide-react";
 import { ErrorBoundary } from "@/components/error";
+
+/** Full-page route loading state — vertically centered in the viewport. */
+export const PageLoadingFallback = () => (
+  <div
+    className="flex flex-1 w-full items-center justify-center"
+    role="status"
+    aria-label="Loading"
+  >
+    <Loader2 className="size-7 animate-spin" />
+  </div>
+);
 
 const PageWrapper = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="min-h-dvh bg-background pt-12 pb-28 px-2">
+    <div className="flex min-h-dvh flex-col bg-background pt-12 pb-28 px-2">
       <ErrorBoundary>
-        <Suspense fallback={<KaomojiAnimation />}>{children}</Suspense>
+        <Suspense fallback={<PageLoadingFallback />}>{children}</Suspense>
       </ErrorBoundary>
     </div>
   );

--- a/src/components/screens/CumUseScreen/CumUseScreen.tsx
+++ b/src/components/screens/CumUseScreen/CumUseScreen.tsx
@@ -4,7 +4,7 @@ import { DefaultErrorFallback } from "@/components/error";
 
 import { ChartData } from "@/components/sections/KanjiCumUseChart/helpers";
 import { KanjiCumUseChart } from "@/components/sections/KanjiCumUseChart";
-import KaomojiAnimation from "@/components/common/KaomojiLoading";
+import { PageLoadingFallback } from "@/components/dependent/site-wide/PageWrapper";
 import assetsPaths from "@/lib/assets-paths";
 import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
 import pageItems from "@/components/items/page-items";
@@ -14,7 +14,7 @@ const CumUseScreen = () => {
   useHtmlDocumentTitle(pageItems.cumUseGraphPage.title);
 
   if (status == "pending") {
-    return <KaomojiAnimation />;
+    return <PageLoadingFallback />;
   }
 
   if (status === "error" || data == null) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Page-level route loading (e.g. `/dashboard`, `/mastery`) previously used a spinner with `h-full` inside a `min-h-dvh` container, so it sat near the top instead of the vertical center.
- `PageWrapper` is now a flex column, and its Suspense fallback uses `flex-1` + centered alignment so the spinner sits in the middle of the viewport.
- The same full-page fallback is reused for the cumulative-use chart’s pending state.

## Test plan
- [ ] Navigate to `/dashboard` (hard refresh or throttle network) and confirm the loading spinner is vertically centered
- [ ] Navigate to `/mastery` and confirm the same
- [ ] Spot-check `/docs`-style pages that use `PageWrapper`
- [ ] Confirm inline/dialog spinners (list control bar, sort dialog) are unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f71ae-d31c-7825-899b-050c318203b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f71ae-d31c-7825-899b-050c318203b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

