### PR TITLE
Add Prettier format check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm format:check
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test

--- a/notes/worker-main-thread-double-caching.md
+++ b/notes/worker-main-thread-double-caching.md
@@ -3,7 +3,7 @@
 **Status:** deferred — to be done in its own PR at a later date.
 
 **Risk:** high. This is the one simplification from the codebase-cleanup pass
-that was *not* done, because it changes the worker protocol, turns a synchronous
+that was _not_ done, because it changes the worker protocol, turns a synchronous
 main-thread API into an async one, and can't be fully verified without a real
 app run (`vite build` + Playwright e2e are blocked in the cleanup environment by
 the egress policy on the `kanjicanvas` dependency).
@@ -40,7 +40,7 @@ side.
 
 - The worker loads the whole extended map via `initialize-extended-kanji-map`
   into `KANJI_INFO_EXTENDED_CACHE`.
-- The main thread *also* lazily fills `kanjiInfo.extended` per-kanji as each
+- The main thread _also_ lazily fills `kanjiInfo.extended` per-kanji as each
   kanji is requested
   (`kanji-worker-provider.tsx`, in `kanjiInfoRequest`, ~line 224:
   `kanjiCacheRef.current[kanji].extended = res;`).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview",
     "peek": "prettier --write . && eslint . && tsc -b && vite build && vite preview --host",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "generate-more-info": "node scripts/generate-more-info.mjs",
     "generate-speed-katakana": "node scripts/generate-speed-katakana.mjs"
   },

