### PR TITLE
Fix kanji worker crash on visit from search race

### DIFF
--- a/src/kanji-worker/kanji-search.test.ts
+++ b/src/kanji-worker/kanji-search.test.ts
@@ -209,4 +209,28 @@ describe("searchKanji", () => {
     );
     expect(result).toEqual(["山", "水", "火"]);
   });
+
+  it("skips kanji that exist in main but lack extended info", () => {
+    const mismatchedPool = {
+      main: {
+        ...pool.main,
+        氷: mainInfo("ice", "n2", 20),
+      },
+      extended: pool.extended,
+    };
+
+    expect(() =>
+      searchKanji(
+        settings({ type: "readings", text: "", primary: "strokes" }),
+        mismatchedPool
+      )
+    ).not.toThrow();
+
+    expect(
+      searchKanji(
+        settings({ type: "readings", text: "", primary: "strokes" }),
+        mismatchedPool
+      )
+    ).toEqual(["山", "水", "火"]);
+  });
 });

--- a/src/kanji-worker/kanji-search.ts
+++ b/src/kanji-worker/kanji-search.ts
@@ -71,13 +71,21 @@ export const filterByKanjiSimple = (
   return allKanji
     .filter((kanji) => {
       const info = kanjiPool.main[kanji];
+      if (info == null) {
+        return false;
+      }
       if ([0, JLPTOptionsCount].includes(jlptFilters.size)) {
         return true;
       }
       return jlptFilters.has(info.jlpt);
     })
     .filter((kanji) => {
+      // Main/extended can briefly diverge (load race) or permanently diverge
+      // (stale SW caches of the two JSON files). Skip rather than crash.
       const exInfo = kanjiPool.extended[kanji];
+      if (exInfo == null) {
+        return false;
+      }
       const withinRange =
         maxStrokes >= exInfo.strokes && exInfo.strokes >= minStrokes;
       return withinRange;
@@ -87,6 +95,9 @@ export const filterByKanjiSimple = (
         return true;
       }
       const info = kanjiPool.main[kanji];
+      if (info == null) {
+        return false;
+      }
       const freq = getFrequency(freqFilter.source, info) ?? Number.MAX_VALUE;
       const withinRange =
         freq >= freqFilter.rankRange.min && freq <= freqFilter.rankRange.max;
@@ -132,29 +143,36 @@ const matchEverything: SearchDescriptor = {
 const SEARCH_DESCRIPTORS: Record<SearchType, SearchDescriptor> = {
   keyword: {
     normalize: toRomajiText,
-    match: (kanji, { pool, text }) => pool.main[kanji].keyword.includes(text),
+    match: (kanji, { pool, text }) =>
+      pool.main[kanji]?.keyword.includes(text) ?? false,
   },
   meanings: {
     normalize: toRomajiText,
     match: (kanji, { pool, text }) =>
-      pool.main[kanji].keyword.includes(text) ||
-      pool.extended[kanji].meanings.find((meaning) => meaning.includes(text)) !=
-        null,
+      (pool.main[kanji]?.keyword.includes(text) ?? false) ||
+      pool.extended[kanji]?.meanings.find((meaning) =>
+        meaning.includes(text)
+      ) != null,
   },
   onyomi: {
     normalize: toHiraganaText,
-    match: (kanji, { pool, text }) => pool.extended[kanji].allOn.has(text),
+    match: (kanji, { pool, text }) =>
+      pool.extended[kanji]?.allOn.has(text) ?? false,
   },
   kunyomi: {
     normalize: toHiraganaText,
     match: (kanji, { pool, text }) =>
-      pool.extended[kanji].allKunStripped.has(text),
+      pool.extended[kanji]?.allKunStripped.has(text) ?? false,
   },
   readings: {
     normalize: toHiraganaText,
-    match: (kanji, { pool, text }) =>
-      pool.extended[kanji].allOn.has(text) ||
-      pool.extended[kanji].allKunStripped.has(text),
+    match: (kanji, { pool, text }) => {
+      const extended = pool.extended[kanji];
+      if (extended == null) {
+        return false;
+      }
+      return extended.allOn.has(text) || extended.allKunStripped.has(text);
+    },
   },
   "multi-kanji": kanjiListSearch,
   handwriting: kanjiListSearch,
@@ -276,8 +294,21 @@ export const sortKanji = (
 
   // TODO: Also add a LRU cache of recently computed results
   return kanjiList.sort((a, b) => {
-    const entryA = { main: kanjiPool.main[a], extended: kanjiPool.extended[a] };
-    const entryB = { main: kanjiPool.main[b], extended: kanjiPool.extended[b] };
+    const mainA = kanjiPool.main[a];
+    const mainB = kanjiPool.main[b];
+    const extendedA = kanjiPool.extended[a];
+    const extendedB = kanjiPool.extended[b];
+    if (
+      mainA == null ||
+      mainB == null ||
+      extendedA == null ||
+      extendedB == null
+    ) {
+      return 0;
+    }
+
+    const entryA = { main: mainA, extended: extendedA };
+    const entryB = { main: mainB, extended: extendedB };
 
     const compareVal = compareBy(primarySort, entryA, entryB);
     if (compareVal != 0) {
@@ -297,9 +328,9 @@ export const searchKanji = (settings: SearchSettings, kanjiPool: DataPool) => {
 export const getSortedByStrokeCount = (kanjiPool: DataPool) => {
   const allKanji = Object.keys(kanjiPool.main);
   return allKanji.sort((a, b) => {
-    const exInfoA = kanjiPool.extended[a];
-    const exInfoB = kanjiPool.extended[b];
-    return numericSort(exInfoA.strokes, exInfoB.strokes);
+    const strokesA = kanjiPool.extended[a]?.strokes ?? -1;
+    const strokesB = kanjiPool.extended[b]?.strokes ?? -1;
+    return numericSort(strokesA, strokesB);
   });
 };
 
@@ -330,6 +361,9 @@ export const searchByRadical = (
   // if kanji has all the radicals in the set then include this in the search result
   const filteredKanjis = filteredKanjisSimple.filter((kanji) => {
     const kanjiRadicalSet = kanjiDecompositionCache[kanji];
+    if (kanjiRadicalSet == null) {
+      return false;
+    }
     return radicalPayload.every((radical) => {
       return kanjiRadicalSet.has(radical);
     });
@@ -340,7 +374,7 @@ export const searchByRadical = (
   // get all radicals in all the remaining kanjis
   const possibleRadicals = kanjis.reduce((acc, kanji) => {
     const kanjiRadicalSet = kanjiDecompositionCache[kanji];
-    kanjiRadicalSet.forEach((item) => acc.add(item));
+    kanjiRadicalSet?.forEach((item) => acc.add(item));
     return acc;
   }, new Set<string>([]));
 

--- a/src/kanji-worker/kanji-worker-hooks.tsx
+++ b/src/kanji-worker/kanji-worker-hooks.tsx
@@ -122,13 +122,20 @@ export const useGetKanjiInfoFn = () => {
 type SearchResult = { kanjis: string[]; possibleRadicals?: Set<string> };
 
 export const useKanjiSearch = (searchSettings: SearchSettings) => {
+  // ItemCountBadge (and similar) can mount before the worker finishes loading
+  // main + extended maps. Searching with only main populated crashes the
+  // worker on `exInfo.strokes` and rejects every pending request via onerror.
+  const ready = useIsKanjiWorkerReady();
+
   const state = useWorkerQuery<SearchResult>(
-    () =>
-      requestWorker({
-        type: "search",
-        payload: searchSettings,
-      }) as Promise<SearchResult>,
-    [searchSettings]
+    ready
+      ? () =>
+          requestWorker({
+            type: "search",
+            payload: searchSettings,
+          }) as Promise<SearchResult>
+      : null,
+    [searchSettings, ready]
   );
 
   return {
@@ -140,13 +147,17 @@ export const useKanjiSearch = (searchSettings: SearchSettings) => {
 };
 
 export const useKanjiSearchCount = (searchSettings: SearchSettings) => {
+  const ready = useIsKanjiWorkerReady();
+
   const state = useWorkerQuery<number>(
-    () =>
-      requestWorker({
-        type: "search-result-count",
-        payload: searchSettings,
-      }) as Promise<number>,
-    [searchSettings]
+    ready
+      ? () =>
+          requestWorker({
+            type: "search-result-count",
+            payload: searchSettings,
+          }) as Promise<number>
+      : null,
+    [searchSettings, ready]
   );
 
   return {

--- a/src/kanji-worker/kanji-worker.ts
+++ b/src/kanji-worker/kanji-worker.ts
@@ -153,6 +153,10 @@ const getSearchPool = () => ({
   similar: KANJI_SIMILAR_CACHE,
 });
 
+const areKanjiCachesReady = () =>
+  Object.keys(KANJI_INFO_MAIN_CACHE).length > 0 &&
+  Object.keys(KANJI_INFO_EXTENDED_CACHE).length > 0;
+
 // "similar" searches need the lazily-fetched similar map before they can run;
 // every other search runs synchronously against the in-memory caches.
 const withSimilarCacheIfNeeded = (
@@ -172,6 +176,13 @@ const withSimilarCacheIfNeeded = (
 };
 
 const handleSearch = requirePayload<SearchSettings>((settings, reply) => {
+  // Main and extended load in parallel. A search that lands between those
+  // completions used to throw on undefined.strokes and kill the worker.
+  if (!areKanjiCachesReady()) {
+    reply.err({ message: "Kanji caches not initialized" });
+    return;
+  }
+
   // Side effect, the first time we search
   // we need to store this in cache which will be useful
   // when searching by radical
@@ -202,6 +213,11 @@ const handleSearch = requirePayload<SearchSettings>((settings, reply) => {
 
 const handleSearchResultCount = requirePayload<SearchSettings>(
   (settings, reply) => {
+    if (!areKanjiCachesReady()) {
+      reply.err({ message: "Kanji caches not initialized" });
+      return;
+    }
+
     withSimilarCacheIfNeeded(settings, reply, () => {
       const pool = getSearchPool();
       const allKanji = Object.keys(pool.main);


### PR DESCRIPTION
## Summary
- Prevent search hooks from firing before the kanji worker finishes loading both main and extended maps (ItemCountBadge was searching early).
- Reject search in the worker until both caches are ready, and null-guard stroke/extended access so mismatched or partial data cannot throw `Cannot read properties of undefined (reading 'strokes')` and kill the worker.
- Add a regression test for kanji present in main but missing from extended.

## Test plan
- [ ] Load the list screen and confirm the app no longer white-screens / worker-errors on first visit
- [ ] Confirm item count and kanji list still populate after worker ready
- [ ] Hard refresh a few times to stress the parallel main/extended load path
- [ ] Run `pnpm exec vitest run src/kanji-worker/kanji-search.test.ts`


Made with [Cursor](https://cursor.com)