### PR TITLE
Polish study notes UI, FAB contrast, and kanji details disclaimers

### DIFF
--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -49,15 +49,20 @@ export const ImprovementCTA = () => {
 
 export const KanjiDetailsBottom = ({ kanji }: { kanji: string }) => {
   return (
-    <>
-      <p className="my-4 text-xs text-left">
-        <strong>⚠ Note:</strong> The speak buttons 🔊 🎧 rely on your{" "}
-        {"browser's"} built-in text-to-speech, which may not work in some
-        devices.
+    <div className="my-4">
+      <p className="text-xs text-left">
+        {"⚠️"} The speak buttons 🔊 🎧 rely on your {"browser's"} built-in
+        text-to-speech, which may not work in some devices.
+      </p>
+      <p className="text-xs text-left">
+        {"⚠️"} We strive for accuracy, but mistakes can happen. If you find an
+        content issue, please report it{" "}
+        <ExternalTextLink href={outLinks.githubContentIssue} text="here" /> 🐞🐛
+        . Always verify important information with official sources.
       </p>
 
       <BottomBar includeNode={<KanjiKeyboardShortcuts kanji={kanji} />} />
-    </>
+    </div>
   );
 };
 const StrokeAnimation = lazy(() => import("./StrokeAnimation"));

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownPreview.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownPreview.tsx
@@ -113,7 +113,7 @@ export const MarkdownPreview = ({ source }: { source: string }) => {
   if (source.trim().length === 0) {
     return (
       <p className="px-4 py-8 text-sm text-center text-muted-foreground">
-        Nothing to view yet.
+        Your notes are empty. Start writing to see them here.
       </p>
     );
   }

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownPreview.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownPreview.tsx
@@ -112,7 +112,7 @@ const components: Components = {
 export const MarkdownPreview = ({ source }: { source: string }) => {
   if (source.trim().length === 0) {
     return (
-      <p className="px-4 py-8 text-sm text-center text-muted-foreground">
+      <p className="px-4 pb-8 text-base text-center pt-11 text-muted-foreground">
         Your notes are empty. Start writing to see them here.
       </p>
     );

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -196,9 +196,9 @@ export const externalLinks: { name: string; url: (x: string) => string }[] = [
 // https: //www.verbix.com/webverbix/japanese/miru
 
 export const outLinks = {
-  githubIssue: "https://github.com/PikaPikaGems/kanji-heatmap/issues/63",
+  githubIssue: "https://github.com/PikaPikaGems/kanji-heatmap/issues/241",
   githubContentIssue:
-    "https://github.com/PikaPikaGems/kanji-heatmap-data/issues/5",
+    "https://github.com/PikaPikaGems/kanji-heatmap-data/issues/27",
   discord: "https://discord.gg/Ash8ZrGb4s",
   ririkku: `https://ririkku.com/?utm_source=kanjiheatmap`,
   twitter: "https://x.com/pikapikagemsJP",


### PR DESCRIPTION
## Summary

- Limit the practice FAB secondary variant to the explore heatmap (`/`) so dashboard and other routes keep the primary styling.
- Polish study notes: larger editor/preview text, clearer empty-state copy, and spacing tweaks on the preview panel.
- Add a content accuracy disclaimer on kanji details and update GitHub issue links for general and content reports.
- Minor dashboard polish: smaller activity filter labels.

## Test plan

- [ ] Open `/` with a heatmap background — practice FAB uses secondary styling with border.
- [ ] Open `/dashboard` — practice FAB uses primary styling (not secondary).
- [ ] Open a kanji details page — TTS disclaimer and new content accuracy disclaimer render with working issue links.
- [ ] Open study notes on a kanji — empty preview shows "Your notes are empty..." copy; editor and preview use larger text; preview tab spacing looks correct.
- [ ] Dashboard activity filters — labels render at smaller text size.


Made with [Cursor](https://cursor.com)