### PR TITLE
Fix floating sidebar Suspense loading fallback

### DIFF
--- a/src/components/site-layout/Header/LazyHeaderDrawer.tsx
+++ b/src/components/site-layout/Header/LazyHeaderDrawer.tsx
@@ -5,53 +5,14 @@ import { Button } from "@/components/ui/button";
 const HeaderDrawer = lazy(() => import("./HeaderDrawer"));
 
 export const HeaderDrawerLoadingFallback = () => (
-  <>
-    <div className="fixed inset-0 z-50 bg-black/80" aria-hidden="true" />
-    <aside
-      className="fixed top-0 bottom-0 right-0 z-50 flex w-72 flex-col border-l-4 border-dashed bg-background p-4 shadow-lg sm:w-80"
-      role="status"
-      aria-label="Loading navigation menu"
-    >
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-2">
-          <div className="w-8 h-8 rounded-full bg-muted animate-pulse" />
-          <div className="w-32 h-5 rounded bg-muted animate-pulse" />
-        </div>
-        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-      </div>
-
-      <div className="flex flex-col gap-3">
-        {Array.from({ length: 5 }, (_, index) => (
-          <div
-            key={index}
-            className="h-11 border-2 border-dashed rounded-xl bg-muted/40 animate-pulse"
-          />
-        ))}
-      </div>
-
-      <div className="flex justify-center gap-2 mt-6">
-        {Array.from({ length: 3 }, (_, index) => (
-          <div
-            key={index}
-            className="w-16 h-4 rounded bg-muted animate-pulse"
-          />
-        ))}
-      </div>
-
-      <div className="flex justify-center gap-2 mt-6">
-        {Array.from({ length: 4 }, (_, index) => (
-          <div
-            key={index}
-            className="w-10 h-10 rounded-xl bg-muted animate-pulse"
-          />
-        ))}
-      </div>
-
-      <span className="mt-auto text-xs text-center text-muted-foreground">
-        Loading menu...
-      </span>
-    </aside>
-  </>
+  <Button
+    variant="outline"
+    size="iconXl"
+    aria-label="Loading navigation menu"
+    disabled
+  >
+    <Loader2 className="w-7 h-7 animate-spin" />
+  </Button>
 );
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The menu Suspense fallback was rendering a full open-drawer skeleton (overlay + aside) while the real drawer was still closed/unmounted, so the loading chrome floated in the air.

**Fix:** Replace `HeaderDrawerLoadingFallback` with a disabled hamburger button that shows a spinner — same size/placement as the real trigger. The actual drawer only appears once `HeaderDrawer` mounts with `initiallyOpen`.

Touched only `LazyHeaderDrawer.tsx`; both `Header` and `PracticeHeader` already share this fallback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f76ec-f995-7a38-a9e2-d64043e82aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f76ec-f995-7a38-a9e2-d64043e82aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

