### PR TITLE
Use PracticeButton for Personal Study Notes Start writing CTA

### DIFF
--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { PracticeButton } from "@/components/ui/practice-button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCoarsePointer } from "@/hooks/use-coarse-pointer";
 import { useLocalStorage } from "@/hooks/use-local-storage";
@@ -94,9 +94,9 @@ const KanjiStudyNotes = ({ kanji }: { kanji: string }) => {
         >
           {isCoarsePointer ? (
             <div className="flex flex-col items-stretch gap-3 rounded-xl border-[3px] border-dashed border-border bg-background px-4 py-8 text-center">
-              <Button type="button" onClick={() => setFullscreenOpen(true)}>
+              <PracticeButton size="lg" onClick={() => setFullscreenOpen(true)}>
                 {notes.trim().length > 0 ? "Continue writing" : "Start writing"}
-              </Button>
+              </PracticeButton>
             </div>
           ) : (
             <>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces the default `Button` on the Personal Study Notes coarse-pointer “Start writing” / “Continue writing” CTA with `PracticeButton`
- Keeps the same open-fullscreen behavior and label logic

## Test plan
- [ ] On a touch / coarse-pointer device (or emulated), open a kanji details panel and expand Personal Study Notes
- [ ] Confirm Edit Mode shows the PracticeButton-styled Start writing CTA
- [ ] Tap it and confirm the fullscreen editor still opens
- [ ] With existing notes, confirm the label shows Continue writing and still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8627-2126-7ed1-aebb-58e37a8b42ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8627-2126-7ed1-aebb-58e37a8b42ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