--- a/src/components/screens/DashboardScreen/HeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/HeatmapGrid.tsx
@@ -18,7 +18,9 @@ export const heatmapFillCn = (level: FreqCategory, emphasizeBorder = false) =>
   level === 0
     ? cn(
         "bg-muted/50 dark:bg-muted/30",
-        emphasizeBorder ? EMPHASIS_BORDER : "border border-border dark:border-border"
+        emphasizeBorder
+          ? EMPHASIS_BORDER
+          : "border border-border dark:border-border"
       )
     : cn(
         freqCategoryCn[level],

--- a/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
@@ -14,10 +14,7 @@ import { ItemTypeSwitch } from "@/components/common/ItemTypeSwitch";
 import { JLPTBordersMeanings } from "@/components/common/jlpt/JLPTBorderMeanings";
 import { StudyStatusBorderMeanings } from "@/components/common/StudyStatusBorderMeanings";
 import { FreqGradientInfoIcon } from "@/components/common/freq/FreqGradientInfoIcon";
-import {
-  useBgSrc,
-  useBgSrcDispatch,
-} from "@/hooks/routing-hooks";
+import { useBgSrc, useBgSrcDispatch } from "@/hooks/routing-hooks";
 import BasicSelect from "@/components/common/BasicSelect";
 import { BorderColorMeaning } from "@/lib/settings/settings";
 

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/use-search-input-controller.ts
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/use-search-input-controller.ts
@@ -160,7 +160,10 @@ export const useSearchInputController = ({
     // Translate first (e.g. romaji → hiragana) so the field and the
     // settled search query stay in sync. Settling the raw keystrokes
     // would search a different string than what the user sees.
-    const updatedValue = translateValue(e.target.value, translateMap[searchType]);
+    const updatedValue = translateValue(
+      e.target.value,
+      translateMap[searchType]
+    );
 
     setValue(updatedValue);
     // NOTE: this is based on https://react.dev/learn/referencing-values-with-refs

--- a/src/components/screens/SpeedKatakanaScreen/use-speed-katakana-progress.ts
+++ b/src/components/screens/SpeedKatakanaScreen/use-speed-katakana-progress.ts
@@ -1,9 +1,5 @@
 import { useMemo } from "react";
-import {
-  computeAverageCpm,
-  countCompletedSets,
-  readSetStats,
-} from "./storage";
+import { computeAverageCpm, countCompletedSets, readSetStats } from "./storage";
 import {
   CHALLENGES_PER_LEVEL,
   LEVELS,

--- a/src/components/sections/KanjiCumUseChart/helpers.test.ts
+++ b/src/components/sections/KanjiCumUseChart/helpers.test.ts
@@ -5,7 +5,12 @@ import { buildTooltipInnerHtml, TooltipContext } from "./chart-tooltip";
 describe("getDataset", () => {
   it("maps series points and applies config label/color", () => {
     const [dataset] = getDataset(
-      { netflix: [[0, 10], [50, 42]] },
+      {
+        netflix: [
+          [0, 10],
+          [50, 42],
+        ],
+      },
       { netflix: { label: "Netflix", color: "#e50914" } }
     );
 

--- a/src/components/sections/KanjiDetails/TextbookVocabulary.tsx
+++ b/src/components/sections/KanjiDetails/TextbookVocabulary.tsx
@@ -1,15 +1,17 @@
 import { useJsonFetch } from "@/hooks/use-json";
 import { TEXT_BOOK_VOCAB_PATH } from "@/lib/assets-paths";
 import { PrimaryDataSources } from "@/components/common/PrimaryDataSources";
-import { TextbookWordEntry, toCommonWordEntries } from "@/lib/sample-vocabulary";
+import {
+  TextbookWordEntry,
+  toCommonWordEntries,
+} from "@/lib/sample-vocabulary";
 import { PaginatedVocabulary } from "./PaginatedVocabulary";
 import { TableSkeleton } from "./TableSkeleton";
 
 export const TextbookVocabulary = ({ kanji }: { kanji: string }) => {
   const url = `${TEXT_BOOK_VOCAB_PATH}/${kanji}.json`;
-  const { data, status, error } = useJsonFetch<Record<string, TextbookWordEntry>>(
-    url
-  );
+  const { data, status, error } =
+    useJsonFetch<Record<string, TextbookWordEntry>>(url);
 
   if (status === "pending" || status === "idle") {
     return <TableSkeleton />;

--- a/src/kanji-worker/kanji-search.test.ts
+++ b/src/kanji-worker/kanji-search.test.ts
@@ -115,7 +115,11 @@ describe("filterKanji", () => {
 
   it("meanings: matches keyword or any meaning", () => {
     expect(
-      filterKanji(allKanji, settings({ type: "meanings", text: "liquid" }), pool)
+      filterKanji(
+        allKanji,
+        settings({ type: "meanings", text: "liquid" }),
+        pool
+      )
     ).toEqual(["水"]);
   });
 

--- a/src/kanji-worker/kanji-search.ts
+++ b/src/kanji-worker/kanji-search.ts
@@ -138,9 +138,8 @@ const SEARCH_DESCRIPTORS: Record<SearchType, SearchDescriptor> = {
     normalize: toRomajiText,
     match: (kanji, { pool, text }) =>
       pool.main[kanji].keyword.includes(text) ||
-      pool.extended[kanji].meanings.find((meaning) =>
-        meaning.includes(text)
-      ) != null,
+      pool.extended[kanji].meanings.find((meaning) => meaning.includes(text)) !=
+        null,
   },
   onyomi: {
     normalize: toHiraganaText,

--- a/src/lib/search-input-logic.test.ts
+++ b/src/lib/search-input-logic.test.ts
@@ -95,7 +95,12 @@ describe("resolvePaste", () => {
         selectionEnd: 2,
         searchType: "multi-kanji",
       })
-    ).toEqual({ value: "水火", caret: 2, nextType: "multi-kanji", announce: true });
+    ).toEqual({
+      value: "水火",
+      caret: 2,
+      nextType: "multi-kanji",
+      announce: true,
+    });
   });
 
   it("keeps similar-type pastes kanji-only without announcing", () => {
@@ -108,7 +113,12 @@ describe("resolvePaste", () => {
         selectionEnd: 1,
         searchType: "similar",
       })
-    ).toEqual({ value: "火水", caret: 2, nextType: "similar", announce: false });
+    ).toEqual({
+      value: "火水",
+      caret: 2,
+      nextType: "similar",
+      announce: false,
+    });
   });
 
   it("ignores a similar-type paste that leaves no kanji", () => {
@@ -116,19 +126,20 @@ describe("resolvePaste", () => {
     // pasting a kanji into an empty field then stripping — the everyday case
     // is a paste whose only kanji fails isKanji. 々 is kana-adjacent: wanakana
     // counts it as kanji but isKanji (CJK unified block) does not.
-    expect(
-      resolvePaste({ ...base, pasted: "々", searchType: "similar" })
-    ).toBe(null);
+    expect(resolvePaste({ ...base, pasted: "々", searchType: "similar" })).toBe(
+      null
+    );
   });
 
   it("switches to readings for kana paste and announces", () => {
-    expect(resolvePaste({ ...base, pasted: "みず", searchType: "meanings" }))
-      .toEqual({
-        value: "みず",
-        caret: 2,
-        nextType: "readings",
-        announce: true,
-      });
+    expect(
+      resolvePaste({ ...base, pasted: "みず", searchType: "meanings" })
+    ).toEqual({
+      value: "みず",
+      caret: 2,
+      nextType: "readings",
+      announce: true,
+    });
   });
 
   it("sends roman words to meanings (or keeps keyword)", () => {
@@ -140,7 +151,12 @@ describe("resolvePaste", () => {
     });
     expect(
       resolvePaste({ ...base, pasted: "water", searchType: "keyword" })
-    ).toEqual({ value: "water", caret: 5, nextType: "keyword", announce: true });
+    ).toEqual({
+      value: "water",
+      caret: 5,
+      nextType: "keyword",
+      announce: true,
+    });
   });
 
   it("keeps the current type for mixed/ambiguous pastes", () => {

--- a/src/providers/create-kanji-lookup-provider.test.tsx
+++ b/src/providers/create-kanji-lookup-provider.test.tsx
@@ -68,7 +68,7 @@ describe("createKanjiLookupProvider", () => {
     });
 
     await waitFor(() =>
-      expect((globalThis.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalled()
+      expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled()
     );
     expect(result.current).toBeNull();
   });

--- a/src/providers/search-settings-provider.tsx
+++ b/src/providers/search-settings-provider.tsx
@@ -11,10 +11,7 @@ import {
   toSearchParams,
   toSearchSettings,
 } from "@/lib/settings/search-settings-adapter";
-import {
-  useSearchParams,
-  useUrlLocation,
-} from "@/hooks/routing-hooks";
+import { useSearchParams, useUrlLocation } from "@/hooks/routing-hooks";
 import { searchSettings } from "./search-settings-hooks";
 import { URL_PARAMS } from "@/lib/settings/url-params";
 import { rememberHomeSearch } from "@/lib/home-search-memory";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `format:check` (`prettier --check .`) next to the existing `format` (`prettier --write .`) script in `package.json`
- Runs `pnpm format:check` in `.github/workflows/ci.yml` so every PR and push to `main` fails if files aren’t Prettier-formatted
- Formats 12 files that were already out of compliance so the new check passes on this branch

## How this gates merges to `main`

CI already runs on `pull_request`. Once this lands, unformatted code will fail the **checks** job. To make that a hard merge blocker, ensure GitHub branch protection on `main` requires the `checks` status check (Settings → Branches → Branch protection rules).

Locally before pushing:

```bash
pnpm format        # fix
pnpm format:check  # verify
```

`.prettierignore` still skips `*.json`, `*.yaml`, and `*.yml`, matching the existing format workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7c03-3bd6-73cc-87ed-8ffd6858e428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7c03-3bd6-73cc-87ed-8ffd6858e428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

