### PR TITLE
Add broader Playwright end-to-end coverage

### DIFF
--- a/docs/test-list.md
+++ b/docs/test-list.md
@@ -1,0 +1,82 @@
+# End-to-end tests
+
+Playwright specs under `e2e/`. Run with `pnpm test:e2e`.
+
+## Explore screen (`e2e/home.spec.ts`)
+
+- Renders the kanji grid with an item count
+- Search narrows results
+- Card presentation settings popover opens
+- Card presentation can switch border meaning to study status
+- Radical search opens its drawer
+- Clicking a kanji opens and closes the detail drawer
+
+## Search input type inference (`e2e/search-input.spec.ts`)
+
+- Pasting kanji switches to Multi-Kanji with a hint chip
+- Pasting a roman word switches to Meanings
+- Pasting kana keeps the default Readings type and searches
+
+## Search types (`e2e/search-types.spec.ts`)
+
+- Meanings search via type select narrows results
+- Similar shapes search via URL returns matches
+- Clear search restores the full grid
+
+## Sort and filter (`e2e/sort-filter.spec.ts`)
+
+- JLPT filter via URL narrows the grid
+- `sort-primary` via URL is applied
+- Sort and filter dialog Apply updates the URL
+- Clear all restores defaults from the dialog
+
+## Kanji detail drawer
+
+### Stroke order (`e2e/kanji-details.spec.ts`)
+
+- Kanji drawer shows the stroke-order animation section
+
+### Drawer sections & navigation (`e2e/kanji-drawer.spec.ts`)
+
+- Accordion sections render static content
+- Arrow keys move to the next kanji in the list
+- Review pile action shows coming soon popover
+
+## Bookmarks (`e2e/bookmarks.spec.ts`)
+
+- Bookmarking a kanji updates explore badge and dashboard
+- Reading practice bookmarked-only with empty bookmarks disables start
+
+## Navigation (`e2e/navigation.spec.ts`)
+
+- Dashboard renders
+- About page renders
+- Unknown route shows the 404 screen
+
+## Route smoke coverage (`e2e/routes.spec.ts`)
+
+- Mastery page renders coming-soon state
+- Cumulative use graph renders its chart heading
+- Terms of use page renders
+- Privacy policy page renders
+- `/docs` redirects to `/about`
+
+## Site chrome (`e2e/site-chrome.spec.ts`)
+
+- Floating island navigates between primary tabs
+- Practice FAB opens modes and routes to reading practice
+- Header menu opens and routes to a docs page
+- Theme toggle flips dark/light and persists
+
+## Dashboard (`e2e/dashboard.spec.ts`)
+
+- Renders overview sections and activity filters
+
+## Practice modes (`e2e/practice.spec.ts`)
+
+- Reading practice: start a session reaches the game screen
+- Writing practice: initial screen renders
+- Speed katakana: typing the correct romaji advances the word
+- Speed katakana: typing skip advances without matching
+- Reading practice: forgot path returns to the start screen
+- Writing practice: model load failure surfaces retry UI

