### PR TITLE
Adopt study engine event cold archival into V2 plan

### DIFF
--- a/docs/notes/STUDY-ENGINE-EVENT-COLD-ARCHIVAL-PLAN.md
+++ b/docs/notes/STUDY-ENGINE-EVENT-COLD-ARCHIVAL-PLAN.md
@@ -1,27 +1,31 @@
-# Study Engine: Event Cold Archival Proposed Plan
+# Study Engine: Event Cold Archival Plan
 
-Proposed extension to
-[`STUDY-ENGINE-PLAN-V2.md`](./STUDY-ENGINE-PLAN-V2.md) for when Postgres cannot
-hold an unbounded `review_events` history.
+Adopted extension to
+[`STUDY-ENGINE-PLAN-V2.md`](./STUDY-ENGINE-PLAN-V2.md) for bounding Postgres
+`review_events` storage without deleting scheduling history.
 
 Related context:
 [`STUDY-ENGINE-STORAGE-AND-ACCESS-DISCUSSION.md`](./STUDY-ENGINE-STORAGE-AND-ACCESS-DISCUSSION.md).
 
-This is **not** part of the current V2 decisions unless adopted. V2 today keeps
-all immutable review events in the backend relational database.
+Resolved policy:
+
+- Keep a rolling 90-day event tail in Postgres.
+- Archive older events to private Cloudflare R2 Standard account-month chunks.
+- Keep verified cold events indefinitely.
+- Begin SQL purge only after readback, checksum, and replay-parity validation.
 
 ## Problem
 
-Immutable review events are the scheduling source of truth. Under V2 they live
-in Postgres (`review_events`) forever so the backend can:
+Immutable review events are the scheduling source of truth. Hot and cold events
+together allow the backend to:
 
 - Replay a card after a late offline review
 - Rebuild projections after settings / FSRS version changes
 - Audit and recover from corruption
 
-Compacting `account_changes` does **not** reduce `review_events` growth. At
-enough accounts and years of reviews, hot SQL storage for the full event log
-may become too expensive.
+Compacting `account_changes` does **not** reduce `review_events` growth.
+Without archival, enough accounts and years of reviews make hot SQL storage
+for the full event log unnecessarily expensive.
 
 Weekly or biweekly **deletion** of events in favor of a snapshot alone is the
 wrong fix: it breaks late offline replay and destroys rebuildability.
@@ -47,87 +51,92 @@ Bound Postgres event storage while preserving rebuildability.
 ## Design summary
 
 ```text
-Hot (Postgres)                         Cold (object storage)
-----------------                       ----------------------
-recent review_events                   older review_events chunks
-card projections                       immutable, reloadable
+Hot (Postgres)                              Cold (private R2 Standard)
+----------------                            --------------------------
+90-day review_events tail                   older account-month chunks
+card projections                            immutable jsonl.gz
+archive-boundary checkpoints                retained indefinitely
 daily summaries
 domain rows (pile, notes, ...)
-account_changes window
-archive index metadata
+bounded account_changes
+archive manifests
 ```
 
-Normal request path uses hot data only. Rebuild path may fetch cold chunks for
-affected cards, concatenate with the hot tail, and replay with the shared
-deterministic FSRS core.
+Normal request paths use current projections, archive-boundary checkpoints,
+and hot data only. Full settings/FSRS-version rebuilds and disaster recovery
+fetch cold chunks, concatenate them with the hot tail, and replay through the
+canonical Python FSRS adapter.
 
 ## Retention policy
 
 ### Hot retention window
 
-Keep events in Postgres for a configurable hot window.
-
-**Recommended starting point:** 90 days.
+Keep events in Postgres for a rolling **90-day** hot window.
 
 **Hard floor:** must be greater than or equal to the offline access window
 (currently 14 days). Archiving inside the offline window would make ordinary
 late sync depend on cold fetches.
 
-Rationale for 90 days:
+The archiver runs daily or weekly. Ninety days is an age cutoff, not a cadence
+for one large quarterly migration.
+
+Rationale:
 
 - Comfortably above the 14-day offline grant
 - Absorbs clock skew / delayed sync edge cases without cold I/O
 - Still bounds SQL growth per account
 
-### Soft archival (recommended default)
+### Soft archival
 
 1. Select events older than the hot window whose order key is strictly before
    the affected card’s current projection frontier.
-2. Write them into immutable cold chunks.
-3. Record archive index rows in Postgres.
-4. Delete (or mark archived and later purge) those event rows from
-   `review_events`.
-5. Keep projections and daily summaries untouched.
+2. Write them into immutable account-month cold chunks.
+3. Read the object back and verify its checksum.
+4. Replay the candidate archive set and verify projection parity.
+5. Record a ready archive manifest and advance affected per-card boundary
+   checkpoints.
+6. Only then purge those event rows from `review_events`.
+7. Keep current projections and daily summaries untouched.
 
 Events remain authoritative because they are still reloadable.
 
-### Hard deletion (optional later policy)
+### Cold retention
 
-A second TTL may eventually delete cold objects too. That is a separate product
-decision:
-
-- After hard deletion, ancient late histories cannot be perfectly replayed
-- Projections become the practical source of truth past that point
-- Do **not** enable hard deletion in the first archival rollout
+Verified R2 events are retained indefinitely. There is no hard cold-object TTL
+in V2. The incremental storage cost is much smaller than the correctness and
+operational cost of making projections authoritative past an arbitrary date.
+Account deletion remains an explicit exception and removes that account's
+objects, manifests, checkpoints, and hot rows.
 
 ## What stays hot forever
 
 These remain in Postgres regardless of archival:
 
-| Data                             | Why                               |
-| -------------------------------- | --------------------------------- |
-| `review_card_projections`        | Live scheduling state for clients |
-| `review_daily_summaries`         | Dashboard without full event scan |
-| Pile, bookmarks, notes, settings | Current domain state              |
-| Hot `review_events` tail         | Late offline sync + cheap replay  |
-| `review_event_archives` index    | Locate cold chunks                |
-| Bounded `account_changes`        | Ordered sync delivery             |
-| `processed_operations`           | Idempotent sync                   |
+| Data                              | Why                                    |
+| --------------------------------- | -------------------------------------- |
+| `review_card_projections`         | Live scheduling state for clients      |
+| `review_card_archive_checkpoints` | Base state before each card's hot tail |
+| `review_daily_summaries`          | Dashboard without full event scan      |
+| Pile, bookmarks, notes, settings  | Current domain state                   |
+| Hot `review_events` tail          | Late offline sync + cheap replay       |
+| `review_event_archives` manifests | Locate and verify cold chunks          |
+| Bounded `account_changes`         | Ordered sync delivery                  |
+| Non-review `processed_operations` | Idempotency for typed upserts          |
 
 ## Cold object layout
 
-Prefer card-scoped chunks so a single-card rebuild does not download an
-account-wide dump.
-
-```text
-events/{account_id}/{kanji}/{card_type}/{chunk_id}.jsonl.gz
-```
-
-Fallback time-partitioned layout if card-scoped packing is too chatty:
+Use one or more account-month chunks:
 
 ```text
 events/{account_id}/{yyyy}/{mm}/part-{nnnn}.jsonl.gz
 ```
+
+At the generous workload of 200 reviews per account per day, one account-month
+contains about 6,000 events. This is large enough to compress well and small
+enough for rare rebuild reads. With 2,000 accounts, the layout creates about
+24,000 objects per year before any unusually large month is split into parts.
+It avoids the tiny-object and manifest complexity of card-scoped storage while
+preserving straightforward account export and deletion.
 
 Chunk rules:
 
@@ -136,6 +145,8 @@ Chunk rules:
 - Gzip or similar compression
 - Include enough fields to replay without joining deleted hot rows
 - Content hash recorded in the archive index for integrity checks
+- Private bucket; no direct browser URLs or credentials
+- Schema version recorded in metadata
 
 Each serialized event must include at least:
 
@@ -158,69 +169,99 @@ Ordering keys used for replay remain the V2 order:
 3. `deviceSequence`
 4. event ID
 
-## Postgres archive index
+## Postgres archive metadata
 
-New logical table:
+Archive manifest:
 
 ```text
 review_event_archives
   account_id
   archive_id
-  kanji                  -- nullable if account-wide chunk
-  card_type              -- nullable if account-wide chunk
+  year_month
+  part_number
   from_order_key
   to_order_key
   object_uri
   content_sha256
   event_count
   byte_size
+  schema_version
   archived_at
-  status                 -- writing | ready | failed | deleting
+  status                 -- writing | validating | ready | failed | purged
 PRIMARY KEY (account_id, archive_id)
-INDEX (account_id, kanji, card_type, to_order_key)
-INDEX (account_id, archived_at)
+UNIQUE (account_id, year_month, part_number)
+INDEX (account_id, year_month, status)
 ```
+
+`purged` means the covering SQL rows were deleted; the R2 object remains
+immutable, authoritative, and discoverable. Rebuilds read both `ready` and
+`purged` manifests.
+
+Per-card archive-boundary checkpoint:
+
+```text
+review_card_archive_checkpoints
+  account_id
+  kanji
+  card_type
+  through_order_key
+  card_state
+  settings_version
+  fsrs_version
+  source_archive_generation
+  updated_at
+PRIMARY KEY (account_id, kanji, card_type)
+```
+
+The checkpoint is a rebuildable optimization, not a replacement source of
+truth. It stores the canonical card state immediately before the remaining hot
+tail. A late event accepted inside the 14-day offline window can therefore
+replay checkpoint + ordered hot events without reading R2. Settings or
+FSRS-version changes invalidate old checkpoints and regenerate them while
+replaying cold + hot events.
 
 Archiver invariants:
 
 - Never delete hot events until the corresponding archive row is `ready` and
-  the object exists with the expected checksum
-- Never archive an event still required by the live projection frontier unless
-  a rebuild path can load it from cold storage first
+  object readback matches the expected checksum.
+- Never advance a checkpoint until replay parity against the current canonical
+  projection succeeds.
+- Never archive an event at or after the affected card's live projection
+  frontier.
 - Archive jobs are idempotent: retries must not create conflicting ready
