### PR TITLE
Fullscreen study notes editor on coarse-pointer devices

### DIFF
--- a/.cursor/rules/tests-only-when-asked.mdc
+++ b/.cursor/rules/tests-only-when-asked.mdc
@@ -1,0 +1,27 @@
+---
+description: Do not write or update tests unless the user explicitly asks
+alwaysApply: true
+---
+
+# Tests only when asked
+
+Do **not** create, update, or expand automated tests unless the user explicitly asks for tests in the current request.
+
+## Do not (unless asked)
+
+- Add new `*.test.ts` / `*.test.tsx` / `*.spec.*` files
+- Extend existing test files while implementing a feature or bugfix
+- “Be thorough” by adding coverage for code you just wrote
+- Update snapshots or e2e specs as a drive-by
+
+## Do
+
+- Implement the requested product/code change
+- Only touch tests when the user says to (e.g. “add tests”, “update the tests”, “fix the failing test”)
+- If an existing test fails because of your change and the user did **not** ask for test work: mention the failure briefly; do not rewrite tests unless they ask
+
+## Examples
+
+- User: “Add fullscreen notes editor” → change app code only; no new/updated unit tests
+- User: “Add fullscreen notes editor and cover it with tests” → app code + tests
+- User: “Fix the failing KanjiStudyNotes test” → only the test (and minimal code if required)

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/KanjiStudyNotes.test.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/KanjiStudyNotes.test.tsx
@@ -51,6 +51,19 @@ beforeAll(() => {
     cancel: vi.fn(),
     speak: vi.fn(),
   });
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    }))
+  );
 });
 
 afterAll(() => {
@@ -171,6 +184,69 @@ describe("KanjiStudyNotes", () => {
     expect(
       screen.getByRole("textbox", { name: "Kanji study notes Markdown" })
     ).toHaveValue("**学ぶ**");
+  });
+
+  it("opens edit mode when the empty preview is clicked", async () => {
+    const user = userEvent.setup();
+    render(<KanjiStudyNotes kanji="空" />);
+
+    await user.click(screen.getByRole("tab", { name: "View Mode" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: /Your notes are empty\. Start writing to see them here\./,
+      })
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "Kanji study notes Markdown" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Edit Mode" })).toHaveAttribute(
+      "data-state",
+      "active"
+    );
+  });
+
+  it("opens a fullscreen editor for coarse pointers", async () => {
+    const user = userEvent.setup();
+    const matchMedia = vi.mocked(window.matchMedia);
+    matchMedia.mockImplementation((query) => ({
+      matches: query === "(pointer: coarse)",
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onchange: null,
+    }));
+
+    try {
+      render(<KanjiStudyNotes kanji="手" />);
+
+      expect(
+        screen.getByRole("button", { name: "Start writing" })
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Start writing" }));
+
+      expect(
+        screen.getByRole("heading", { name: /Study Notes/ })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("textbox", { name: "Kanji study notes Markdown" })
+      ).toBeInTheDocument();
+    } finally {
+      matchMedia.mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      }));
+    }
   });
 
   it("does not render raw HTML or javascript: links in preview", () => {

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownEditor.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownEditor.tsx
@@ -18,12 +18,17 @@ interface MarkdownEditorProps {
   value: string;
   maxLength: number;
   onChange: (value: string) => void;
+  /** Grow to fill the parent instead of a fixed h-64. */
+  fill?: boolean;
+  autoFocus?: boolean;
 }
 
 export const MarkdownEditor = ({
   value,
   maxLength,
   onChange,
+  fill = false,
+  autoFocus = false,
 }: MarkdownEditorProps) => {
   const backdropRef = useRef<HTMLPreElement>(null);
   const segments = useMemo(() => getMarkdownHighlightSegments(value), [value]);
@@ -37,9 +42,14 @@ export const MarkdownEditor = ({
   };
 
   return (
-    <div>
+    <div className={cn(fill && "flex h-full min-h-0 flex-col")}>
       {/* No padding here — absolute backdrop + flowing textarea must share the same origin. */}
-      <div className="relative overflow-hidden bg-background rounded-xl border-[3px] border-dotted border-border focus-within:border-ring focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-ring">
+      <div
+        className={cn(
+          "relative overflow-hidden bg-background rounded-xl border-[3px] border-dotted border-border focus-within:border-ring focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-ring",
+          fill && "min-h-0 flex-1"
+        )}
+      >
         <pre
           ref={backdropRef}
           aria-hidden="true"
@@ -64,10 +74,12 @@ export const MarkdownEditor = ({
           maxLength={maxLength}
           rows={8}
           spellCheck={false}
+          autoFocus={autoFocus}
           placeholder="Write your notes here. Markdown is supported. Fun fact! Japanese texts (e.g. 日本語, にほんご) are clickable in View Mode."
           className={cn(
             sharedEditorTextClass,
-            "relative block w-full h-64 resize-none bg-transparent outline-none",
+            "relative block w-full resize-none bg-transparent outline-none",
+            fill ? "h-full min-h-0" : "h-64",
             // Glyphs stay invisible so only the backdrop colors show; caret stays visible.
             "text-transparent caret-foreground [-webkit-text-fill-color:transparent]",
             // Translucent wash (not opaque lime) so backdrop text stays readable.
@@ -82,7 +94,7 @@ export const MarkdownEditor = ({
         />
       </div>
       <p
-        className={`mt-1.5 text-xs text-right font-bold ${value.length >= maxLength ? "text-red-500" : "text-muted-foreground"}`}
+        className={`mt-1.5 shrink-0 text-xs text-right font-bold ${value.length >= maxLength ? "text-red-500" : "text-muted-foreground"}`}
         aria-live="polite"
       >
         {value.length} / {maxLength}

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownPreview.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/MarkdownPreview.tsx
@@ -109,8 +109,27 @@ const components: Components = {
   span: MarkdownSpan,
 };
 
-export const MarkdownPreview = ({ source }: { source: string }) => {
+export const MarkdownPreview = ({
+  source,
+  onEmptyClick,
+}: {
+  source: string;
+  /** When set, the empty state becomes a control that starts editing. */
+  onEmptyClick?: () => void;
+}) => {
   if (source.trim().length === 0) {
+    if (onEmptyClick != null) {
+      return (
+        <button
+          type="button"
+          onClick={onEmptyClick}
+          className="block w-full px-4 pb-8 text-base text-center pt-11 text-muted-foreground hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+        >
+          Your notes are empty. Start writing to see them here.
+        </button>
+      );
+    }
+
     return (
       <p className="px-4 pb-8 text-base text-center pt-11 text-muted-foreground">
         Your notes are empty. Start writing to see them here.

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
@@ -1,0 +1,103 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { CircleX } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useVisualViewport } from "@/hooks/use-visual-viewport";
+import { cn } from "@/lib/utils";
+import { MarkdownEditor } from "./MarkdownEditor";
+
+interface StudyNotesFullscreenEditorProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  kanji: string;
+  value: string;
+  maxLength: number;
+  onChange: (value: string) => void;
+}
+
+/** Above the kanji Vaul drawer (`z-50`) so compose covers the sheet. */
+const FULLSCREEN_Z = "z-[60]";
+
+/**
+ * Phone-friendly compose surface: pinned to the visual viewport so the
+ * soft keyboard does not cover the textarea (unlike editing inside the
+ * kanji Vaul drawer).
+ */
+export const StudyNotesFullscreenEditor = ({
+  open,
+  onOpenChange,
+  kanji,
+  value,
+  maxLength,
+  onChange,
+}: StudyNotesFullscreenEditorProps) => {
+  const viewport = useVisualViewport();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogOverlay className={FULLSCREEN_Z} />
+        <DialogPrimitive.Content
+          className={cn(
+            FULLSCREEN_Z,
+            "fixed inset-x-0 flex flex-col gap-0 overflow-hidden border-0 bg-background p-0 shadow-none outline-none",
+            "duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=open]:slide-in-from-bottom-2 data-[state=closed]:slide-out-to-bottom-2"
+          )}
+          style={{ top: viewport.offsetTop, height: viewport.height }}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            const textarea = (event.currentTarget as HTMLElement).querySelector(
+              "textarea"
+            );
+            textarea?.focus();
+          }}
+          onKeyDown={(event) => event.stopPropagation()}
+        >
+          <DialogHeader className="relative shrink-0 gap-1 border-b border-border px-4 py-3 pr-16 text-left">
+            <DialogTitle className="flex items-center gap-2 text-base">
+              <span className="text-2xl leading-none kanji-font">{kanji}</span>
+              <span>Study Notes</span>
+            </DialogTitle>
+            <DialogDescription className="text-xs text-muted-foreground">
+              Markdown supported. Japanese text is clickable in View Mode.
+            </DialogDescription>
+            <DialogPrimitive.Close asChild className="absolute top-2 right-2">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="p-4 border-2 border-dashed rounded-xl bg-background"
+              >
+                <CircleX className="size-8" />
+                <span className="sr-only">Close</span>
+              </Button>
+            </DialogPrimitive.Close>
+          </DialogHeader>
+          <div className="flex min-h-0 flex-1 flex-col px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3">
+            <MarkdownEditor
+              value={value}
+              maxLength={maxLength}
+              onChange={onChange}
+              fill
+              autoFocus
+            />
+            <p className="mt-2 shrink-0 text-xs leading-snug text-muted-foreground">
+              Optional:{" "}
+              <code className="break-all text-[0.7rem]">
+                {`:vocab[日本語]{kana="にほんご" definition="…"}`}
+              </code>
+            </p>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  );
+};

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
@@ -1,8 +1,11 @@
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useCoarsePointer } from "@/hooks/use-coarse-pointer";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { MarkdownPreview } from "./MarkdownPreview";
+import { StudyNotesFullscreenEditor } from "./StudyNotesFullscreenEditor";
 import { getKanjiStudyNotesStorageKey, MAX_STUDY_NOTE_LENGTH } from "./storage";
 
 interface StoredStudyNotes {
@@ -20,16 +23,44 @@ const KanjiStudyNotes = ({ kanji }: { kanji: string }) => {
     typeof storedNotes.notes === "string"
       ? storedNotes.notes.slice(0, MAX_STUDY_NOTE_LENGTH)
       : "";
+  const isCoarsePointer = useCoarsePointer();
   const [mode, setMode] = useState<NotesMode>(
     notes.length > 0 ? "view" : "edit"
   );
+  const [fullscreenOpen, setFullscreenOpen] = useState(false);
+
+  const persistNotes = (value: string) => {
+    setStoredNotes("notes", value.slice(0, MAX_STUDY_NOTE_LENGTH));
+  };
+
+  const openEditor = () => {
+    setMode("edit");
+    if (isCoarsePointer) {
+      setFullscreenOpen(true);
+    }
+  };
+
+  const handleModeChange = (value: string) => {
+    const next = value as NotesMode;
+    setMode(next);
+    if (next === "edit" && isCoarsePointer) {
+      setFullscreenOpen(true);
+    }
+  };
+
+  const handleFullscreenOpenChange = (open: boolean) => {
+    setFullscreenOpen(open);
+    if (!open && notes.trim().length > 0) {
+      setMode("view");
+    }
+  };
 
   return (
     <div
       className="px-1 pt-2 pb-3"
       onKeyDown={(event) => event.stopPropagation()}
     >
-      <Tabs value={mode} onValueChange={(value) => setMode(value as NotesMode)}>
+      <Tabs value={mode} onValueChange={handleModeChange}>
         <div className="flex flex-wrap items-center justify-between gap-2.5 mb-2.5">
           <TabsList
             aria-label="Kanji study notes mode"
@@ -61,30 +92,49 @@ const KanjiStudyNotes = ({ kanji }: { kanji: string }) => {
           value="edit"
           className="mt-1.5 motion-safe:data-[state=active]:animate-in motion-safe:data-[state=active]:fade-in-0 motion-safe:data-[state=active]:slide-in-from-bottom-1 motion-safe:data-[state=active]:duration-200"
         >
-          <MarkdownEditor
-            value={notes}
-            maxLength={MAX_STUDY_NOTE_LENGTH}
-            onChange={(value) =>
-              setStoredNotes("notes", value.slice(0, MAX_STUDY_NOTE_LENGTH))
-            }
-          />
-          <p className="mt-3 text-xs leading-snug text-muted-foreground">
-            Fun fact! Japanese texts are clickable in View Mode. <br />
-            Optional special syntax:{" "}
-            <code className="text-[0.7rem] break-all">
-              {`:vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`}
-            </code>
-          </p>
+          {isCoarsePointer ? (
+            <div className="flex flex-col items-stretch gap-3 rounded-xl border-[3px] border-dashed border-border bg-background px-4 py-8 text-center">
+              <Button type="button" onClick={() => setFullscreenOpen(true)}>
+                {notes.trim().length > 0 ? "Continue writing" : "Start writing"}
+              </Button>
+            </div>
+          ) : (
+            <>
+              <MarkdownEditor
+                value={notes}
+                maxLength={MAX_STUDY_NOTE_LENGTH}
+                onChange={persistNotes}
+              />
+              <p className="mt-3 text-xs leading-snug text-muted-foreground">
+                Fun fact! Japanese texts are clickable in View Mode. <br />
+                Optional special syntax:{" "}
+                <code className="text-[0.7rem] break-all">
+                  {`:vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`}
+                </code>
+              </p>
+            </>
+          )}
         </TabsContent>
         <TabsContent
           value="view"
           className="mt-1.5 motion-safe:data-[state=active]:animate-in motion-safe:data-[state=active]:fade-in-0 motion-safe:data-[state=active]:slide-in-from-bottom-1 motion-safe:data-[state=active]:duration-200"
         >
           <div className="overflow-hidden bg-background rounded-xl border-[3px] border-dashed pb-4 border-border">
-            <MarkdownPreview source={notes} />
+            <MarkdownPreview source={notes} onEmptyClick={openEditor} />
           </div>
         </TabsContent>
       </Tabs>
+
+      {isCoarsePointer ? (
+        <StudyNotesFullscreenEditor
+          open={fullscreenOpen}
+          onOpenChange={handleFullscreenOpenChange}
+          kanji={kanji}
+          value={notes}
+          maxLength={MAX_STUDY_NOTE_LENGTH}
+          onChange={persistNotes}
+        />
+      ) : null}
     </div>
   );
 };

--- a/src/hooks/use-coarse-pointer.ts
+++ b/src/hooks/use-coarse-pointer.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
+
+const getCoarsePointerMatch = () => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  return window.matchMedia(COARSE_POINTER_QUERY).matches;
+};
+
+/**
+ * True when the primary pointing device is coarse (typically a finger).
+ * Prefer this over viewport width or `touchstart` for “phone-like” UX —
+ * touch laptops stay fine-pointer; phones/tablets report coarse.
+ */
+export function useCoarsePointer() {
+  const [isCoarse, setIsCoarse] = useState(getCoarsePointerMatch);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(COARSE_POINTER_QUERY);
+    const update = () => setIsCoarse(mediaQuery.matches);
+    update();
+    mediaQuery.addEventListener("change", update);
+    return () => mediaQuery.removeEventListener("change", update);
+  }, []);
+
+  return isCoarse;
+}


### PR DESCRIPTION
## Summary
- On `(pointer: coarse)` devices, study notes edit opens a visualViewport-sized fullscreen dialog instead of typing inside the kanji drawer.
- Empty preview is clickable and switches to edit mode (fullscreen on coarse pointer).
- Adds a Cursor rule: do not write/update tests unless explicitly asked.

## Test plan
- [ ] On a phone (or device emulation with coarse pointer): open a kanji → Personal Study Notes → Edit Mode / Start writing → confirm fullscreen editor opens above the drawer and stays usable with the soft keyboard
- [ ] Close fullscreen with notes present → returns to View Mode
- [ ] In View Mode with empty notes, tap empty state → enters edit (fullscreen on coarse pointer)
- [ ] On desktop (fine pointer): edit stays inline in the accordion as before
- [ ] Notes still persist per kanji in localStorage


Made with [Cursor](https://cursor.com)