--- a/e2e/bookmarks.spec.ts
+++ b/e2e/bookmarks.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "./fixtures";
+
+test.describe("bookmarks", () => {
+  test("bookmarking a kanji updates explore badge and dashboard", async ({
+    page,
+  }) => {
+    await page.goto("/?open=%E6%B0%B4"); // 水
+
+    const drawer = page.getByRole("dialog");
+    await expect(drawer).toBeVisible({ timeout: 30_000 });
+
+    const bookmarkButton = drawer.getByRole("button", { name: "Bookmark" });
+    await expect(bookmarkButton).toBeVisible({ timeout: 30_000 });
+    await bookmarkButton.click();
+    await expect(
+      drawer.getByRole("button", { name: "✓ Bookmarked" })
+    ).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(drawer).toBeHidden();
+
+    await expect(page.getByText("✓ 1 Bookmarked")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.goto("/dashboard");
+    await expect(page.getByText("Bookmarks")).toBeVisible({
+      timeout: 30_000,
+    });
+    // 水 is N5 — the band row should show one bookmarked entry.
+    await expect(page.getByText(/^1 \/ \d+$/)).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test("reading practice bookmarked-only with empty bookmarks disables start", async ({
+    page,
+  }) => {
+    await page.goto("/reading-practice");
+
+    await expect(
+      page.getByRole("button", { name: "Start Practicing" })
+    ).toBeVisible({ timeout: 30_000 });
+
+    await page.getByLabel("Bookmarked only").click();
+
+    await expect(page.getByText("0 kanji match your filters")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Start Practicing" })
+    ).toBeDisabled();
+  });
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "./fixtures";
+
+test.describe("dashboard", () => {
+  test("renders overview sections and activity filters", async ({ page }) => {
+    await page.goto("/dashboard");
+
+    await expect(page.getByText(/Saved only on this device/)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByText("All-time Overview")).toBeVisible();
+    await expect(page.getByText("Activity Heatmap")).toBeVisible();
+    await expect(page.getByText("Speed Katakana").first()).toBeVisible();
+    await expect(page.getByText("Bookmarks")).toBeVisible();
+
+    await expect(page.getByLabel("Previous period")).toBeVisible();
+    await expect(page.getByLabel("Next period")).toBeVisible();
+
+    await expect(page.getByLabel("Kanji Writing")).toBeVisible();
+    await expect(page.getByLabel("Kanji Reading")).toBeVisible();
+    await expect(page.getByLabel("Speed Katakana")).toBeVisible();
+  });
+});

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -15,8 +15,14 @@ test.describe("dashboard", () => {
     await expect(page.getByLabel("Previous period")).toBeVisible();
     await expect(page.getByLabel("Next period")).toBeVisible();
 
-    await expect(page.getByLabel("Kanji Writing")).toBeVisible();
-    await expect(page.getByLabel("Kanji Reading")).toBeVisible();
-    await expect(page.getByLabel("Speed Katakana")).toBeVisible();
+    await expect(
+      page.getByRole("checkbox", { name: "Kanji Writing" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("checkbox", { name: "Kanji Reading" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("checkbox", { name: "Speed Katakana" })
+    ).toBeVisible();
   });
 });

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -39,6 +39,24 @@ test.describe("explore screen", () => {
     ).toBeVisible();
   });
 
+  test("card presentation can switch border meaning to study status", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page
+      .getByRole("button", { name: "Card Presentation Settings" })
+      .click();
+
+    await page.getByLabel("Border Color Meaning").click();
+    await page
+      .getByRole("option", { name: "Study Status", exact: true })
+      .click();
+
+    await expect(page.getByText("Bookmarked & Reviewing")).toBeVisible();
+    await expect(page.getByText("No Status")).toBeVisible();
+  });
+
   test("radical search opens its drawer", async ({ page }) => {
     await page.goto("/?search-type=radicals");
 

--- a/e2e/kanji-drawer.spec.ts
+++ b/e2e/kanji-drawer.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "./fixtures";
+
+test.describe("kanji detail drawer", () => {
+  test("accordion sections render static content", async ({ page }) => {
+    await page.goto("/?open=%E6%B0%B4"); // 水
+
+    const drawer = page.getByRole("dialog");
+    await expect(drawer).toBeVisible({ timeout: 30_000 });
+
+    // General Information is open by default.
+    await expect(
+      drawer.getByRole("button", { name: "General Information" })
+    ).toBeVisible({ timeout: 30_000 });
+
+    const structure = drawer.getByRole("button", {
+      name: "Character Structure",
+    });
+    await structure.scrollIntoViewIfNeeded();
+    await structure.click();
+
+    const frequency = drawer.getByRole("button", { name: "Frequency Ranks" });
+    await frequency.scrollIntoViewIfNeeded();
+    await frequency.click();
+
+    await expect(
+      drawer.getByRole("button", { name: /External Links for 水/ })
+    ).toBeVisible();
+  });
+
+  test("arrow keys move to the next kanji in the list", async ({ page }) => {
+    await page.goto("/?open=%E6%B0%B4"); // 水
+
+    const drawer = page.getByRole("dialog");
+    await expect(drawer).toBeVisible({ timeout: 30_000 });
+    await expect(drawer.getByText("水").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.keyboard.press("ArrowRight");
+
+    await expect(page).toHaveURL(/open=/);
+    await expect(page).not.toHaveURL(/open=%E6%B0%B4/);
+    await expect(drawer).toBeVisible();
+  });
+
+  test("review pile action shows coming soon popover", async ({ page }) => {
+    await page.goto("/?open=%E6%B0%B4"); // 水
+
+    const drawer = page.getByRole("dialog");
+    await expect(drawer).toBeVisible({ timeout: 30_000 });
+
+    await drawer
+      .getByRole("button", { name: /Add .+ to my review pile/ })
+      .click();
+    await expect(page.getByText("Coming soon!")).toBeVisible();
+  });
+});

--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -48,4 +48,69 @@ test.describe("practice modes", () => {
     await expect(page.getByText("アメリカ")).toBeVisible();
     await expect(answerBox).toHaveValue("");
   });
+
+  test("speed katakana: typing skip advances without matching", async ({
+    page,
+  }) => {
+    await page.goto("/speed-katakana");
+
+    await page.getByRole("button", { name: "Start Game" }).click();
+    await expect(page.getByText("パーセント")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const answerBox = page.getByPlaceholder('Type romaji or "skip"');
+    await answerBox.pressSequentially("skip");
+    await answerBox.press("Enter");
+
+    await expect(page.getByText("2 / 48")).toBeVisible();
+    await expect(page.getByText("アメリカ")).toBeVisible();
+  });
+
+  test("reading practice: forgot path returns to the start screen", async ({
+    page,
+  }) => {
+    await page.goto("/reading-practice");
+
+    const startButton = page.getByRole("button", { name: "Start Practicing" });
+    await expect(startButton).toBeEnabled({ timeout: 30_000 });
+    await startButton.click();
+
+    const answerBox = page.getByLabel('Type the reading or type "forgot"');
+    await expect(answerBox).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole("button", { name: "Forgot" }).click();
+    await expect(page.getByLabel("Forgot")).toBeVisible();
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Back on an answer prompt (next card) — end the session from there.
+    await expect(
+      page.getByLabel('Type the reading or type "forgot"')
+    ).toBeVisible({ timeout: 30_000 });
+    await page.getByRole("button", { name: "End session" }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Start Practicing" })
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("writing practice: model load failure surfaces retry UI", async ({
+    page,
+  }) => {
+    await page.goto("/writing-practice");
+
+    const startButton = page.getByRole("button", { name: "Start Practicing" });
+    await expect(startButton).toBeEnabled({ timeout: 30_000 });
+    await startButton.click();
+
+    // Fixtures abort /onnx/**, so warmup fails and the error screen appears.
+    await expect(
+      page.getByRole("heading", { name: "Could not load the model" })
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Back" }).click();
+    await expect(startButton).toBeVisible({ timeout: 30_000 });
+  });
 });

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "./fixtures";
+
+test.describe("route smoke coverage", () => {
+  test("mastery page renders coming-soon state", async ({ page }) => {
+    await page.goto("/mastery");
+    await expect(page.getByText("Coming soon")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(
+      page.getByRole("link", { name: /Kanji Reading Practice/ })
+    ).toBeVisible();
+  });
+
+  test("cumulative use graph renders its chart heading", async ({ page }) => {
+    await page.goto("/cumulative-use-graph");
+    await expect(
+      page.getByRole("heading", {
+        name: "Cumulative Use vs Standard Competition Ranking (Frequency)",
+      })
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("terms of use page renders", async ({ page }) => {
+    await page.goto("/terms");
+    await expect(
+      page.getByRole("heading", { name: "Terms of Use", exact: true })
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("privacy policy page renders", async ({ page }) => {
+    await page.goto("/privacy");
+    await expect(
+      page.getByRole("heading", { name: "Privacy Policy", exact: true })
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("/docs redirects to /about", async ({ page }) => {
+    await page.goto("/docs");
+    await expect(page).toHaveURL(/\/about$/);
+    await expect(
+      page.getByRole("heading", { name: "About", exact: true })
+    ).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/e2e/search-types.spec.ts
+++ b/e2e/search-types.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "./fixtures";
+
+test.describe("search types", () => {
+  test("meanings search via type select narrows results", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByLabel("Search Type").click();
+    await page.getByRole("option", { name: "Meanings", exact: true }).click();
+
+    const searchBox = page.getByLabel("Search kanji");
+    await expect(searchBox).toHaveAttribute(
+      "placeholder",
+      "Enter meanings (e.g., world, person)"
+    );
+
+    await searchBox.fill("water");
+    await expect(page.getByText(/\d+ Items? Matched/)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page).toHaveURL(/search-type=meanings/);
+    await expect(page).toHaveURL(/search-text=water/);
+  });
+
+  test("similar shapes search via URL returns matches", async ({ page }) => {
+    await page.goto("/?search-type=similar&search-text=%E6%B0%B4"); // 水
+
+    await expect(page.getByText(/\d+ Items? Matched/)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(
+      page.getByRole("button", { name: /氷|永|泳/ }).first()
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("clear search restores the full grid", async ({ page }) => {
+    await page.goto("/?search-type=meanings&search-text=water");
+
+    await expect(page.getByText(/\d+ Items? Matched/)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.getByRole("button", { name: /Clear search text/ }).click();
+
+    await expect(page.getByLabel("Search kanji")).toHaveValue("");
+    await expect(page.getByText(/\d+ Items(?! Matched)/)).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+});

--- a/e2e/site-chrome.spec.ts
+++ b/e2e/site-chrome.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "./fixtures";
+
+test.describe("site chrome", () => {
+  test("floating island navigates between primary tabs", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
+
+    const island = page.getByRole("navigation", { name: "Primary" });
+    await island.getByRole("link", { name: "Dashboard" }).click();
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.getByText(/Saved only on this device/)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await island.getByRole("link", { name: "Visualize Mastery" }).click();
+    await expect(page).toHaveURL(/\/mastery$/);
+    await expect(page.getByText("Coming soon")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await island.getByRole("link", { name: "Explore Kanji" }).click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("practice FAB opens modes and routes to reading practice", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole("button", { name: "Open practice menu" }).click();
+    await expect(page.getByText("Select a mode")).toBeVisible();
+
+    await page.getByRole("link", { name: /Kanji Reading Practice/ }).click();
+    await expect(page).toHaveURL(/\/reading-practice$/);
+    await expect(
+      page.getByRole("button", { name: "Start Practicing" })
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("header menu opens and routes to a docs page", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Open menu" }).click();
+    const menu = page.getByRole("dialog", { name: "Navigation menu" });
+    await expect(menu).toBeVisible();
+
+    await menu.getByRole("link", { name: "Privacy Policy" }).click();
+    await expect(page).toHaveURL(/\/privacy$/);
+    await expect(
+      page.getByRole("heading", { name: "Privacy Policy", exact: true })
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("theme toggle flips dark/light and persists", async ({ page }) => {
+    await page.goto("/");
+
+    // App default theme is dark.
+    await expect(page.locator("html")).toHaveClass(/dark/);
+
+    await page.getByRole("button", { name: "Toggle theme" }).click();
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => localStorage.getItem("vite-ui-theme"))
+      )
+      .toBe("light");
+
+    await page.reload();
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+  });
+});

--- a/e2e/site-chrome.spec.ts
+++ b/e2e/site-chrome.spec.ts
@@ -19,7 +19,7 @@ test.describe("site chrome", () => {
     });
 
     await island.getByRole("link", { name: "Explore Kanji" }).click();
-    await expect(page).toHaveURL(/\/$/);
+    await expect(page).toHaveURL(/\/(\?.*)?$/);
     await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
   });
 
@@ -56,10 +56,14 @@ test.describe("site chrome", () => {
   test("theme toggle flips dark/light and persists", async ({ page }) => {
     await page.goto("/");
 
-    // App default theme is dark.
+    // App default theme is dark; the toggle lives in the header drawer.
     await expect(page.locator("html")).toHaveClass(/dark/);
 
-    await page.getByRole("button", { name: "Toggle theme" }).click();
+    await page.getByRole("button", { name: "Open menu" }).click();
+    const menu = page.getByRole("dialog", { name: "Navigation menu" });
+    await expect(menu).toBeVisible();
+
+    await menu.getByRole("button", { name: "Toggle theme" }).click();
     await expect(page.locator("html")).not.toHaveClass(/dark/);
     await expect
       .poll(async () =>

--- a/e2e/sort-filter.spec.ts
+++ b/e2e/sort-filter.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "./fixtures";
+
+test.describe("sort and filter", () => {
+  test("JLPT filter via URL narrows the grid", async ({ page }) => {
+    await page.goto("/?filter-jlpt=n5");
+
+    await expect(page.getByText(/\d+ Items Matched/)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(
+      page.getByRole("button", { name: /水|一|人|日/ }).first()
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("sort-primary via URL is applied", async ({ page }) => {
+    await page.goto("/?sort-primary=strokes");
+
+    await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
+    await expect(page).toHaveURL(/sort-primary=strokes/);
+  });
+
+  test("sort and filter dialog apply updates the URL", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
+
+    await page
+      .getByRole("button", { name: "Sort and Filter Settings" })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Sorting and Filtering Settings" })
+    ).toBeVisible();
+
+    // Desktop uses Combobox for Primary sort.
+    await dialog.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: /Stroke Count/ }).click();
+
+    await dialog.getByRole("button", { name: "Apply" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/sort-primary=strokes/);
+    await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("clear all restores defaults from the dialog", async ({ page }) => {
+    await page.goto("/?sort-primary=strokes&filter-jlpt=n5");
+    await expect(page.getByText(/\d+ Items Matched/)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page
+      .getByRole("button", { name: "Sort and Filter Settings" })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByRole("button", { name: "Clear all" }).click();
+    await dialog.getByRole("button", { name: "Apply" }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page).not.toHaveURL(/sort-primary=/);
+    await expect(page).not.toHaveURL(/filter-jlpt=/);
+    await expect(page.getByText(/\d+ Items(?! Matched)/)).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Expands Playwright e2e coverage beyond the existing smoke tests so more of the app’s real user flows are guarded in CI.

Also adds `docs/test-list.md` — a bullet inventory of every current e2e test, grouped by suite file.

### New coverage
- **Routes:** `/mastery`, `/cumulative-use-graph`, `/terms`, `/privacy`, `/docs` → `/about`
- **Site chrome:** floating island tabs, practice FAB → reading practice, header menu → privacy, theme toggle persistence
- **Search / sort:** meanings select search, similar-shapes URL search, clear search, JLPT/sort URL params, sort dialog Apply/Clear all
- **Bookmarks:** bookmark from drawer → explore badge + dashboard N5 count; reading practice “Bookmarked only” empty-deck guard
- **Kanji drawer:** accordion sections, ArrowRight next-kanji, review-pile coming-soon popover
- **Dashboard:** overview sections, duration nav, activity kind filters
- **Practice:** speed katakana skip, reading forgot → end session, writing model-load failure (ONNX aborted in fixtures)
- **Home:** card presentation border meaning → Study Status

Existing fixtures still stub CDN SVGs, sample vocab, `/api/*`, and ONNX so these stay reliable without ML/canvas flakiness.

## Test plan
- [x] `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
- [x] `pnpm test:e2e` — **41 passed**
- [ ] Confirm CI e2e job is green on the PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f768d-0445-7dab-9509-d46db1144c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f768d-0445-7dab-9509-d46db1144c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