-  objects for the same event set
+  objects for the same event set.
+- A failed object, checksum, replay, or metadata transaction leaves the SQL
+  events untouched.
 
 ## Runtime paths
 
-### Normal sync / rating accept
-
-Unchanged from V2 hot path:
+### Normal sync / rating acceptance
 
 1. Verify session + premium entitlement
 2. Accept events into hot `review_events`
-3. Replay affected cards from hot history needed for that card
-   (projection + hot events; cold fetch not required if hot window holds)
-4. Update projections and daily summaries
-5. Append `account_changes`
+3. For a newest in-order event, advance the current canonical projection
+4. For a late event, load the card's archive-boundary checkpoint and ordered
+   hot tail, insert the event, and replay that tail
+5. Update projections and daily summaries
+6. Append `account_changes`
 
-If a late event arrives whose predecessors were archived, the backend loads the
-needed cold chunks for that card, replays full history, writes the new
-projection, and leaves cold objects in place.
-
-Because the product rejects reviews outside the offline access window, cold
-fetches during ordinary sync should be rare when hot retention is ≥ 14 days and
-preferably 90 days.
+Because the backend rejects reviews outside the 14-day offline access window
+and the hot tail is 90 days, an accepted late review is always after the
+archive boundary. Ordinary sync therefore does not fetch R2. If checkpoint
+metadata is missing or invalid, the safe fallback is cold + hot replay; it is
+never acceptable to guess a projection.
 
 ### Projection rebuild (settings / FSRS version change)
 
 Account-wide rebuild job:
 
 1. For each active card, determine required event span
-2. Fetch cold chunks listed by `review_event_archives`
+2. Fetch the account-month chunks listed by `review_event_archives`
 3. Read remaining hot events
 4. Merge/sort by V2 event order
-5. Replay with the shared deterministic FSRS core
-6. Publish a new projection generation atomically
+5. Replay with the canonical Python FSRS adapter
+6. Regenerate archive-boundary checkpoints for the new settings/FSRS version
+7. Publish a new projection generation atomically
 
 Rebuild latency and cost become the main tradeoff of archival.
 
@@ -236,43 +277,58 @@ Unchanged:
 
 - Corrupted local client DB: bootstrap as today
 - Corrupted hot projection: rebuild from cold + hot events
+- Corrupted checkpoint: regenerate it from cold events without trusting it
 - Missing cold object: alert; do not delete remaining hot/archive metadata
   until repaired
 
 ## Archiver job
 
-Background job per account or account shard:
+Run a bounded background job daily or weekly:
 
 1. Compute archive cutoff = now − hot retention window
-2. Find archivable events older than cutoff and before each card’s projection
-   frontier
-3. Pack into chunks under a size/count budget (e.g. N events or M MB)
-4. Upload object with checksum
-5. Insert/update archive index as `ready`
-6. Delete archived rows from `review_events` in the same transactional boundary
-   that the database supports for that step (if object store is external, use
-   a two-phase ready/purge pattern so a crash never loses the only copy)
-7. Emit metrics: events archived, bytes uploaded, hot table size, purge lag
+2. Select a closed account-month event range older than cutoff and before every
+   affected card's projection frontier
+3. Pack one or more size-bounded `jsonl.gz` parts
+4. Insert or resume a deterministic `writing` manifest
+5. Upload each object and read it back
+6. Verify checksum, schema, event count, event boundaries, and ordering
+7. Replay the candidate archived facts plus remaining hot events and compare
+   with current canonical projections
+8. In one Postgres transaction, mark manifests `ready` and advance affected
+   per-card archive-boundary checkpoints
+9. In a later idempotent purge transaction, delete only rows covered by ready
+   manifests and checkpoints
+10. Let autovacuum make deleted pages reusable
+11. Emit metrics: events/bytes archived, compression ratio, hot table and index
+    size, oldest hot event, validation failures, purge lag, and rebuild time
 
 Suggested safety pattern:
 
 ```text
-writing -> upload object -> ready -> purge hot rows
+writing -> upload -> validating -> ready -> checkpoint -> purge SQL rows
 ```
 
-Failed uploads stay `failed` and are retried. Never purge on `writing` or
-`failed`.
+Failed upload or validation stays `failed` and is retried. Never purge on
+`writing`, `validating`, or `failed`. R2 and Postgres cannot share one
+transaction, so the ready/checkpoint/purge sequence intentionally tolerates
+duplicate data but never a period with no authoritative copy.
+
+Deleting rows does not reduce already provisioned Render disk. It prevents
+future growth and lets PostgreSQL reuse pages. The job must begin before
+storage autoscaling raises the permanent allocation; routine `VACUUM FULL` is
+not part of normal archival.
 
 ## Interaction with existing V2 mechanisms
 
-| Mechanism                    | Interaction                                                                           |
-| ---------------------------- | ------------------------------------------------------------------------------------- |
-| 14-day offline access grant  | Hot retention must be ≥ 14 days; user messaging stays tied to the grant, not archival |
-| `account_changes` compaction | Independent; still compact delivery log after bootstrap frontier                      |
-| Bootstrap snapshots          | Remain the device checkpoint; archival is server-only                                 |
-| Deterministic FSRS core      | Same replay rules; input may come from cold + hot concatenation                       |
-| Premium entitlement          | Unchanged; archival is storage policy, not access control                             |
-| Stress test (2.19M events)   | Re-run with archival enabled: measure hot size, cold fetch rebuild time               |
+| Mechanism                    | Interaction                                                                       |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| 14-day offline access grant  | Hot retention is 90 days; user messaging stays tied to the grant, not archival    |
+| `account_changes` compaction | Independent; still compact delivery log after bootstrap frontier                  |
+| Review-event idempotency     | `operationId = event.id`; no second permanent processed row per review            |
+| Bootstrap snapshots          | Remain the device checkpoint; archival is server-only                             |
+| Python FSRS adapter          | Canonical replay consumes ordered cold + hot facts                                |
+| Premium entitlement          | Unchanged; archival is storage policy, not access control                         |
+| Stress test (2.19M events)   | Re-run with archival enabled: measure hot size, validation, and cold rebuild time |
 
 ## Product / UX implications
 
@@ -285,32 +341,31 @@ Failed uploads stay `failed` and are retried. Never purge on `writing` or
 
 ## Rollout plan
 
-1. **Measure first** — run the V2 review-history stress test and estimate
-   per-account / fleet Postgres growth without archival.
-2. **Add archive index + object storage writer** behind a feature flag; do not
-   purge yet.
-3. **Dual-write validation** — archive candidates to cold storage and verify
-   checksum + replay parity against hot rows before purge.
-4. **Enable purge** for accounts above a hot-size threshold.
-5. **Keep hard cold TTL off** until an explicit product decision.
+No event is eligible before day 91:
 
-## Open decisions
+1. **Measure immediately** — generate representative rows and record
+   `pg_total_relation_size`, index size, bloat, and replay performance.
+2. **Provision private R2 Standard** — use least-privilege backend credentials;
+   clients never receive object access.
+3. **Ship manifests, checkpoints, and writer behind flags** — initially create
+   candidate objects without deleting SQL.
+4. **Validate** — read objects back and compare checksums, counts, order
+   boundaries, and canonical replay results against still-hot rows.
+5. **Enable checkpoint publication** — only for validated ranges.
+6. **Enable purge** — on or after day 91, only for ranges whose manifests and
+   checkpoints are ready.
+7. **Fail safe** — if code or validation is late, let Postgres grow temporarily
+   instead of weakening a purge invariant.
 
-- Exact hot retention length (30 vs 90 days; recommend 90 to start)
-- Card-scoped vs time-partitioned chunk layout as the default
-- Maximum chunk size / event count
-- Whether any admin/export API needs direct cold event access
-- Whether hard cold deletion is ever acceptable, and after how long
-- Storage vendor and retention/compliance requirements for cold objects
+There is no hard R2 TTL rollout. Account deletion is implemented and tested
+separately from retention.
 
-## Adoption criteria
+## Remaining implementation choices
 
-Adopt this plan into V2 only when:
+The product decisions are resolved. Implementation benchmarks still choose:
 
-- Measured or projected `review_events` SQL cost exceeds acceptable budget, and
-- Soft archival replay tests show projection parity with full-hot replay, and
-- Rebuild latency budgets for settings changes remain acceptable with cold
-  fetches
-
-Until then, V2’s “retain all review events in Postgres” remains the simpler
-default.
+- Maximum compressed part size and event count
+- Archiver concurrency and per-run account budget
+- R2 retry and alert thresholds
+- Rebuild latency and memory budgets
+- Whether an admin/export API needs direct cold-event access

--- a/docs/notes/STUDY-ENGINE-PLAN-V2.md
+++ b/docs/notes/STUDY-ENGINE-PLAN-V2.md
@@ -22,8 +22,10 @@ The first release deliberately favors simple, explicit rules:
 - One Markdown note exists per kanji.
 - Practice history stores device-scoped summaries, not session histories.
 - Review events are immutable and remain the scheduling source of truth.
-- The backend runs the shared deterministic FSRS core and stores rebuildable
-  canonical card projections.
+- Postgres keeps a rolling 90-day review-event tail; older events move to
+  private R2 Standard account-month chunks and remain there indefinitely.
+- The backend runs the canonical, version-pinned Python FSRS adapter and stores
+  rebuildable canonical card projections.
 - New devices bootstrap from projections and compact history summaries instead
   of downloading every historical review event.
 - The backend uses typed sync and bootstrap endpoints.
@@ -50,13 +52,18 @@ flowchart LR
     App --> Contract["Study Engine Contract"]
     Contract --> Noop["Built-in No-op Engine"]
     Contract --> Engine["kh-study-engine"]
+    Engine --> BrowserScheduler["Pinned ts-fsrs adapter"]
     Engine --> DeviceDB[(Device Metadata DB)]
     Engine --> AccountDB[(Account Dexie DB)]
     Engine --> API[Private Sync API]
     API --> Auth[Auth and Entitlements]
