### PR TITLE
Add Speed Katakana ?challenge= deep links

### DIFF
--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -67,6 +67,21 @@ test.describe("practice modes", () => {
     await expect(page.getByText("アメリカ")).toBeVisible();
   });
 
+  test("speed katakana: ?challenge= selects the set and syncs on click", async ({
+    page,
+  }) => {
+    await page.goto("/speed-katakana?challenge=200");
+
+    await expect(page.getByText("Challenge 20-10 (#200):")).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Challenge position 1 within the selected level updates the URL.
+    await page.getByRole("button", { name: "1", exact: true }).last().click();
+    await expect(page).toHaveURL(/challenge=191/);
+    await expect(page.getByText("Challenge 20-1 (#191):")).toBeVisible();
+  });
+
   test("reading practice: forgot path returns to the start screen", async ({
     page,
   }) => {

--- a/src/components/screens/DashboardScreen/HeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/HeatmapGrid.tsx
@@ -57,7 +57,7 @@ export const HeatmapCell = ({
         )}
       />
     </PopoverTrigger>
-    <PopoverContent className="p-3 w-52" side="top">
+    <PopoverContent className="w-56 p-3" side="top">
       {detail}
     </PopoverContent>
   </Popover>

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
@@ -5,10 +5,14 @@ import {
   positionInLevel,
   setFromLevelAndPos,
 } from "@/components/screens/SpeedKatakanaScreen/constants";
+import { speedKatakanaChallengeHref } from "@/components/screens/SpeedKatakanaScreen/challenge-search-param";
 import {
   ChallengeSetStats,
   readSetStats,
 } from "@/components/screens/SpeedKatakanaScreen/storage";
+import { Link } from "@/components/dependent/routing";
+import { ArrowRight } from "@/components/icons";
+import { Button } from "@/components/ui/button";
 import { CPM_BAND_LABELS, cpmToBand } from "@/lib/activity";
 import { HeatmapCell, HeatmapGrid, heatmapFillCn } from "./HeatmapGrid";
 
@@ -68,6 +72,19 @@ const SetDetail = ({
       ) : (
         <div className="text-muted-foreground">Not attempted yet</div>
       )}
+      <div className="pt-2 mt-1 border-t border-border">
+        <Button
+          asChild
+          size="sm"
+          variant="secondary"
+          className="w-full h-8 font-semibold"
+        >
+          <Link to={speedKatakanaChallengeHref(setNumber)}>
+            Practice
+            <ArrowRight className="size-3.5 opacity-70" aria-hidden />
+          </Link>
+        </Button>
+      </div>
     </div>
   );
 };

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
@@ -11,7 +11,6 @@ import {
   readSetStats,
 } from "@/components/screens/SpeedKatakanaScreen/storage";
 import { Link } from "@/components/dependent/routing";
-import { ArrowRight } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { CPM_BAND_LABELS, cpmToBand } from "@/lib/activity";
 import { HeatmapCell, HeatmapGrid, heatmapFillCn } from "./HeatmapGrid";
@@ -72,17 +71,14 @@ const SetDetail = ({
       ) : (
         <div className="text-muted-foreground">Not attempted yet</div>
       )}
-      <div className="pt-2 mt-1 border-t border-border">
+      <div className="border-t border-dotted border-border">
         <Button
           asChild
           size="sm"
-          variant="secondary"
-          className="w-full h-8 font-semibold"
+          variant="ghost"
+          className="w-full text-xs font-semibold underline underline-offset-4 decoration-dotted"
         >
-          <Link to={speedKatakanaChallengeHref(setNumber)}>
-            Practice
-            <ArrowRight className="size-3.5 opacity-70" aria-hidden />
-          </Link>
+          <Link to={speedKatakanaChallengeHref(setNumber)}>Practice Now</Link>
         </Button>
       </div>
     </div>

