### PR TITLE
Add codebase review notes from 2026-07-19

### DIFF
--- a/notes/code-review-20260719-111016.md
+++ b/notes/code-review-20260719-111016.md
@@ -1,0 +1,79 @@
+# Codebase Review — 2026-07-19
+
+Reviewer: Claude Code. Branch: `claude/codebase-review-1rcyp0`.
+
+## Health checks: all passing
+
+- **ESLint**: 0 errors (19 warnings, all the benign `react-refresh/only-export-components` kind)
+- **TypeScript**: clean (`tsc -b` for app and e2e)
+- **Unit tests**: 162/162 passing
+- **Production build + PWA**: succeeds
+- **Playwright e2e**: 15/15 passing
+
+Note on the sandbox: installing dependencies required a workaround — `codeload.github.com`
+is blocked by the network policy, so the `kanjicanvas` GitHub dependency can't be fetched
+as a tarball here. It was built locally from a git clone of the pinned commit
+(`a9214105f156def3b96930e5fcf10b7652b7a1f7`); nothing in the repo was changed to make
+installs work.
+
+## Things that look actually wrong
+
+### 1. `kd` and `wkfr` frequency ranks appear swapped (must investigate)
+
+In `src/kanji-worker/helpers.ts:104` we assign `kd: freq[3]` and at line 116 `wkfr: freq[15]`,
+but the `FreqList` tuple in `src/lib/kanji/kanji-worker-types.ts:77` declares index 3 as
+`rank_wkfr` and index 15 (line 89) as `rank_kd`. The inline comments in helpers.ts even
+admit the contradiction (`kd: freq[3], //rank_wkfr` and `wkfr: freq[15], //rank_kd`).
+
+If the tuple declaration reflects how `public/json/kanji_main.json` is generated, then
+everywhere the UI shows "Kanji Database" ranks it is actually showing "Wikipedia Kanji
+Frequency Report" data and vice versa — affecting both the frequency badges
+(`src/components/common/freq/FrequencyBadges.tsx:28`) and sorting/filtering by those
+sources. Present since the initial import. Whichever side is correct, the other must be
+fixed so the two agree.
+
+### 2. Dead fallback in `PartComponentLink.tsx`
+
+`src/components/sections/KanjiDetails/PartComponentLink.tsx:21`:
+`getKanjiInfo?.(component ?? radicalFalseFriends[component])` — by this point `component`
+is guaranteed truthy (line 19 returns early), so the `radicalFalseFriends` fallback can
+never execute. Likely intent:
+`getKanjiInfo?.(component) ?? getKanjiInfo?.(radicalFalseFriends[component])`
+(try the canonical form when the variant itself has no kanji info).
+
+### 3. Stray leading space in `radicals.ts`
+
+`src/lib/radicals.ts:350`: `艹: " ⺾"` — the value is `" ⺾"` with a leading space.
+Harmless only by accident: the URL settings adapter trims search text, and
+`PartComponentLink.tsx:11` defensively calls `.trim()`. But `GlobalRadicalLink`
+(`src/components/dependent/routing/global-links.tsx:96`) still injects the untrimmed
+value into a link URL. Remove the space at the source and drop the `.trim()` workaround.
+
+### 4. NaN hazard in `searchByRadical`
+
+`src/kanji-worker/kanji-search.ts:318-321`: for any character not in
+`radicalStrokeCountMap`, `Number(undefined)` is `NaN`, and `Math.max(min, NaN)` makes the
+minimum stroke filter `NaN`, rejecting every kanji. Currently masked (an unknown radical
+yields empty results anyway via the decomposition check) but fragile. Guard with
+`count == null ? acc : Math.max(acc, Number(count))`.
+
+Related: this function mutates `settings.filterSettings.strokeRange.min` in place. Contained
+today because the worker receives a fresh structured-clone per message, but it would bite
+if ever called with a shared settings object.
+
+## Minor, take-or-leave
+
+- `createFetch` in `src/kanji-worker/helpers.ts:18` never checks `response.ok`, so a 404
+  (e.g. missing JSON asset) surfaces as a confusing JSON-parse error instead of a clear
+  HTTP error. `useJsonFetch` (`src/hooks/use-json.ts:77`) does this correctly — worth mirroring.
+- In `src/hooks/use-json.ts:47-51`, the effect calls `execute()` which rethrows on failure,
+  producing an unhandled promise rejection in the console for every failed fetch. A
+  `.catch(() => {})` in the effect (the error is already captured in state) would silence it.
+- Existing known TODOs: early-exit/LRU cache in `kanji-search.ts:210,278`; ambiguous
+  `阝/衤/飠` radical handling in `radicals.ts:368`; the `回` "#name?" meaning artifact in
+  `General.tsx:130`.
+
+## Bottom line
+
+Nothing is on fire. Item 1 (the kd/wkfr swap) is the only must-investigate because it
+silently mislabels user-facing data; the rest are correctness cleanups and hardening.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive codebase review document capturing health checks, identified issues, and recommendations for the kanji canvas application as of 2026-07-19.

## Changes

- **Added**: `notes/code-review-20260719-111016.md` — A detailed review report documenting:
  - **Health status**: All checks passing (ESLint, TypeScript, unit tests, production build, e2e tests)
  - **Critical issues requiring investigation**:
    - Potential swap of `kd` and `wkfr` frequency rank assignments in `kanji-worker/helpers.ts` vs. type declarations, causing user-facing mislabeling
    - Dead fallback logic in `PartComponentLink.tsx` that can never execute
    - Stray leading space in `radicals.ts` that relies on defensive trimming elsewhere
    - NaN hazard in `searchByRadical` when handling unknown radicals
  - **Minor improvements**: Response validation in `createFetch`, unhandled promise rejection in `use-json.ts`, and existing known TODOs

## Notes

This is a review document only — no source code changes are included. The review identifies four issues of varying severity, with the frequency rank swap flagged as the highest priority due to its impact on user-facing data accuracy.

https://claude.ai/code/session_018Po9aQJ3WLSSdEEfC7SGX1