-    API --> Scheduler["Shared deterministic FSRS core"]
-    Scheduler --> Projections[(Card Projections)]
+    API --> BackendScheduler["Pinned py-fsrs adapter"]
+    BrowserScheduler -.-> FsrsContract["Versioned FSRS contract and golden vectors"]
+    BackendScheduler -.-> FsrsContract
+    BackendScheduler --> Projections[(Card Projections)]
     API --> BackendDB[(Backend Relational DB)]
+    BackendDB --> Archiver["Validated 90-day archiver"]
+    Archiver --> R2[(Private R2 Standard)]
 ```
 
 ### Kanji Heatmap owns
@@ -75,9 +82,8 @@ Application components never import `kh-study-engine` directly.
 
 ### `kh-study-engine` owns
 
-- `ts-fsrs` integration
-- A framework-independent deterministic scheduler-core package consumed by
-  both the browser engine and backend
+- A version-pinned `ts-fsrs` adapter
+- A language-neutral, versioned FSRS contract and JSON conformance fixtures
 - Dexie and IndexedDB schemas
 - Review-pile membership and review sessions
 - Card scheduling, previews, and statistics
@@ -92,9 +98,10 @@ Application components never import `kh-study-engine` directly.
 The engine is framework-independent. It does not depend on React, Wouter,
 Tailwind, or Kanji Heatmap components.
 
-The shared scheduler core contains only versioned settings validation, event
-ordering, deterministic PRNG/fuzz behavior, and FSRS replay. It contains no
-Dexie, HTTP, authentication, or UI code.
+The scheduler contract defines settings validation, event ordering, time and
+rating normalization, state mapping, interval rounding, and serialized
+conformance fixtures. It contains no executable TypeScript- or Python-specific
+persistence, HTTP, authentication, or UI code.
 
 ### Private backend owns
 
@@ -104,8 +111,11 @@ Dexie, HTTP, authentication, or UI code.
 - Canonical cloud data
 - Idempotent sync processing
 - Ordered account change delivery
-- The same version-pinned deterministic FSRS core used by the browser
+- A version-pinned `py-fsrs` adapter implementing the same scheduler contract
+- Canonical scheduler output and cross-runtime conformance verification
 - Canonical, rebuildable card projections and compact review summaries
+- Validated review-event archival to private R2 Standard
+- Per-card archive-boundary checkpoints for hot-tail replay
 - Fast new-device bootstrap snapshots
 - Note conflict preservation
 - Billing, rate limits, secrets, and abuse prevention
@@ -392,22 +402,39 @@ export interface ReviewSettings {
 }
 ```
 
-The settings map to these `ts-fsrs` parameters:
+The browser adapter maps the settings to `ts-fsrs`; the backend adapter maps
+the same contract to `py-fsrs`:
 
 ```text
-requestRetention       -> request_retention
-maximumIntervalDays    -> maximum_interval
-enableFuzz             -> enable_fuzz
-enableShortTerm        -> enable_short_term
-learningStepsMinutes   -> learning_steps
-relearningStepsMinutes -> relearning_steps
-modelWeights           -> w
+Contract               ts-fsrs             py-fsrs
+requestRetention       request_retention    desired_retention
+maximumIntervalDays    maximum_interval     maximum_interval
+enableFuzz             portable adapter     portable adapter
+enableShortTerm        enable_short_term    adapter controls empty/nonempty steps
+learningStepsMinutes   learning_steps       learning_steps as timedeltas
+relearningStepsMinutes relearning_steps     relearning_steps as timedeltas
+modelWeights           w                    parameters
 ```
 
 When short-term scheduling is disabled, learning and relearning steps remain
 stored but are ignored. The UI hides those controls. Model weights are an
 advanced option and are validated against the engine's pinned FSRS version.
 FSRS 6 currently uses 21 weights.
+
+The Fuzz policy remains open. The current Python implementation uses unseeded
+randomness for built-in fuzzing, so the two libraries' native fuzz flags must
+never be enabled independently for synchronized accounts. Before the V1
+contract freezes, choose one:
+
+1. **Portable deterministic fuzz (better behavior):** keep `enableFuzz`; run
+   both libraries with native fuzz disabled; apply one contract-defined,
+   event-ID-seeded integer algorithm in TypeScript and Python; require exact
+   golden-vector parity.
+2. **No fuzz (simpler):** remove or permanently disable `enableFuzz`, hide the
+   control, and keep both native fuzz flags false.
+
+Until that decision is made, `enableFuzz` is provisional and no synchronized
+implementation may turn on native library fuzz.
 
 There are no `newCardsPerDay` or `maximumReviewsPerDay` settings.
 
@@ -473,20 +500,31 @@ queued offline, but existing schedules remain in place until the backend
 accepts it and publishes the rebuilt projection generation. The UI shows that
 recalculation is pending.
 
-### Deterministic scheduling
+### Cross-runtime scheduling contract
 
-The browser and backend use the same version-pinned scheduler package. Every
-review event supplies the seed for interval fuzz:
+The browser and backend pin package versions independently:
 
-```text
-fuzzSeed = reviewEvent.id
-```
+- The browser uses `ts-fsrs` through a TypeScript adapter.
+- The FastAPI backend uses `py-fsrs` through a Python adapter.
+- The Python result is canonical. Browser scheduling is an immediate,
+  offline-capable projection that the next successful sync may correct.
 
-The scheduler obtains all randomness from a deterministic PRNG initialized
-with that seed. Replaying the same ordered events, FSRS version, and settings
-must produce byte-equivalent scheduling state on every platform. If the
-selected `ts-fsrs` integration cannot inject deterministic randomness, fuzz
-must remain disabled for synchronized accounts until that capability exists.
+Both adapters consume the same normalized settings and ordered review events.
+They must pass shared JSON golden vectors covering new, learning, review, and
+relearning cards; all ratings; short-term steps; maximum intervals; timestamp
+boundaries; and long replay sequences.
+
+Golden-vector assertions are exact for discrete outputs such as state,
+scheduled interval, due timestamp, repetitions, and lapses. Floating-point
+stability, difficulty, and retrievability use an explicitly versioned
+tolerance because JavaScript and Python calculations are not promised to be
+byte-identical. Canonical backend values are stored and synced without being
+recomputed by the client.
+
+An upgrade to either FSRS package requires a scheduler-contract version
+change, regenerated fixtures, a reviewed output diff, and passing tests in
+both runtimes. If portable fuzz is selected, its algorithm and vectors are
+versioned independently from both FSRS packages.
 
 ## Review sessions
 
@@ -556,8 +594,10 @@ time, then New cards by pile addition time.
 
 ### Rating behavior
 
-- Incorrect answer maps to `again`.
-- Correct answer reveals Hard, Normal, and Easy.
+- Forgot and an incorrect selected answer map to `again`.
+- Reading Review reveals Hard, Normal, and Easy after a correct reading.
+- Writing Review normally derives the rating from handwriting-recognizer rank
+  after the user selects the correct kanji.
 - Normal maps to FSRS `good`.
 - The engine records review time using its clock.
 - The UI does not provide a timestamp.