--- a/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
@@ -1,4 +1,3 @@
-import { useLocalStorage } from "@/hooks/use-local-storage";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -6,17 +5,13 @@ import { RadioRow, ToggleRow } from "@/components/shared-practice";
 import { LeavePractice } from "@/components/shared-practice/EndSessionButton";
 import { useEnterAction } from "@/hooks/use-enter-action";
 import { speedKatakanaPageMeta } from "@/lib/pages/practice-pages";
-import { SoundMode, SpeedKatakanaSettings, WordCount } from "./types";
+import { SoundMode, WordCount } from "./types";
 import { readSetStats } from "./storage";
 import { SpeedKatakanaStatsSummary } from "./SpeedKatakanaStatsSummary";
-import {
-  DEFAULT_SETTINGS,
-  levelOf,
-  positionInLevel,
-  SETTINGS_KEY,
-} from "./constants";
+import { levelOf, positionInLevel } from "./constants";
 import { useSpeedKatakanaProgress } from "./use-speed-katakana-progress";
 import { ChallengeSetSelector } from "./ChallengeSetSelector";
+import { useChallengeSearchParam } from "./use-challenge-search-param";
 
 const SetStats = ({ challengeSet }: { challengeSet: number }) => {
   const currentStats = readSetStats(challengeSet);
@@ -65,10 +60,8 @@ const SetStats = ({ challengeSet }: { challengeSet: number }) => {
 };
 
 export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
-  const [settings, setSetting] = useLocalStorage<SpeedKatakanaSettings>(
-    SETTINGS_KEY,
-    DEFAULT_SETTINGS
-  );
+  const { settings, setSetting, selectChallengeSet } =
+    useChallengeSearchParam();
 
   const { summary, levelCompletion } = useSpeedKatakanaProgress();
 
@@ -176,7 +169,7 @@ export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
             <ChallengeSetSelector
               challengeSet={settings.challengeSet}
               levelCompletion={levelCompletion}
-              onSelect={(setNumber) => setSetting("challengeSet", setNumber)}
+              onSelect={selectChallengeSet}
             />
           </div>
 

--- a/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/SpeedKatakanaScreen.tsx
@@ -1,21 +1,17 @@
 import { useRef, useState } from "react";
 import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
-import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { speedKatakanaPageMeta } from "@/lib/pages/practice-pages";
 import { SpeedKatakanaHeader } from "./SpeedKatakanaHeader";
 import { InitialScreen } from "./InitialScreen";
 import { Game } from "./Game";
 import { EndSession } from "./EndSession";
-import { SessionStats, SpeedKatakanaSettings } from "./types";
+import { SessionStats } from "./types";
 import { recordActivity } from "@/lib/activity";
 import { recordSetResult } from "./storage";
 import { useCompletedSetsCount } from "./use-completed-sets-count";
-import {
-  DEFAULT_SETTINGS,
-  SETTINGS_KEY,
-  SPEED_KATAKANA_TOTAL_CHALLENGES,
-} from "./constants";
+import { SPEED_KATAKANA_TOTAL_CHALLENGES } from "./constants";
+import { useChallengeSearchParam } from "./use-challenge-search-param";
 
 type Phase = "initial" | "playing" | "ended";
 
@@ -26,10 +22,7 @@ const SpeedKatakanaScreen = () => {
   useHtmlDocumentTitle(speedKatakanaPageMeta.heading);
 
   const [phase, setPhase] = useState<Phase>("initial");
-  const [settings, setSetting] = useLocalStorage<SpeedKatakanaSettings>(
-    SETTINGS_KEY,
-    DEFAULT_SETTINGS
-  );
+  const { settings, selectChallengeSet } = useChallengeSearchParam();
   const [progress, setProgress] = useState(0);
   const [stats, setStats] = useState<SessionStats | null>(null);
   const completedSetsCount = useCompletedSetsCount();
@@ -72,7 +65,7 @@ const SpeedKatakanaScreen = () => {
 
   const startNextChallenge = () => {
     primerRef.current?.focus();
-    setSetting("challengeSet", nextChallengeSet(settings.challengeSet));
+    selectChallengeSet(nextChallengeSet(settings.challengeSet));
     setProgress(0);
     setPhase("playing");
   };

--- a/src/components/screens/SpeedKatakanaScreen/challenge-search-param.test.ts
+++ b/src/components/screens/SpeedKatakanaScreen/challenge-search-param.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseChallengeParam,
+  speedKatakanaChallengeHref,
+} from "./challenge-search-param";
+
+describe("parseChallengeParam", () => {
+  it("accepts integers in 1..200", () => {
+    expect(parseChallengeParam("1")).toBe(1);
+    expect(parseChallengeParam("200")).toBe(200);
+    expect(parseChallengeParam("42")).toBe(42);
+  });
+
+  it("rejects missing, empty, non-integer, and out-of-range values", () => {
+    expect(parseChallengeParam(null)).toBeNull();
+    expect(parseChallengeParam("")).toBeNull();
+    expect(parseChallengeParam("abc")).toBeNull();
+    expect(parseChallengeParam("1.5")).toBeNull();
+    expect(parseChallengeParam("0")).toBeNull();
+    expect(parseChallengeParam("201")).toBeNull();
+    expect(parseChallengeParam("-3")).toBeNull();
+  });
+});
+
+describe("speedKatakanaChallengeHref", () => {
+  it("builds the deep link with the challenge query param", () => {
+    expect(speedKatakanaChallengeHref(200)).toBe(
+      "/speed-katakana?challenge=200"
+    );
+  });
+});

--- a/src/components/screens/SpeedKatakanaScreen/challenge-search-param.ts
+++ b/src/components/screens/SpeedKatakanaScreen/challenge-search-param.ts
@@ -1,0 +1,20 @@
+import { URL_PARAMS } from "@/lib/settings/url-params";
+import { speedKatakanaPageMeta } from "@/lib/pages/practice-pages";
+import { SPEED_KATAKANA_TOTAL_CHALLENGES } from "./constants";
+
+/**
+ * Parse `?challenge=` into a valid challenge set id (1–200), or null when
+ * missing / non-integer / out of range.
+ */
+export const parseChallengeParam = (raw: string | null): number | null => {
+  if (raw == null || raw === "") return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > SPEED_KATAKANA_TOTAL_CHALLENGES) {
+    return null;
+  }
+  return n;
+};
+
+/** Build `/speed-katakana?challenge=<id>` for deep links (e.g. dashboard). */
+export const speedKatakanaChallengeHref = (challengeSet: number) =>
+  `${speedKatakanaPageMeta.href}?${URL_PARAMS.challenge}=${challengeSet}`;

--- a/src/components/screens/SpeedKatakanaScreen/use-challenge-search-param.ts
+++ b/src/components/screens/SpeedKatakanaScreen/use-challenge-search-param.ts
@@ -1,0 +1,64 @@
+import { useCallback, useLayoutEffect } from "react";
+import { useSearchParams } from "@/hooks/routing-hooks";
+import { URL_PARAMS } from "@/lib/settings/url-params";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+import { DEFAULT_SETTINGS, SETTINGS_KEY } from "./constants";
+import { SpeedKatakanaSettings } from "./types";
+import { parseChallengeParam } from "./challenge-search-param";
+
+/**
+ * Keeps Speed Katakana `challengeSet` in sync with `?challenge=` on the URL:
+ * - Valid URL param → settings (so InitialScreen selection + stats match)
+ * - Selecting a challenge → URL (replace, so browsing sets doesn't spam history)
+ */
+export const useChallengeSearchParam = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [settings, setSetting] = useLocalStorage<SpeedKatakanaSettings>(
+    SETTINGS_KEY,
+    DEFAULT_SETTINGS
+  );
+
+  const challengeFromUrl = parseChallengeParam(
+    searchParams.get(URL_PARAMS.challenge)
+  );
+
+  useLayoutEffect(() => {
+    if (
+      challengeFromUrl != null &&
+      challengeFromUrl !== settings.challengeSet
+    ) {
+      setSetting("challengeSet", challengeFromUrl);
+    }
+  }, [challengeFromUrl, settings.challengeSet, setSetting]);
+
+  const syncChallengeToUrl = useCallback(
+    (challengeSet: number) => {
+      setSearchParams(
+        (prev) => {
+          const value = String(challengeSet);
+          if (prev.get(URL_PARAMS.challenge) === value) return prev;
+          const next = new URLSearchParams(prev);
+          next.set(URL_PARAMS.challenge, value);
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  const selectChallengeSet = useCallback(
+    (challengeSet: number) => {
+      setSetting("challengeSet", challengeSet);
+      syncChallengeToUrl(challengeSet);
+    },
+    [setSetting, syncChallengeToUrl]
+  );
+
+  return {
+    settings,
+    setSetting,
+    selectChallengeSet,
+    syncChallengeToUrl,
+  };
+};

--- a/src/components/screens/SpeedKatakanaScreen/use-challenge-search-param.ts
+++ b/src/components/screens/SpeedKatakanaScreen/use-challenge-search-param.ts
@@ -9,6 +9,7 @@ import { parseChallengeParam } from "./challenge-search-param";
 /**
  * Keeps Speed Katakana `challengeSet` in sync with `?challenge=` on the URL:
  * - Valid URL param → settings (so InitialScreen selection + stats match)
+ * - Invalid / empty URL param → removed from the URL (replace)
  * - Selecting a challenge → URL (replace, so browsing sets doesn't spam history)
  */
 export const useChallengeSearchParam = () => {
@@ -18,18 +19,37 @@ export const useChallengeSearchParam = () => {
     DEFAULT_SETTINGS
   );
 
-  const challengeFromUrl = parseChallengeParam(
-    searchParams.get(URL_PARAMS.challenge)
-  );
+  const rawChallenge = searchParams.get(URL_PARAMS.challenge);
+  const challengeFromUrl = parseChallengeParam(rawChallenge);
 
   useLayoutEffect(() => {
+    // Present but invalid (e.g. ?challenge=999 or ?challenge=abc) → strip it.
+    if (rawChallenge != null && challengeFromUrl == null) {
+      setSearchParams(
+        (prev) => {
+          if (!prev.has(URL_PARAMS.challenge)) return prev;
+          const next = new URLSearchParams(prev);
+          next.delete(URL_PARAMS.challenge);
+          return next;
+        },
+        { replace: true }
+      );
+      return;
+    }
+
     if (
       challengeFromUrl != null &&
       challengeFromUrl !== settings.challengeSet
     ) {
       setSetting("challengeSet", challengeFromUrl);
     }
-  }, [challengeFromUrl, settings.challengeSet, setSetting]);
+  }, [
+    rawChallenge,
+    challengeFromUrl,
+    settings.challengeSet,
+    setSetting,
+    setSearchParams,
+  ]);
 
   const syncChallengeToUrl = useCallback(
     (challengeSet: number) => {

--- a/src/lib/settings/url-params.ts
+++ b/src/lib/settings/url-params.ts
@@ -17,4 +17,6 @@ export const URL_PARAMS = {
     secondary: "sort-secondary",
   },
   bgSrc: "bg-src",
+  /** Speed Katakana challenge set id (`/speed-katakana?challenge=200`). */
+  challenge: "challenge",
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `/speed-katakana?challenge=<id>` selects that challenge set on the InitialScreen (challenge set + challenge buttons) and shows the matching localStorage stats.
- Changing the challenge selection updates the URL (`replace`) so it stays in sync.
- Invalid or empty `challenge` values are removed from the URL (`replace`).
- Dashboard Speed Katakana heatmap popovers now include a **Practice** button that navigates to `/speed-katakana?challenge=<id>`.

## Notes
- Advancing to the next challenge after a session also updates the query param.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8568-869f-78dc-9e76-0cf03cb863a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8568-869f-78dc-9e76-0cf03cb863a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

