### PR TITLE
Polish study notes, activity filters, and practice FAB contrast

### DIFF
--- a/src/components/screens/DashboardScreen/ActivityKindFiltersRow.tsx
+++ b/src/components/screens/DashboardScreen/ActivityKindFiltersRow.tsx
@@ -24,7 +24,7 @@ export const ActivityKindFiltersRow = ({
             checked={filters[kind]}
             onCheckedChange={(v) => onChange(kind, v === true)}
           />
-          <Label htmlFor={id} className="cursor-pointer text-sm font-semibold">
+          <Label htmlFor={id} className="text-xs font-semibold cursor-pointer">
             {ACTIVITY_KIND_LABELS[kind]}
           </Label>
         </div>

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownEditor.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownEditor.tsx
@@ -9,7 +9,7 @@ import { getMarkdownHighlightSegments } from "./markdown";
  */
 const sharedEditorTextClass = cn(
   "m-0 box-border p-3.5",
-  "font-mono text-sm font-normal not-italic leading-[1.55rem] tracking-normal",
+  "font-mono text-base font-normal not-italic leading-[1.55rem] tracking-normal",
   "text-left whitespace-pre-wrap break-words [overflow-wrap:anywhere]",
   "border-0"
 );

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
@@ -80,7 +80,7 @@ const KanjiStudyNotes = ({ kanji }: { kanji: string }) => {
           value="view"
           className="mt-1.5 motion-safe:data-[state=active]:animate-in motion-safe:data-[state=active]:fade-in-0 motion-safe:data-[state=active]:slide-in-from-bottom-1 motion-safe:data-[state=active]:duration-200"
         >
-          <div className="overflow-hidden bg-background rounded-xl border-[3px] border-dashed border-border">
+          <div className="overflow-hidden bg-background rounded-xl border-[3px] border-dashed pb-4 border-border">
             <MarkdownPreview source={notes} />
           </div>
         </TabsContent>

--- a/src/components/site-layout/PracticeFab.tsx
+++ b/src/components/site-layout/PracticeFab.tsx
@@ -29,6 +29,11 @@ export const PracticeFab = () => {
   const [open, setOpen] = useState(false);
   const bgSrc = useBgSrc();
   const hasBgMeaning = bgSrc !== "none";
+  // Secondary (contrast) only when the page heatmap bg is meaningful.
+  // Today that applies on `/` only. Once `/mastery` ships a heatmap, include
+  // it here too. `/dashboard` (and other FAB routes) always stay primary.
+  const useSecondaryVariant = location === "/" && hasBgMeaning;
+
   const buttonRef = useScrollLockSettleRef<HTMLButtonElement>();
 
   if (!fabHrefs.has(location)) {
@@ -48,10 +53,10 @@ export const PracticeFab = () => {
         <PracticeButton
           ref={buttonRef}
           size="icon"
-          variant={hasBgMeaning ? "secondary" : "primary"}
+          variant={useSecondaryVariant ? "secondary" : "primary"}
           className={cn(
             "fixed-viewport-layer fixed z-40 rounded-full h-[5rem] w-[5rem] p-6 border-b-[8px] active:translate-y-[5px] active:border-b-[3px] [&_svg]:size-10 right-[calc(0.35rem+5px)] bottom-[calc(1rem+env(safe-area-inset-bottom))]",
-            hasBgMeaning && "border-foreground/40"
+            useSecondaryVariant && "border-foreground/40"
           )}
           aria-label="Open practice menu"
           aria-expanded={open}


### PR DESCRIPTION
## Summary
- Keep the practice FAB on the secondary (contrast) variant only when the explore heatmap background is meaningful; dashboard and other FAB routes stay primary.
- Bump study notes markdown editor text to `text-base`, add bottom padding on the notes preview, and shrink activity kind filter labels slightly.

## Test plan
- [ ] On `/` with a heatmap background, confirm the practice FAB uses the secondary/contrast style.
- [ ] On `/dashboard` (and other FAB routes), confirm the practice FAB stays primary.
- [ ] Open kanji study notes: editor text should be larger; preview should have a bit more bottom padding.
- [ ] On dashboard activity filters, confirm labels still look balanced at the smaller size.


Made with [Cursor](https://cursor.com)