@@ -581,6 +621,117 @@ export interface ReviewOutcome {
 
 Previewing does not mutate data. Rating recalculates from the actual current
 time before saving.
+
+### Round and run structure
+
+One review round calls `startSession({ cardType, limit: 10 })`. The resulting
+`ReviewSession` owns at most 10 cards and has the same initial, playing, and
+ended presentation rhythm as the existing Reading and Writing Practice
+screens. A review run may contain multiple rounds. Continue starts another
+session from cards eligible at that time; End returns to the review start
+screen.
+
+The engine queue, not React, decides eligibility and order. An `again` rating
+does not use the practice game's immediate “forgotten items first” list.
+Short-term learning or relearning cards become eligible according to their
+calculated due times and may appear in a later round.
+
+Each rating must finish its atomic local transaction before feedback advances
+to the next card. Network sync remains non-blocking. Round completion requests
+an immediate sync, while the outbox remains durable if that request fails.
+
+### Kanji Reading Review flow
+
+Reading Review reuses the Reading Practice prompt, kana input, answer matching,
+feedback, and keyboard behavior. The answer screen shows Forgot instead of
+allowing an incorrect answer to advance. After a correct reading, the feedback
+screen replaces Practice's single Next action with Hard, Normal, and Easy.
+
+```mermaid
+flowchart TD
+    ReadingStart["Start Reading Review round (limit 10)"] --> ReadingPrompt["Show word and reading input"]
+    ReadingPrompt --> ReadingAction{User action}
+    ReadingAction -->|Forgot| ReadingAgain["Rating = Again"]
+    ReadingAction -->|Incorrect text| ReadingPrompt
+    ReadingAction -->|Correct reading| ReadingFeedback["Reveal answer and Hard / Normal / Easy"]
+    ReadingFeedback -->|Hard| ReadingHard["Rating = Hard"]
+    ReadingFeedback -->|Normal| ReadingGood["Rating = Good"]
+    ReadingFeedback -->|Easy| ReadingEasy["Rating = Easy"]
+    ReadingAgain --> ReadingSave["Atomically save card, event, and outbox"]
+    ReadingHard --> ReadingSave
+    ReadingGood --> ReadingSave
+    ReadingEasy --> ReadingSave
+    ReadingSave --> ReadingSync["Schedule non-blocking sync"]
+    ReadingSync --> ReadingRemaining{Cards remain in round?}
+    ReadingRemaining -->|Yes| ReadingPrompt
+    ReadingRemaining -->|No| ReadingEnd["Show round summary and request sync"]
+    ReadingEnd --> ReadingContinue{Continue run?}
+    ReadingContinue -->|Yes| ReadingStart
+    ReadingContinue -->|No| ReadingDone["End run"]
+```
+
+### Kanji Writing Review flow
+
+Writing Review reuses the Writing Practice drawing pad, handwriting-recognizer
+warmup and fallback, candidate construction, `SelectSimilarKanjiDrawer`, and
+feedback drawer. The normal candidate drawer shows Forgot and Grade instead of
+Forgot and Next.
+
+When recognition succeeds, Grade is deterministic:
+
+- If the selected kanji is incorrect, the chosen or derived rating is invalid
+  and the engine records `again` (the user-facing result is Forgot).
+- Correct selection with recognizer rank 1 through 3 records `easy`.
+- Correct selection with recognizer rank 4 through 10 records `good`
+  (user-facing Normal).
+- Correct selection outside the top 10 records `hard`.
+
+These are one-based user-facing ranks. For a zero-based recognizer candidate
+array, indexes 0–2 are Easy, indexes 3–9 are Normal, and `-1` is Hard when the
+user still selects the correct target from the constructed grid.
+
+When the recognizer is unavailable for the run or fails for one card, no rank
+exists. `SelectSimilarKanjiDrawer` shows the candidate grid plus Forgot, Hard,
+Normal, and Easy in that same drawer; it does not add a later rating screen.
+The rating buttons may be visible before selection but remain disabled until a
+candidate is selected. A correct candidate preserves the chosen rating. An
+incorrect candidate invalidates Hard, Normal, or Easy and records `again`.
+
+```mermaid
+flowchart TD
+    WritingStart["Start Writing Review round (limit 10)"] --> WritingWarm["Warm handwriting recognizer"]
+    WritingWarm --> WritingPrompt["Show writing prompt and drawing pad"]
+    WritingPrompt --> WritingAction{User action}
+    WritingAction -->|Forgot| WritingAgain["Rating = Again"]
+    WritingAction -->|Submit drawing| WritingAvailable{Recognizer result available?}
+    WritingAvailable -->|Yes| WritingRecognize["Rank target and build candidate grid"]
+    WritingAvailable -->|No| WritingFallback["Build fallback candidate grid"]
+    WritingRecognize --> WritingAutoDrawer["Drawer: select candidate, Forgot, Grade"]
+    WritingAutoDrawer -->|Forgot| WritingAgain
+    WritingAutoDrawer -->|Grade| WritingCorrect{Selected target kanji?}
+    WritingCorrect -->|No| WritingAgain
+    WritingCorrect -->|Yes| WritingRank{Recognizer rank}
+    WritingRank -->|1 through 3| WritingEasy["Rating = Easy"]
+    WritingRank -->|4 through 10| WritingGood["Rating = Good"]
+    WritingRank -->|Outside top 10| WritingHard["Rating = Hard"]
+    WritingFallback --> WritingManualDrawer["Drawer: select candidate, Forgot, Hard / Normal / Easy"]
+    WritingManualDrawer -->|Forgot| WritingAgain
+    WritingManualDrawer -->|"Hard / Normal / Easy"| WritingManualCorrect{Selected target kanji?}
+    WritingManualCorrect -->|No| WritingAgain
+    WritingManualCorrect -->|Yes| WritingManualRating["Use selected rating"]
+    WritingAgain --> WritingSave["Atomically save card, event, and outbox"]
+    WritingEasy --> WritingSave
+    WritingGood --> WritingSave
+    WritingHard --> WritingSave
+    WritingManualRating --> WritingSave
+    WritingSave --> WritingFeedback["Show feedback and schedule non-blocking sync"]
+    WritingFeedback --> WritingRemaining{Cards remain in round?}
+    WritingRemaining -->|Yes| WritingPrompt
+    WritingRemaining -->|No| WritingEnd["Show round summary and request sync"]
+    WritingEnd --> WritingContinue{Continue run?}
+    WritingContinue -->|Yes| WritingStart
+    WritingContinue -->|No| WritingDone["End run"]
+```
 
 ### Review state lifecycle
 
@@ -610,7 +761,7 @@ flowchart TD
     AuthCheck -->|Yes| Tx[Begin Dexie transaction]
     Tx --> ReadCard[Read current card]
     ReadCard --> EventIdentity["Create event ID and reserve device sequence"]
-    EventIdentity --> Calculate["Calculate FSRS result with event ID fuzz seed"]
+    EventIdentity --> Calculate["Calculate FSRS result with TypeScript adapter"]
     Calculate --> SaveCard[Update derived card]
     SaveCard --> AddEvent["Append event with device sequence and local date"]
     AddEvent --> AddOutbox[Add typed outbox operation]
@@ -844,8 +995,8 @@ device.
 ### Sentence shadowing history
 
 ```ts
-export interface SentenceShadowingSessionProgress {
-  sessionId: string;
+export interface SentenceShadowingChallengeProgress {
+  challengeId: string;
   attemptCount: number;
   lastAttemptAt: string;
   updatedAt: string;
@@ -853,12 +1004,12 @@ export interface SentenceShadowingSessionProgress {
 
 export interface SentenceShadowingHistoryService {
   /**
-   * Atomically increments today's session count and the selected session's
+   * Atomically increments today's attempt count and the selected challenge's
    * attempt count.
    */
-  recordAttempt(
-    sessionId: string
-  ): Promise<SentenceShadowingSessionProgress | null>;
+  recordAttempt(input: {
+    challengeId: string;
+  }): Promise<SentenceShadowingChallengeProgress | null>;
 
   getDailyCounts(input: {
     from: string;
@@ -867,12 +1018,12 @@ export interface SentenceShadowingHistoryService {
 
   getTotal(): Promise<number | null>;
 
-  listSessions(): Promise<SentenceShadowingSessionProgress[] | null>;
+  listChallenges(): Promise<SentenceShadowingChallengeProgress[] | null>;
 }
 ```
 
-Sentence-session IDs are stable content identifiers. Device rows merge into
-account totals, so its heatmap shows attempts across all devices.
+Sentence Shadowing challenge IDs are stable content identifiers. Device rows
+merge into account totals, so its heatmap shows attempts across all devices.
 
 ### Review history
 
@@ -945,7 +1096,7 @@ The dashboard includes:
 - Total Speed Katakana sessions
 - Total Kanji Reading Practice rounds
 - Total Kanji Writing Practice rounds
-- Total Sentence Shadowing sessions
+- Total Sentence Shadowing attempts
 - Total Kanji Reading Reviews
 - Total Kanji Writing Reviews
 - Total New Kanji Added
@@ -965,7 +1116,7 @@ Activity heatmap filters include:
 ### Specialized heatmaps
 
 - Speed Katakana keeps its per-device challenge heatmap.
-- Sentence Shadowing shows one cell per stable session ID, colored by total
+- Sentence Shadowing shows one cell per stable challenge ID, colored by total
   attempt count across devices.
 
 ### Kanji Mastery and Kanji Difficulty
@@ -1200,19 +1351,19 @@ id, [kanji+cardType+reviewedAt], reviewedAt, [deviceId+deviceSequence], localDat
 
 #### `reviewSettings`
 
-| Column                   | Type        | Purpose                   |
-| ------------------------ | ----------- | ------------------------- |
-| `id`                     | `"current"` | Singleton primary key     |
-| `fsrsVersion`            | string      | Parameter compatibility   |
-| `version`                | number      | Optimistic sync version   |
-| `requestRetention`       | number      | Target recall probability |
-| `maximumIntervalDays`    | number      | Interval cap              |
-| `enableFuzz`             | boolean     | Interval fuzz             |
-| `enableShortTerm`        | boolean     | Short-term scheduling     |
-| `learningStepsMinutes`   | number[]    | Learning steps            |
-| `relearningStepsMinutes` | number[]    | Relearning steps          |
-| `modelWeights`           | number[]    | FSRS model weights        |
-| `updatedAt`              | string      | Last update               |
+| Column                   | Type        | Purpose                       |
+| ------------------------ | ----------- | ----------------------------- |
+| `id`                     | `"current"` | Singleton primary key         |
+| `fsrsVersion`            | string      | Parameter compatibility       |
+| `version`                | number      | Optimistic sync version       |
+| `requestRetention`       | number      | Target recall probability     |
+| `maximumIntervalDays`    | number      | Interval cap                  |
+| `enableFuzz`             | boolean     | Provisional; open V1 decision |
+| `enableShortTerm`        | boolean     | Short-term scheduling         |
+| `learningStepsMinutes`   | number[]    | Learning steps                |
+| `relearningStepsMinutes` | number[]    | Relearning steps              |
+| `modelWeights`           | number[]    | FSRS model weights            |
+| `updatedAt`              | string      | Last update                   |
 
 Dexie indexes:
 
@@ -1276,21 +1427,21 @@ Dexie indexes:
 id, &[deviceId+challengeId], deviceId, challengeId
 ```
 
-#### `deviceSentenceShadowingSessions`
+#### `deviceSentenceShadowingChallenges`
 
-| Column          | Type   | Purpose                            |
-| --------------- | ------ | ---------------------------------- |
-| `id`            | string | `deviceId + sessionId` primary key |
-| `deviceId`      | string | Owning device                      |
-| `sessionId`     | string | Stable content identity            |
-| `attemptCount`  | number | Monotonic attempt count            |
-| `lastAttemptAt` | string | Latest completion                  |
-| `updatedAt`     | string | Last update                        |
+| Column          | Type   | Purpose                              |
+| --------------- | ------ | ------------------------------------ |
+| `id`            | string | `deviceId + challengeId` primary key |
+| `deviceId`      | string | Owning device                        |
+| `challengeId`   | string | Stable content identity              |
+| `attemptCount`  | number | Monotonic attempt count              |
+| `lastAttemptAt` | string | Latest completion                    |
+| `updatedAt`     | string | Last update                          |
 
 Dexie indexes:
 
 ```text
-id, &[deviceId+sessionId], deviceId, sessionId
+id, &[deviceId+challengeId], deviceId, challengeId
 ```
 
 #### `reviewDailySummaries`
@@ -1405,7 +1556,7 @@ erDiagram
     DEVICE ||--o{ DEVICE_SEQUENCE_COUNTER : reserves
     DEVICE ||--o{ DEVICE_DAILY_HISTORY : owns
     DEVICE ||--o{ DEVICE_SPEED_CHALLENGE : owns
-    DEVICE ||--o{ DEVICE_SHADOWING_SESSION : owns
+    DEVICE ||--o{ DEVICE_SHADOWING_CHALLENGE : owns
     DEVICE_SEQUENCE_COUNTER ||--o{ REVIEW_EVENT : orders
     REVIEW_PILE_ITEM ||--o{ CARD_PROJECTION : owns
     REVIEW_PILE_ITEM ||--o{ REVIEW_EVENT : records
@@ -1451,10 +1602,10 @@ erDiagram
         string challengeId
         number attemptCount
     }
-    DEVICE_SHADOWING_SESSION {
+    DEVICE_SHADOWING_CHALLENGE {
         string id PK
         string deviceId
-        string sessionId
+        string challengeId
         number attemptCount
     }
     REVIEW_DAILY_SUMMARY {
@@ -1506,6 +1657,9 @@ Every local mutation:
 
 ```ts
 export interface ReviewEventPush {
+  /**
+   * Must equal event.id. The event row is also the idempotency record.
+   */
   operationId: string;
   event: {
     id: string;
@@ -1554,9 +1708,9 @@ export type SyncUpsert =
       value: DeviceSpeedChallengeSyncRecord;
     }
   | {
-      kind: "device-sentence-shadowing-session";
+      kind: "device-sentence-shadowing-challenge";
       operationId: string;
-      value: DeviceSentenceShadowingSyncRecord;
+      value: DeviceShadowingChallengeSyncRecord;
     };
 
 export interface SyncRequest {
@@ -1575,7 +1729,7 @@ export type AccountChange =
   | NoteConflictChange
   | DeviceDailyHistoryChange
   | DeviceSpeedChallengeChange
-  | DeviceSentenceShadowingChange
+  | DeviceShadowingChallengeChange
   | ReviewCardProjectionChange
   | ReviewDailySummaryChange
   | ReviewProjectionMetadataChange;
@@ -1594,6 +1748,15 @@ Each `AccountChange` is a discriminated union member with a sequence, a
 literal kind, and a fully typed domain value. The protocol has no
 `payload: unknown` and does not allow update/delete actions on immutable
 review events.
+
+For `ReviewEventPush`, `operationId` must equal `event.id`. The backend
+deduplicates with the `review_events` primary key and the unique
+`(account_id, device_id, device_sequence)` constraint. Review pushes do not
+create a second permanent row in `processed_operations`; otherwise cold
+archival would not bound SQL growth. That table remains the idempotency store
+for non-review typed upserts. A duplicate event ID or device sequence is
+acknowledged only when the immutable fields match the accepted row; conflicting
+payloads are rejected and logged.
 
 `affectedReviewCardProjections` contains the canonical projection for every
 card changed by review events accepted in this request, independent of change
@@ -1618,9 +1781,9 @@ sequenceDiagram
     App->>Dexie: Read bounded outbox batch and cursor
     App->>API: POST typed pushes and cursor
     API->>DB: Begin account transaction
-    DB->>DB: Dedupe operation IDs
+    DB->>DB: Dedupe event identities and upsert operation IDs
     DB->>DB: Apply domain-specific merges
-    DB->>DB: Replay affected cards with shared FSRS core
+    DB->>DB: Advance or checkpoint-replay affected cards
     DB->>DB: Update affected daily review summaries
     DB->>DB: Append ordered account changes
     DB-->>API: Commit
@@ -1637,20 +1800,24 @@ For each `POST /api/sync`, the backend:
 1. Verifies the HttpOnly session and premium entitlement.
 2. Validates the full typed batch before applying it.
 3. Begins one database transaction.
-4. Skips operations already present in `processed_operations`.
+4. Deduplicates review pushes by event ID/device sequence and skips non-review
+   upserts already present in `processed_operations`.
 5. Applies new operations with entity-specific rules.
-6. Replays each card affected by accepted review events, using the canonical
-   settings and deterministic event order.
+6. Advances a current projection for a newest in-order review; for a late
+   review, replays its affected card from the archive-boundary checkpoint plus
+   the ordered hot tail.
 7. Updates review daily summaries for affected local dates.
 8. Appends domain rows and changed projections to `account_changes`.
-9. Records accepted operation IDs.
+9. Records accepted non-review operation IDs.
 10. Selects the next bounded page after the supplied cursor.
 11. Commits and returns acknowledgements and changes.
 
 A late offline review may invalidate every later projection for that card.
-The backend replays that card's full event stream, not the entire account.
-Concurrent offline reviews can therefore adjust a due date that another device
-previously displayed.
+Because accepted review timestamps are limited by the 14-day offline window
+and Postgres retains 90 days, the backend replays that card's checkpoint + hot
+tail without fetching R2. Concurrent offline reviews can therefore adjust a
+due date that another device previously displayed. A missing or invalid
+checkpoint falls back to cold + hot replay rather than guessing.
 
 A settings, model-weight, or FSRS-version change enqueues one idempotent
 account-wide projection rebuild. The current projection generation remains
@@ -1722,8 +1889,8 @@ sequenceDiagram
   maximum.
 - **Speed challenge:** for one device/challenge, merge attempt count and best
   values by maximum and latest attempt by newest timestamp.
-- **Shadowing session:** for one device/session, merge attempt count by maximum
-  and latest attempt by newest timestamp.
+- **Shadowing challenge:** for one device/challenge, merge attempt count by
+  maximum and latest attempt by newest timestamp.
 - **Card projections:** server-authoritative but rebuildable; accept only from
   the backend and replace older generations locally.
 - **Review daily summaries:** server-authoritative, rebuildable aggregates of
@@ -1731,20 +1898,50 @@ sequenceDiagram
 
 ### Sync triggers
 
-Sync runs:
+Every mutation is durable locally before sync is scheduled. Rating a review
+atomically commits the card projection, immutable event, and outbox operation;
+the review UI waits for that local transaction but never waits for the network.
 
-- At engine startup after session verification
-- Shortly after a local mutation, with debounce
-- When connectivity returns
-- When the tab becomes focused
-- Periodically while an authenticated tab remains active
-- When the user requests Sync Now
+The engine does not poll every 30 seconds. When the outbox changes from empty
+to nonempty, it schedules one one-shot deadline for 30 seconds after the oldest
+pending operation. It starts sync earlier when any of these occurs:
 
-Use the Web Locks API so one tab owns sync work for an account at a time.
-Use exponential backoff with jitter after transient errors.
+- The outbox reaches 10 pending operations.
+- A 10-item review or practice round finishes.
+- The user ends the current review or practice run.
+- Connectivity returns.
+- The tab becomes focused.
+- The user requests Sync Now.
 
-Do not add WebSockets, CRDTs, background service-worker sync, or aggressive
-real-time polling in the first release.
+The engine also syncs at startup after session verification. While an
+authenticated tab remains visible, it performs a remote-change pull at most
+once every five minutes even when its local outbox is empty. This keeps
+multiple devices reasonably current without aggressive polling.
+
+Only one sync may be in flight for an account. Use the Web Locks API so one tab
+owns that work across the browser profile. Mutations committed during an
+in-flight request remain in the outbox; after the request completes, the owner
+starts another request immediately if the 10-operation threshold or oldest
+operation deadline has already been reached.
+
+When the document becomes hidden or receives `pagehide`, the engine may send
+one bounded best-effort request using keepalive transport. It must not block
+navigation or rely on `beforeunload`. The outbox remains the source of
+durability: entries are removed only after an acknowledgement is applied
+locally. If the server accepts a keepalive request but the page closes before
+applying its response, the next startup safely retries the same operation IDs.
+
+Transient failures retain every pending operation and use exponential backoff
+with jitter, capped at five minutes. Startup, explicit Sync Now, reconnect, or
+focus may retry sooner. Successful responses apply acknowledgements, pulled
+changes, canonical projections, and the new cursor in one Dexie transaction.
+
+A review round keeps its current in-memory queue stable while sync applies
+canonical projections. Reconciled due dates and remote changes affect the next
+round; sync does not remove or replace the card currently shown to the user.
+
+Do not add WebSockets, CRDTs, background service-worker sync, empty 30-second
+polling, or more than one concurrent account sync in the first release.
 
 ### Fast bootstrap
 
@@ -1763,7 +1960,7 @@ export interface BootstrapResponse {
   noteConflicts: NoteConflictSyncRecord[];
   deviceDailyHistory: DeviceDailyHistorySyncRecord[];
   speedKatakanaChallenges: DeviceSpeedChallengeSyncRecord[];
-  sentenceShadowingSessions: DeviceSentenceShadowingSyncRecord[];
+  sentenceShadowingChallenges: DeviceShadowingChallengeSyncRecord[];
   reviewCardProjections: ReviewCardProjectionSyncRecord[];
   reviewDailySummaries: ReviewDailySummarySyncRecord[];
   reviewProjectionMetadata: ReviewProjectionMetadataSyncRecord;
@@ -1798,18 +1995,19 @@ sequenceDiagram
     API-->>App: Changes committed after snapshot
 ```
 
-The backend retains all immutable review events for audit, projection rebuild,
-and disaster recovery. Full-log replay is a backend recovery and verification
-tool, not the normal new-device path.
+The backend retains all immutable review events across the 90-day Postgres tail
+and indefinite private R2 archive. Full-log replay is a backend recovery and
+verification tool, not the normal new-device path.
 
 ### Projection invalidation and recovery
 
-- A new review replays only its affected card.
-- A late event replays its affected card from the beginning because it may
-  change every later interval.
+- A newest in-order review advances only its current affected-card projection.
+- A late event replays its affected card from the archive-boundary checkpoint
+  plus ordered hot events because it may change every later hot interval.
 - A pile membership change updates the projection's active/removed status.
 - A settings or engine-version change rebuilds every card asynchronously and
-  publishes a new projection generation atomically.
+  publishes a new projection generation and new boundary checkpoints
+  atomically after cold + hot replay.
 - Daily review summaries are rebuilt for dates affected by late events or
   corrected pile-addition metadata.
 - A corrupted local account database is deleted and restored through
@@ -1824,7 +2022,14 @@ tool, not the normal new-device path.
 
 The backend may compact old `account_changes` after all supported clients can
 bootstrap beyond the compaction frontier. Event retention is independent:
-immutable review events remain available for canonical rebuilds.
+immutable review events remain available in Postgres or R2 for canonical
+rebuilds.
+
+Detailed archival invariants, account-month object layout, rollout, and cost
+assumptions are specified in
+[`STUDY-ENGINE-EVENT-COLD-ARCHIVAL-PLAN.md`](./STUDY-ENGINE-EVENT-COLD-ARCHIVAL-PLAN.md)
+and
+[`STUDY-ENGINE-STORAGE-AND-ACCESS-DISCUSSION.md`](./STUDY-ENGINE-STORAGE-AND-ACCESS-DISCUSSION.md).
 
 ## Backend relational schema
 
@@ -1841,6 +2046,9 @@ operation_id
 processed_at
 PRIMARY KEY (account_id, operation_id)
 ```
+
+This table stores non-review typed-upsert idempotency records. A review event's
+own primary key is its idempotency record.
 
 #### `account_changes`
 
@@ -1890,6 +2098,9 @@ PRIMARY KEY (account_id, kanji)
 
 #### `review_events`
 
+This table contains the rolling 90-day hot tail. Older rows remain
+authoritative in R2 account-month chunks.
+
 ```text
 account_id
 event_id
@@ -1905,6 +2116,52 @@ PRIMARY KEY (account_id, event_id)
 INDEX (account_id, kanji, card_type, reviewed_at)
 UNIQUE (account_id, device_id, device_sequence)
 ```
+
+#### `review_event_archives`
+
+```text
+account_id
+archive_id
+year_month
+part_number
+from_order_key
+to_order_key
+object_uri
+content_sha256
+event_count
+byte_size
+schema_version
+archived_at
+status
+PRIMARY KEY (account_id, archive_id)
+UNIQUE (account_id, year_month, part_number)
+INDEX (account_id, year_month, status)
+```
+
+`status` is `writing`, `validating`, `ready`, `failed`, or `purged`. SQL event
+rows may be deleted only after the covering manifest is `ready` and affected
+boundary checkpoints have advanced. `purged` means the SQL rows were removed;
+the R2 object remains authoritative and available to rebuilds.
+
+#### `review_card_archive_checkpoints`
+
+```text
+account_id
+kanji
+card_type
+through_order_key
+card_state
+settings_version
+fsrs_version
+source_archive_generation
+updated_at
+PRIMARY KEY (account_id, kanji, card_type)
+```
+
+These rows are rebuildable base states immediately before each card's hot
+event tail. They make accepted late-event replay independent of R2 on the
+ordinary sync path. Full settings/FSRS-version rebuilds regenerate them from
+cold + hot events.
 
 #### `review_settings`
 
@@ -2005,16 +2262,16 @@ updated_at
 PRIMARY KEY (account_id, device_id, challenge_id)
 ```
 
-#### `device_sentence_shadowing_sessions`
+#### `device_sentence_shadowing_challenges`
 
 ```text
 account_id
 device_id
-session_id
+challenge_id
 attempt_count
 last_attempt_at
 updated_at
-PRIMARY KEY (account_id, device_id, session_id)
+PRIMARY KEY (account_id, device_id, challenge_id)
 ```
 
 #### `notes`
@@ -2056,13 +2313,15 @@ erDiagram
     ACCOUNT ||--o{ BOOKMARK : owns
     ACCOUNT ||--o{ REVIEW_PILE_ITEM : owns
     ACCOUNT ||--o{ REVIEW_EVENT : records
+    ACCOUNT ||--o{ REVIEW_EVENT_ARCHIVE : archives
+    ACCOUNT ||--o{ REVIEW_ARCHIVE_CHECKPOINT : checkpoints
     ACCOUNT ||--|| REVIEW_SETTINGS : configures
     ACCOUNT ||--o{ REVIEW_CARD_PROJECTION : materializes
     ACCOUNT ||--o{ REVIEW_DAILY_SUMMARY : aggregates
     ACCOUNT ||--|| REVIEW_PROJECTION_METADATA : versions
     ACCOUNT ||--o{ DEVICE_DAILY_HISTORY : aggregates
     ACCOUNT ||--o{ DEVICE_SPEED_CHALLENGE : tracks
-    ACCOUNT ||--o{ DEVICE_SHADOWING_SESSION : tracks
+    ACCOUNT ||--o{ DEVICE_SHADOWING_CHALLENGE : tracks
     ACCOUNT ||--o{ NOTE : owns
     NOTE ||--o{ NOTE_CONFLICT : preserves
 
@@ -2087,6 +2346,23 @@ erDiagram
         string reviewedAt
         string deviceId
         number deviceSequence
+    }
+    REVIEW_EVENT_ARCHIVE {
+        string archiveId PK
+        string accountId
+        string yearMonth
+        number partNumber
+        string objectUri
+        string contentSha256
+        string status
+    }
+    REVIEW_ARCHIVE_CHECKPOINT {
+        string accountId PK
+        string kanji PK
+        string cardType PK
+        string throughOrderKey
+        object cardState
+        string fsrsVersion
     }
     REVIEW_PILE_ITEM {
         string accountId PK
@@ -2128,10 +2404,10 @@ erDiagram
         string challengeId PK
         number attemptCount
     }
-    DEVICE_SHADOWING_SESSION {
+    DEVICE_SHADOWING_CHALLENGE {
         string accountId PK
         string deviceId PK
-        string sessionId PK
+        string challengeId PK
         number attemptCount
     }
     NOTE {
@@ -2156,7 +2432,8 @@ ReviewService facade
 ├── CardProjectionRepository
 ├── ReviewEventRepository
 ├── ReviewSessionManager
-├── SharedDeterministicFsrsCore
+├── TypeScriptFsrsAdapter
+├── SchedulerContractValidator
 ├── ReviewSettingsRepository
 ├── ReviewDailySummaryRepository
 ├── EngineClock
@@ -2164,8 +2441,8 @@ ReviewService facade
 ```
 
 These parts are implementation details and can be unit-tested independently.
-The backend imports the same `SharedDeterministicFsrsCore`; it does not import
-browser persistence or session-management code.
+The backend implements the same contract with its own `PythonFsrsAdapter`; it
+does not import TypeScript, browser persistence, or session-management code.
 
 ## Selecting an engine
 
@@ -2244,9 +2521,10 @@ monitoring alerts when the deployed engine reports `unavailable`.
 
 - Kanji Heatmap remains GPLv3.
 - `kh-study-engine` is public and GPL-compatible.
-- The shared scheduler-core package uses a permissive GPL-compatible license
-  so the private backend can consume it without coupling to browser code.
+- The language-neutral scheduler contract and golden-vector fixtures use a
+  permissive GPL-compatible license so both repositories can consume them.
 - `ts-fsrs` is MIT.
+- `py-fsrs` is MIT.
 - Dexie is Apache-2.0.
 - Required notices are retained.
 - The private backend remains separate and proprietary.
@@ -2263,8 +2541,8 @@ terms.
 1. Publish and test the versioned engine contract.
 2. Add the no-op engine and React provider.
 3. Add Vite virtual-module selection.
-4. Publish the version-pinned deterministic FSRS core shared by browser and
-   backend.
+4. Resolve the V1 fuzz policy, publish the versioned FSRS contract and golden
+   vectors, and implement pinned TypeScript and Python adapters that pass them.
 5. Add device metadata and account-scoped Dexie databases.
 6. Implement review pile, projections, events, settings, and migrations.
 7. Add review facade and repository unit tests.
@@ -2277,9 +2555,11 @@ terms.
 14. Implement typed sync, canonical backend projections, and relational
     schema.
 15. Implement fast bootstrap and projection rebuild jobs.
-16. Add multi-device, retry, conflict, bootstrap, and rebuild tests.
-17. Add the pinned production build.
-18. Add monitoring for accidental no-op production deployments.
+16. Implement private R2 account-month archival, archive-boundary checkpoints,
+    validation, and feature-flagged SQL purge.
+17. Add multi-device, retry, conflict, bootstrap, archival, and rebuild tests.
+18. Add the pinned production build.
+19. Add monitoring for accidental no-op production deployments.
 
 ## Required tests
 
@@ -2288,12 +2568,31 @@ terms.
 - Pile removal tombstones both cards.
 - No daily card/review limits are applied.
 - Rating atomically updates card, event, and outbox.
+- Reading Forgot records Again; a correct reading exposes Hard, Normal, and
+  Easy in the feedback UI.
+- Writing correct-selection ranks 1–3, 4–10, and outside top 10 record Easy,
+  Good, and Hard respectively.
+- Any incorrect writing candidate invalidates another rating and records Again.
+- Writing recognition failure exposes manual Hard, Normal, and Easy in the
+  candidate drawer without adding a later rating screen.
 - Settings are shared by reading and writing.
 - Settings changes deterministically rebuild cards.
-- Deterministic fuzz produces the same intervals from the same event IDs in
-  browser and backend runtimes.
+- TypeScript and Python adapters pass the same base FSRS golden vectors with
+  both libraries' native fuzz disabled.
+- If portable fuzz is selected, both adapters produce exact event-ID-seeded
+  fuzz vectors.
+- If no fuzz is selected, the contract and UI omit or reject the setting.
+- Replaying the same inputs in the canonical Python adapter is deterministic.
 - Duplicate sync operation IDs do not duplicate data.
+- A duplicate review identity with different immutable fields is rejected.
 - Lost sync responses are safe to retry.
+- The oldest pending outbox operation triggers sync within 30 seconds without
+  empty periodic requests.
+- Ten pending operations and round/run completion trigger immediate,
+  non-blocking sync attempts.
+- Concurrent tabs and mutations during an in-flight request never create
+  overlapping account syncs or lose outbox entries.
+- A keepalive response lost during `pagehide` is safely retried on startup.
 - Review events from two offline devices are both retained.
 - Clock ties order by device ID, device sequence, and event ID.
 - `deviceSequence` preserves same-device order and never acts as a
@@ -2306,7 +2605,7 @@ terms.
 - Daily practice history from two devices sums without lost increments.
 - Same-device daily rows merge counters by maximum.
 - Speed challenge rows merge best and latest values correctly.
-- Shadowing session rows merge attempt counts and latest times correctly.
+- Shadowing challenge rows merge attempt counts and latest times correctly.
 - Review totals count immutable rating events.
 - First-time new-kanji totals count one pile item, not its two cards.
 - Stale note updates preserve conflict copies.
@@ -2317,6 +2616,17 @@ terms.
   replay.
 - Changes committed after the bootstrap cursor are pulled normally.
 - Rebuilt daily summaries match a full immutable-event aggregation.
+- Review pushes deduplicate by event identity without permanent duplicate
+  `processed_operations` rows.
+- Archive validation failure never deletes hot review events.
+- Ready account-month objects pass checksum, count, boundary, ordering, and
+  replay-parity validation before SQL purge.
+- A late event inside the offline window replays checkpoint + hot tail without
+  fetching R2.
+- Settings/FSRS-version rebuilds from cold + hot facts reproduce canonical
+  projections and regenerate archive checkpoints.
+- Account deletion removes its hot events, manifests, checkpoints, and R2
+  objects.
 
 ### Review-history stress test
 
@@ -2327,7 +2637,12 @@ Measure and publish:
 
 - Batched event-ingestion throughput and database growth
 - Full backend projection-rebuild wall time, CPU, and peak memory
-- Single-card replay latency for a late event near the beginning of history
+- Single-card checkpoint + hot-tail replay latency for an accepted event near
+  the 14-day lateness limit
+- Diagnostic cold + hot single-card rebuild latency from earliest history
+- Ninety-day hot-table/index size and steady-state bloat
+- Archive compression, object-operation count, validation time, and purge lag
+- Cold + hot rebuild time, R2 bytes read, and regenerated-checkpoint parity
 - Bootstrap payload compressed/uncompressed size and server response time
 - IndexedDB bootstrap-apply time and storage size
 - Time until `/mastery` and `/dashboard` are interactive
@@ -2343,7 +2658,8 @@ required new-device workflow.
 
 - Offline access window: 14 days.
 - FSRS settings: shared by reading and writing.
-- FSRS execution: one version-pinned deterministic core in browser and backend.
+- FSRS execution: pinned TypeScript and Python adapters implement one
+  versioned contract; backend output is canonical.
 - Notes: one per kanji.
 - Review pile: one item per kanji.
 - Pile list order: newest first.
@@ -2357,3 +2673,22 @@ required new-device workflow.
 - Backend cards: canonical, rebuildable projections.
 - New-device recovery: consistent bootstrap snapshot plus later cursor pulls.
 - Sync transport: typed push, ordered cursor pull, and fast bootstrap.
+- Review rounds: at most 10 cards; a run may contain multiple rounds.
+- Reading ratings: Forgot is Again; correct answers expose Hard/Normal/Easy.
+- Writing ratings: correct rank 1–3 is Easy, 4–10 is Normal, outside top 10 is
+  Hard; an incorrect candidate is Again.
+- Writing recognizer fallback: manual Hard/Normal/Easy remains inside the
+  candidate drawer.
+- Review-event hot retention: rolling 90 days in Postgres.
+- Review-event cold storage: private R2 Standard account-month chunks retained
+  indefinitely.
+- Archive rollout: copy, read back, checksum, and replay-validate before SQL
+  purge; retain SQL on any failure.
+
+## Open product decisions
+
+- FSRS interval fuzz:
+  - **Portable deterministic fuzz:** keep the setting and implement one
+    event-ID-seeded, integer-only algorithm in both adapters.
+  - **No fuzz:** remove or permanently disable the setting for the simpler V1.
+  - Never enable the two libraries' native fuzz independently.

--- a/docs/notes/STUDY-ENGINE-STORAGE-AND-ACCESS-DISCUSSION.md
+++ b/docs/notes/STUDY-ENGINE-STORAGE-AND-ACCESS-DISCUSSION.md
@@ -27,18 +27,18 @@ their data is not lost.
 - V2 already has a checkpoint-style path for **devices**: bootstrap from card
   projections and compact daily summaries, not the full event log.
 - Compacting `account_changes` (the sync delivery log) is the first safe
-  cleanup lever in the written plan.
-- Under the current plan, compacting `account_changes` does **not** delete
-  `review_events`. Immutable review events remain in Postgres.
+  cleanup lever and remains independent of event archival.
+- V2 keeps 90 days of `review_events` in Postgres and retains older events in
+  private R2 Standard account-month chunks.
 - Weekly/biweekly **deletion** of review events is risky because late offline
-  reviews need the full event stream for that card to rebuild correctly.
+  reviews require ordered replay. The adopted design instead uses verified cold
+  facts plus a per-card archive-boundary checkpoint and hot tail.
 - The existing **14-day offline access window** is already the user-facing
   “come online periodically” rule. Framing it as “open the app online at least
   every couple of weeks” matches the plan; weekly is stricter than necessary
   unless the grant window is shortened.
-- If Postgres cannot hold unbounded event history, prefer **cold archival**
-  (events leave SQL but remain reloadable) over checkpoint deletion. That
-  option is sketched later in this note; it is not spelled out in V2 yet.
+- Cold archival is part of V2: events leave SQL only after object readback,
+  checksum verification, and replay parity, and remain reloadable indefinitely.
 
 ---
 
@@ -147,10 +147,12 @@ online again.
 
 ## Where backend event logs are stored
 
-In V2, backend review history lives in the relational database (Postgres, or
-equivalent) as the `review_events` table.
+V2 keeps a rolling 90-day event tail in Postgres and archives older immutable
+events to a private Cloudflare R2 Standard bucket. R2 events are retained
+indefinitely so they remain available for projection rebuild, audit, and
+disaster recovery.
 
-Logical columns:
+The hot `review_events` table and each serialized cold event contain:
 
 - `account_id`
 - `event_id`
@@ -163,7 +165,7 @@ Logical columns:
 - `local_date`
 - `utc_offset_minutes`
 
-The plan keeps these rows as the scheduling source of truth for:
+Hot and cold events together remain the scheduling source of truth for:
 
 - Audit
 - Projection rebuild
@@ -180,171 +182,181 @@ bootstrap from:
 Bootstrap is described in V2 as the V1 checkpoint format for devices. Full-log
 replay is a backend recovery/verification tool, not the normal new-device path.
 
-### Compacting `account_changes` vs keeping events
+### Review-volume-safe sync infrastructure
 
-Even after `account_changes` is compacted:
+Archiving `review_events` would not bound SQL growth if each review also left
+another permanent row in `processed_operations` or `account_changes`.
 
-- **Yes, all `review_events` are still kept** under the current written plan.
-- Change-log compaction only shrinks the sync delivery queue once clients can
-  catch up via bootstrap.
-- Event retention is explicitly independent of that cleanup.
+V2 therefore uses three separate rules:
 
-Rough capacity intuition (order of magnitude only):
+- Review-event `operationId` equals `event.id`. The backend deduplicates review
+  pushes with the `review_events` primary key and unique device sequence; it
+  does not create a second permanent `processed_operations` row per review.
+- Non-review typed upserts continue to use `processed_operations`.
+- `account_changes` is compacted after supported clients can bootstrap beyond
+  its compaction frontier.
 
-- Each event row is small (hundreds of bytes with indexes).
-- The plan’s stress test (about 2.19M events: 2,000/day for three years) is an
-  abuse/benchmark bound, not a typical user.
-- Postgres is likely fine early; pressure appears at many accounts × long
-  unbounded retention.
-
----
-
-## Cold archival option (if SQL cannot hold unbounded events)
-
-This section entertains the constraint: **we may not have bandwidth/capacity
-to keep every review event in Postgres forever.**
-
-Cold archival is a coherent extension of V2. It is **not** yet specified in
-the plan document.
-
-### Goal
-
-Bound Postgres event storage while preserving rebuildability, instead of
-weekly checkpoint deletion.
-
-### Hot vs cold
-
-**Keep hot in Postgres:**
-
-- Card projections (current scheduling state)
-- Review daily summaries (dashboard)
-- Pile, notes, bookmarks, settings
-- A recent tail of `review_events` for late offline sync and cheap single-card
-  replay
-- Sync infra (`account_changes` window, `processed_operations`)
-
-**Move cold (object storage such as S3/R2/GCS, or another cheap append-only
-store):**
-
-- Older immutable `review_events` past the chosen hot retention window
-
-### Suggested policy
-
-1. **Hot retention window** — e.g. 30–90 days of events in Postgres.
-   Must be ≥ the offline access window (14 days is the product floor, not
-   necessarily the archive floor).
-2. **Archive frontier** — events older than the hot window are written to cold
-   storage, then deleted or marked archived in Postgres.
-3. Per card, archive only events that are strictly before that card’s current
-   projection frontier. Do not drop events still required to explain the live
-   projection unless cold metadata can reload them.
-
-### Rebuild behavior after archival
-
-| Operation                             | Behavior                                                 |
-| ------------------------------------- | -------------------------------------------------------- |
-| Normal sync / new review              | Hot events + current projection only                     |
-| Late offline review inside hot window | Replay from hot Postgres events                          |
-| Full card rebuild / disaster recovery | Load that card’s cold segment(s) + hot tail, then replay |
-| New device bootstrap                  | Still projections + summaries; no full event download    |
-
-Devices stay cheap. Only the backend pays cold-fetch cost, and mainly on rare
-rebuild paths.
-
-### Example cold layout
-
-```text
-events/{account_id}/{kanji}/{card_type}/{chunk_id}.jsonl.gz
-```
-
-or by time:
-
-```text
-events/{account_id}/{yyyy}/{mm}/part-000.jsonl.gz
-```
-
-Chunks should be append-only and immutable. Postgres can keep a small index,
-for example:
-
-```text
-review_event_archives
-  account_id
-  kanji / card_type (or null for account-wide chunks)
-  from_order_key
-  to_order_key
-  object_uri
-  event_count
-  archived_at
-```
-
-### Soft archival vs hard deletion
-
-**A. Soft archival (recommended under the capacity constraint):**
-
-- Events leave Postgres but remain reloadable from cold storage.
-- Extremely late rebuilds are slower (cold fetch + replay) but still correct.
-- Matches “events remain authoritative.”
-
-**B. Hard deletion after some cold TTL:**
-
-- Eventually drop cold events too.
-- Ancient late offline histories can no longer be perfectly replayed.
-- Projections become the practical source of truth past that point.
-- Real correctness/product tradeoff; not free.
-
-For “SQL is too expensive, but we still care about recoverability,” choose
-**A**.
-
-### Interaction with the 14-day offline rule
-
-- Archive only after a window larger than 14 days (e.g. ≥ 30–90 days hot).
-- Normal offline users should not hit cold storage on sync.
-- Extremely stale devices may need a cold fetch for affected cards, or reviews
-  older than the offline window are rejected (V2 already validates timestamps
-  against the 14-day window).
-- User-facing guidance can remain: be online within the offline access window
-  so sync and offline access stay valid. Archival is an ops concern behind
-  that.
-
-### Relationship to earlier checkpoint idea
-
-| Approach                            | What happens to events              | Risk                                      |
-| ----------------------------------- | ----------------------------------- | ----------------------------------------- |
-| Weekly/biweekly checkpoint deletion | Delete history; keep snapshot only  | Breaks late offline replay / rebuild      |
-| Compact `account_changes` only      | Events stay in Postgres             | Does not solve unbounded event SQL growth |
-| Soft cold archival                  | Events leave SQL, remain reloadable | Extra infra; rare rebuilds slower         |
-| Hard delete after cold TTL          | Events eventually gone              | Lose perfect ancient replay               |
-
-Cold archival is the option that addresses SQL capacity without treating the
-checkpoint as “delete the source of truth every two weeks.”
-
-### Cost shape under cold archival
-
-- SQL holds a **bounded** event tail per account, not unbounded history.
-- Object storage holds the long tail cheaply.
-- Rebuild jobs become “fetch cold chunks for N cards” rather than unbounded
-  hot-table growth.
-- `account_changes` compaction remains independent and should still happen.
+The non-review receipt table is low-volume rather than strictly bounded. Its
+retention can be revisited from measured usage; it is not multiplied by the
+146-million-review planning bound. These cleanup paths are independent of cold
+archival.
 
 ---
 
-## Practical stance distilled from the discussion
+## Back-of-the-envelope capacity and cost
 
-1. **Devices:** already checkpoint-like via bootstrap projections + summaries.
-2. **Sync delivery log:** compact `account_changes` when safe.
-3. **Review events (current V2 text):** stay in Postgres `review_events`.
-4. **If Postgres cannot afford that:** add soft cold archival (hot tail in SQL,
-   long tail in object storage, reload on rebuild).
-5. **User messaging:** align with the 14-day offline access window rather than
-   inventing a separate weekly deletion policy.
-6. **Entitlement:** premium check gates cloud/sync; offline grant separately
-   gates cached local access for 14 days.
+Estimate dated **July 21, 2026**. It is a planning bound, not a vendor quote.
+All figures are in USD.
 
-## Open follow-ups
+### Workload assumption
 
-- Whether to add an explicit “Event cold archival” section to
-  `STUDY-ENGINE-PLAN-V2.md`.
-- Concrete hot retention length (30 vs 90 days, etc.).
-- Whether hard deletion after a cold TTL is ever acceptable for this product.
-- Storage/cost budgets from the plan’s review-history stress test once
-  measured.
+- 2,000 daily active users
+- 200 review ratings per user per day
+- 400,000 review events per day
+- 146,000,000 review events per year
+- 4.63 ratings per second on average
+
+Two hundred ratings means 20 ten-item rounds. That is plausible for a heavy
+learner. Assuming every one of 2,000 registered users does this every day is
+deliberately generous. For comparison, 25% daily activity at 100 ratings per
+active user produces 18.25 million events per year, one eighth of the planning
+bound.
+
+### SQL storage assumption
+
+Budget **1 to 1.5 KB of attributable hot SQL storage per accepted rating**.
+This is intentionally conservative and includes the event heap row, primary
+key and replay indexes, page overhead/bloat allowance, and bounded sync
+infrastructure attributable to reviews. It assumes review pushes do not create
+a second permanent idempotency row.
+
+Without archival:
+
+- End-of-year event-attributable SQL: **146 to 219 GB**
+- Average first-year stored amount while growing linearly: **73 to 109.5 GB**
+
+With a rolling 90-day hot tail:
+
+- Steady hot event footprint: **36 to 54 GB**
+- Average first-year hot amount during the initial ramp and steady tail:
+  approximately **31.6 to 47.3 GB**
+
+Actual size must be measured from representative data before selecting the
+production plan:
+
+```sql
+SELECT count(*) FROM review_events;
+SELECT pg_total_relation_size('review_events');
+SELECT pg_indexes_size('review_events');
+```
+
+The benchmark should also measure bounded `account_changes`, non-review
+`processed_operations`, autovacuum behavior, write-ahead log volume, backups,
+and projection-rebuild compute.
+
+### Render estimate
+
+Current references:
+
+- [Render pricing](https://render.com/pricing)
+- [Render Postgres flexible plans](https://render.com/docs/postgresql-refresh)
+
+Render bills Postgres storage at **$0.30 per GB-month** independently of
+compute.
+
+- No archival, Basic-1GB compute at $19/month: approximately **$491 to
+  $622/year**. This is a price floor, not a recommendation; 1 GB RAM is risky
+  for this row count and rebuild workload.
+- No archival, Pro-4GB compute at $55/month: approximately **$923 to
+  $1,054/year**.
+- Ninety-day hot retention, Pro-4GB compute: approximately **$774 to
+  $830/year**, plus negligible R2 cost.
+
+These figures exclude the FastAPI web service/worker, observability, taxes,
+unusual bandwidth, and backup charges not included by the selected plan.
+Render storage cannot be reduced after provisioning, so archival must start
+before autoscaling permanently raises allocated capacity. Deleted pages should
+be reused through normal autovacuum; routine `VACUUM FULL` is not part of the
+plan.
+
+### Heroku estimate
+
+Current references:
+
+- [Heroku pricing](https://www.heroku.com/pricing/)
+- [Heroku Postgres plans](https://elements.heroku.com/addons/heroku-postgresql)
+
+Heroku plans have fixed storage tiers:
+
+- Essential-2 provides 32 GB at $20/month and does not fit the generous
+  90-day estimate.
+- Standard-0 provides 64 GB at $50/month, or **$600/year**. A 36 to 54 GB hot
+  tail can fit, but the upper bound leaves little room for projections,
+  sync tables, bloat, and operational headroom.
+- Without archival, the first-year 146 to 219 GB endpoint requires at least
+  Standard-2 with 256 GB at $200/month, or **$2,400/year**. The upper estimate
+  is still close enough to the tier limit to require measurement.
+
+Heroku's tier jump makes archival financially more significant than on Render.
+Render's independently scalable storage is the safer initial choice while
+actual row size and active-user behavior are unknown.
+
+### Cloudflare R2 estimate
+
+Current reference:
+[Cloudflare R2 pricing](https://developers.cloudflare.com/r2/pricing/).
+
+R2 Standard includes 10 GB-month of storage, 1 million Class A operations, and
+10 million Class B operations per month. Additional storage is $0.015 per
+GB-month with no internet-egress charge.
+
+Assume compressed canonical JSON Lines consumes 100 to 300 bytes per event:
+
+- At the end of year one, approximately 110 million events are older than 90
+  days: **11 to 33 GB** compressed.
+- First-year R2 Standard storage and operation cost should be approximately
+  **$0 to $2** after the monthly free tier.
+- Each later full year adds roughly **15 to 44 GB**, approximately $0.23 to
+  $0.66 per month at current storage rates.
+
+Account-month chunks create about 24,000 objects per year for 2,000 accounts,
+far below the monthly Class A free allowance. R2 Infrequent Access has no
+Standard free tier and adds retrieval charges, so Standard is simpler and
+likely cheaper at this scale.
+
+---
+
+## Adopted cold-archival policy
+
+The detailed design lives in
+[`STUDY-ENGINE-EVENT-COLD-ARCHIVAL-PLAN.md`](./STUDY-ENGINE-EVENT-COLD-ARCHIVAL-PLAN.md).
+
+The resolved policy is:
+
+- Keep 90 rolling days of events in Postgres.
+- Run the archiver daily or weekly; do not perform one large migration every
+  90 days.
+- Store one or more immutable `jsonl.gz` chunks per account/month in a private
+  R2 Standard bucket.
+- Keep verified R2 events indefinitely.
+- Maintain a rebuildable per-card archive-boundary checkpoint so a late event
+  inside the 14-day offline window replays from checkpoint + hot tail without
+  fetching cold history.
+- Do not purge SQL until object readback, checksum verification, and replay
+  parity all pass.
+- If verification fails, retain SQL rows and alert.
+- New-device bootstrap remains projections + summaries; it never downloads
+  cold events.
+- Full settings/FSRS-version rebuilds and disaster recovery read cold + hot
+  facts through the canonical Python adapter.
+- Account deletion removes the account's hot rows, archive manifests,
+  checkpoints, and R2 objects.
+
+No event becomes eligible before day 91. The archive writer and validation path
+can therefore ship behind feature flags before the first purge. Correctness
+wins over the retention target: if purge readiness is late, Postgres grows
+temporarily rather than deleting an unverified source of truth.
+
+The user-facing offline guidance remains tied to the 14-day access grant, not
+to archival. Premium entitlement still gates cloud sync; the offline grant
+separately gates cached local access.


### PR DESCRIPTION
## Summary
- Adopt the 90-day Postgres hot tail + private R2 Standard account-month cold archival policy into the study engine V2 plan.
- Specify archive manifests, per-card archive-boundary checkpoints, validation-before-purge, and indefinite cold retention.
- Capture capacity/cost bounds (Render, Heroku, R2) and review-volume-safe sync rules so archival actually bounds SQL growth.

## Test plan
- [ ] Skim `STUDY-ENGINE-PLAN-V2.md` decisions and architecture diagram for cold archival + Python/ts-fsrs adapters
- [ ] Confirm `STUDY-ENGINE-EVENT-COLD-ARCHIVAL-PLAN.md` matches the adopted policy (90-day hot window, R2 layout, checkpoint/purge sequence)
- [ ] Confirm `STUDY-ENGINE-STORAGE-AND-ACCESS-DISCUSSION.md` cost estimates and adopted-policy section align with the archival plan


Made with [Cursor](https://cursor.com)