### PR TITLE
Add Jōyō grade filters

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -4,7 +4,7 @@ test.describe("dashboard", () => {
   test("renders overview sections and activity filters", async ({ page }) => {
     await page.goto("/dashboard");
 
-    await expect(page.getByText(/Saved only on this device/)).toBeVisible({
+    await expect(page.getByText(/Local storage only/)).toBeVisible({
       timeout: 30_000,
     });
     await expect(page.getByText("All-time Overview")).toBeVisible();

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "./fixtures";
 test.describe("navigation", () => {
   test("dashboard renders", async ({ page }) => {
     await page.goto("/dashboard");
-    await expect(page.getByText(/Saved only on this device/)).toBeVisible({
+    await expect(page.getByText(/Local storage only/)).toBeVisible({
       timeout: 30_000,
     });
   });

--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -24,6 +24,33 @@ test.describe("practice modes", () => {
     ).toBeVisible({ timeout: 30_000 });
   });
 
+  for (const { name, route } of [
+    { name: "reading", route: "/reading-practice" },
+    { name: "writing", route: "/writing-practice" },
+  ]) {
+    test(`${name} practice: Jōyō-grade filter narrows the deck`, async ({
+      page,
+    }) => {
+      await page.goto(route);
+
+      const count = page.getByText(/\d+ kanji match your filters/);
+      await expect(count).toBeVisible({ timeout: 30_000 });
+      const initialCount = await count.textContent();
+
+      await page.getByLabel("Jōyō grade").click();
+      await page
+        .getByRole("option", { name: "(Select All)", exact: true })
+        .click();
+      await page.getByRole("option", { name: "Grade 1", exact: true }).click();
+      await page.keyboard.press("Escape");
+
+      await expect(count).not.toHaveText(initialCount ?? "", {
+        timeout: 30_000,
+      });
+      await expect(page.getByLabel("Jōyō grade")).toContainText("Grade 1");
+    });
+  }
+
   // Guards the Speed Katakana matching engine before its extraction into
   // lib/speed-katakana-match. Default settings keep word order fixed, so
   // challenge set 1 always starts with パーセント ("paasento" — also covers

--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -42,7 +42,7 @@ test.describe("practice modes", () => {
         .getByRole("option", { name: "(Select All)", exact: true })
         .click();
       await page.getByRole("option", { name: "Grade 1", exact: true }).click();
-      await page.keyboard.press("Escape");
+      await page.getByRole("option", { name: "Close", exact: true }).click();
 
       await expect(count).not.toHaveText(initialCount ?? "", {
         timeout: 30_000,

--- a/e2e/site-chrome.spec.ts
+++ b/e2e/site-chrome.spec.ts
@@ -8,7 +8,7 @@ test.describe("site chrome", () => {
     const island = page.getByRole("navigation", { name: "Primary" });
     await island.getByRole("link", { name: "Dashboard" }).click();
     await expect(page).toHaveURL(/\/dashboard$/);
-    await expect(page.getByText(/Saved only on this device/)).toBeVisible({
+    await expect(page.getByText(/Local storage only/)).toBeVisible({
       timeout: 30_000,
     });
 

--- a/e2e/sort-filter.spec.ts
+++ b/e2e/sort-filter.spec.ts
@@ -42,6 +42,29 @@ test.describe("sort and filter", () => {
     await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
   });
 
+  test("Jōyō-grade filter from the dialog updates the URL", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
+
+    await page
+      .getByRole("button", { name: "Sort and Filter Settings" })
+      .click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Jōyō grade").click();
+    await page.getByRole("option", { name: "Grade 1", exact: true }).click();
+    await page.keyboard.press("Escape");
+    await dialog.getByRole("button", { name: "Apply" }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/filter-jouyou-grade=1/);
+    await expect(page.getByText(/\d+ Items Matched/)).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
   test("clear all restores defaults from the dialog", async ({ page }) => {
     await page.goto("/?sort-primary=strokes&filter-jlpt=n5");
     await expect(page.getByText(/\d+ Items Matched/)).toBeVisible({

--- a/src/components/common/FilterMultiSelect.tsx
+++ b/src/components/common/FilterMultiSelect.tsx
@@ -22,7 +22,7 @@ export const FilterMultiSelect = <T extends string>({
   placeholder: string;
 }) => {
   const id = useId();
-  const fieldId = `${label.toLowerCase().replaceAll(" ", "-")}-${id}`;
+  const fieldId = `${label.toLowerCase().replace(/\s+/g, "-")}-${id}`;
 
   return (
     <div>

--- a/src/components/common/FilterMultiSelect.tsx
+++ b/src/components/common/FilterMultiSelect.tsx
@@ -1,0 +1,45 @@
+import { ReactNode, useId } from "react";
+import { Label } from "@/components/ui/label";
+import { MultiSelect } from "@/components/ui/multi-select";
+
+type FilterOption<T extends string> = {
+  label: string;
+  value: T;
+  iconNode?: ReactNode;
+};
+
+export const FilterMultiSelect = <T extends string>({
+  label,
+  options,
+  selectedValues,
+  onValueChange,
+  placeholder,
+}: {
+  label: string;
+  options: FilterOption<T>[];
+  selectedValues?: T[];
+  onValueChange: (values: T[]) => void;
+  placeholder: string;
+}) => {
+  const id = useId();
+  const fieldId = `${label.toLowerCase().replaceAll(" ", "-")}-${id}`;
+
+  return (
+    <div>
+      <Label className="text-xs font-thin" htmlFor={fieldId}>
+        {label}
+      </Label>
+      <MultiSelect
+        id={fieldId}
+        name={fieldId}
+        options={options}
+        onValueChange={(values) => onValueChange(values as T[])}
+        value={selectedValues}
+        placeholder={placeholder}
+        variant="inverted"
+        maxCount={options.length}
+        hasSearchInput={false}
+      />
+    </div>
+  );
+};

--- a/src/components/common/JouyouGradeSelector.tsx
+++ b/src/components/common/JouyouGradeSelector.tsx
@@ -1,0 +1,18 @@
+import { JouyouGradeOptions, JouyouGradeType } from "@/lib/jouyou-grade";
+import { FilterMultiSelect } from "@/components/common/FilterMultiSelect";
+
+export const JouyouGradeSelector = ({
+  selectedGrades,
+  setSelectedGrades,
+}: {
+  selectedGrades?: JouyouGradeType[];
+  setSelectedGrades: (values: JouyouGradeType[]) => void;
+}) => (
+  <FilterMultiSelect
+    label="Jōyō grade"
+    options={JouyouGradeOptions}
+    selectedValues={selectedGrades}
+    onValueChange={setSelectedGrades}
+    placeholder="All grades selected"
+  />
+);

--- a/src/components/common/StrokeCountField.tsx
+++ b/src/components/common/StrokeCountField.tsx
@@ -22,7 +22,7 @@ export const StrokeCountField = ({
         id={fieldId}
         label={(value) => value}
         labelPosition="bottom"
-        className="text-xs pt-2"
+        className="pt-2 pb-4 text-xs"
         value={values}
         onValueChange={setValues}
         min={1}

--- a/src/components/common/jlpt/JLPTSelector.tsx
+++ b/src/components/common/jlpt/JLPTSelector.tsx
@@ -1,7 +1,5 @@
-import { useId } from "react";
 import { JLPTOptions, JLTPTtypes } from "@/lib/jlpt";
-import { Label } from "@/components/ui/label";
-import { MultiSelect } from "@/components/ui/multi-select";
+import { FilterMultiSelect } from "@/components/common/FilterMultiSelect";
 
 const JLPTOptionsWithIcon = JLPTOptions.map((entry) => {
   return {
@@ -22,23 +20,13 @@ export function JLPTSelector({
   selectedJLPT: JLTPTtypes[];
   setSelectedJLPT: (v: JLTPTtypes[]) => void;
 }) {
-  const id = useId();
-  const fieldId = `jlpt-multiselect-${id}`;
   return (
-    <div>
-      <Label className="text-xs font-thin" htmlFor={fieldId}>
-        JLPT
-      </Label>
-      <MultiSelect
-        name={fieldId}
-        options={JLPTOptionsWithIcon}
-        onValueChange={setSelectedJLPT as (v: string[]) => void}
-        value={selectedJLPT}
-        placeholder="All levels selected"
-        variant="inverted"
-        maxCount={JLPTOptionsWithIcon.length}
-        hasSearchInput={false}
-      />
-    </div>
+    <FilterMultiSelect
+      label="JLPT"
+      options={JLPTOptionsWithIcon}
+      selectedValues={selectedJLPT}
+      onValueChange={setSelectedJLPT}
+      placeholder="All levels selected"
+    />
   );
 }

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
@@ -18,21 +18,21 @@ export const FilterSectionLayout = ({
   return (
     <section className="text-start">
       <UppercaseHeading title="Filters" icon={<FilterX size={15} />} />
-      <div className="grid w-full grid-cols-1 gap-4 pb-8 md:grid-cols-3">
+      <div className="grid w-full grid-cols-1 gap-4 pb-8 xl:grid-cols-3">
         <div>{strokeCountField}</div>
         <div>{jlptField}</div>
         <div>{jouyouGradeField}</div>
       </div>
-      <div className="py-2 mt-4 md:mt-0 uppercase text-xs font-extrabold">
+      <div className="py-2 mt-4 text-xs font-extrabold uppercase md:mt-0">
         Frequency Ranking
       </div>
-      <div className="flex w-full flex-col md:flex-row md:space-x-4">
+      <div className="flex flex-col w-full md:flex-row md:space-x-4">
         <div className="w-full md:w-1/2">
-          <div className="text-left w-full pb-4 md:pb-0">
+          <div className="w-full pb-4 text-left md:pb-0">
             {freqRankSourceField}
           </div>
         </div>
-        <div className="w-full md:w-1/2 pb-8">{freqRankRangeField}</div>
+        <div className="w-full pb-8 md:w-1/2">{freqRankRangeField}</div>
       </div>
     </section>
   );

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
@@ -4,11 +4,13 @@ import { UppercaseHeading } from "@/components/common/UpperCaseHeading";
 
 export const FilterSectionLayout = ({
   jlptField,
+  jouyouGradeField,
   strokeCountField,
   freqRankRangeField,
   freqRankSourceField,
 }: {
   jlptField: ReactNode;
+  jouyouGradeField: ReactNode;
   strokeCountField: ReactNode;
   freqRankSourceField: ReactNode;
   freqRankRangeField?: ReactNode;
@@ -16,9 +18,10 @@ export const FilterSectionLayout = ({
   return (
     <section className="text-start">
       <UppercaseHeading title="Filters" icon={<FilterX size={15} />} />
-      <div className="flex w-full flex-col md:flex-row md:space-x-4">
-        <div className="w-full md:w-1/2 pb-8">{strokeCountField}</div>
-        <div className="w-full md:w-1/2">{jlptField}</div>
+      <div className="grid w-full grid-cols-1 gap-4 pb-8 md:grid-cols-3">
+        <div>{strokeCountField}</div>
+        <div>{jlptField}</div>
+        <div>{jouyouGradeField}</div>
       </div>
       <div className="py-2 mt-4 md:mt-0 uppercase text-xs font-extrabold">
         Frequency Ranking

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/ItemCount.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/ItemCount.tsx
@@ -9,6 +9,15 @@ import { SEARCH_TYPE_OPTIONS } from "@/lib/search-input-maps";
 const disclaimer =
   "Some kanji characters may be excluded based on your selected frequency source filter.";
 
+const SEARCH_TEXT_DISPLAY_MAX = 200;
+
+const formatSearchTextForDisplay = (text: string) => {
+  if (text.length <= SEARCH_TEXT_DISPLAY_MAX) {
+    return text;
+  }
+  return `${text.slice(0, SEARCH_TEXT_DISPLAY_MAX)}...`;
+};
+
 const AllMatchMsg = () => {
   return (
     <div className="block w-full text-right text-xs">
@@ -31,7 +40,7 @@ const ItemCountComputed = ({ settings }: { settings: SearchSettings }) => {
       <>
         Your Search Text is{" "}
         <span className="mx-1 font-extrabold">
-          {`"${settings.textSearch.text}"`}
+          {`"${formatSearchTextForDisplay(settings.textSearch.text)}"`}
         </span>
         <span>{`(Search Type: ${SEARCH_TYPE_OPTIONS.find((item) => item.value === settings.textSearch.type)?.label} )`}</span>
         .

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
@@ -1,7 +1,7 @@
 import { SORT_ORDER_SELECT } from "@/lib/options/options-arr";
 import { SearchSettings } from "@/lib/settings/settings";
 
-import { Button } from "@/components/ui/button";
+import { PracticeButton } from "@/components/ui/practice-button";
 
 import { FreqRankTypeInfo } from "@/components/common/freq/FreqRankTypeInfo";
 import { StrokeCountField } from "@/components/common/StrokeCountField";
@@ -160,8 +160,8 @@ export const SortAndFilterSettingsForm = ({
           </div>
         )}
         <div className="flex justify-end px-0 pt-2 space-x-1">
-          <Button
-            variant="outline"
+          <PracticeButton
+            variant="secondary"
             onClick={(e) => {
               e.preventDefault();
               form.resetToDefaults();
@@ -169,10 +169,10 @@ export const SortAndFilterSettingsForm = ({
             }}
           >
             Clear all
-          </Button>
-          <Button disabled={isDisabled} type="submit">
+          </PracticeButton>
+          <PracticeButton disabled={isDisabled} type="submit">
             Apply
-          </Button>
+          </PracticeButton>
         </div>
       </div>
     </form>

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { FreqRankTypeInfo } from "@/components/common/freq/FreqRankTypeInfo";
 import { StrokeCountField } from "@/components/common/StrokeCountField";
 import { JLPTSelector } from "@/components/common/jlpt/JLPTSelector";
+import { JouyouGradeSelector } from "@/components/common/JouyouGradeSelector";
 import { FrequencyRankDataSource } from "@/components/common/freq/FrequencyRankDataSource";
 import { FrequencyRankingRangeField } from "@/components/common/freq/FrequencyRankingRangeField";
 
@@ -118,6 +119,12 @@ export const SortAndFilterSettingsForm = ({
             <JLPTSelector
               selectedJLPT={filterValues.jlpt}
               setSelectedJLPT={form.setJlpt}
+            />
+          }
+          jouyouGradeField={
+            <JouyouGradeSelector
+              selectedGrades={filterValues.jouyouGrade}
+              setSelectedGrades={form.setJouyouGrade}
             />
           }
           freqRankSourceField={

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.test.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.test.tsx
@@ -23,6 +23,15 @@ describe("useSortAndFilterForm", () => {
     expect(result.current.isDisabled).toBe(false);
   });
 
+  it("tracks Jōyō-grade edits in the filter values", () => {
+    const { result } = renderHook(() => useSortAndFilterForm(initial));
+
+    act(() => result.current.setJouyouGrade(["1", "none"]));
+
+    expect(result.current.filterValues.jouyouGrade).toEqual(["1", "none"]);
+    expect(result.current.isDisabled).toBe(false);
+  });
+
   it("keeps the secondary sort when the new primary is a grouping sort", () => {
     const { result } = renderHook(() => useSortAndFilterForm(initial));
 

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.ts
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/settings/search-settings-adapter";
 import { SearchSettings } from "@/lib/settings/settings";
 import { JLTPTtypes } from "@/lib/jlpt";
+import { JouyouGradeType } from "@/lib/jouyou-grade";
 
 const isGroupSort = (sortKey: string) =>
   (GROUP_OPTIONS as readonly string[]).includes(sortKey);
@@ -53,6 +54,10 @@ export const useSortAndFilterForm = (initialValue: SearchSettings) => {
 
   const setJlpt = (val: JLTPTtypes[]) => {
     setFilterValues((prev) => ({ ...prev, jlpt: val }));
+  };
+
+  const setJouyouGrade = (val: JouyouGradeType[]) => {
+    setFilterValues((prev) => ({ ...prev, jouyouGrade: val }));
   };
 
   const setFreqSource = (val: string) => {
@@ -110,6 +115,7 @@ export const useSortAndFilterForm = (initialValue: SearchSettings) => {
     setSecondarySort,
     setStrokeRange,
     setJlpt,
+    setJouyouGrade,
     setFreqSource,
     setFreqRankRange,
     resetToDefaults,

--- a/src/components/shared-practice/PracticeInitialScreen.tsx
+++ b/src/components/shared-practice/PracticeInitialScreen.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from "react";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { JLPTSelector } from "@/components/common/jlpt/JLPTSelector";
+import { JouyouGradeSelector } from "@/components/common/JouyouGradeSelector";
 import { JLTPTtypes } from "@/lib/jlpt";
+import { JOUYOU_GRADE_TYPE_ARR, JouyouGradeType } from "@/lib/jouyou-grade";
 import { LeavePractice } from "./EndSessionButton";
 import { ToggleRow } from "./ToggleRow";
 import { DeckFilterSettings } from "./types";
@@ -52,10 +54,19 @@ export const PracticeInitialScreen = ({
             Kanji to include
           </h2>
           <div className="pt-2 pb-6">
-            <JLPTSelector
-              selectedJLPT={filters.jlpt}
-              setSelectedJLPT={(v: JLTPTtypes[]) => onFilterChange("jlpt", v)}
-            />
+            <div className="flex flex-col gap-3">
+              <JLPTSelector
+                selectedJLPT={filters.jlpt}
+                setSelectedJLPT={(v: JLTPTtypes[]) => onFilterChange("jlpt", v)}
+              />
+              <JouyouGradeSelector
+                selectedGrades={
+                  filters.jouyouGrade ??
+                  ([...JOUYOU_GRADE_TYPE_ARR] as JouyouGradeType[])
+                }
+                setSelectedGrades={(v) => onFilterChange("jouyouGrade", v)}
+              />
+            </div>
           </div>
           <ToggleRow
             id="bookmarked-only"

--- a/src/components/shared-practice/build-deck.test.ts
+++ b/src/components/shared-practice/build-deck.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { JLPT_TYPE_ARR, JLTPTtypes } from "@/lib/jlpt";
 import { bookmarkStorageKey } from "@/lib/bookmarks";
 import { buildPracticeDeck, withFreshFonts } from "./build-deck";
 import { DeckFilterSettings, PracticeItem } from "./types";
@@ -12,14 +11,9 @@ const repWords: Record<string, RepEntry> = {
   日: ["日本", "にほん", "Japan", ""],
 };
 
-const jlptMap: Record<string, JLTPTtypes | null> = {
-  水: "n5",
-  火: "n3",
-  日: "n5",
-};
-
 const defaultSettings: DeckFilterSettings = {
   jlpt: [],
+  jouyouGrade: [],
   bookmarkedOnly: false,
   randomizeOrder: false,
   randomizeFont: false,
@@ -27,11 +21,12 @@ const defaultSettings: DeckFilterSettings = {
 
 const build = (
   overrides: Partial<DeckFilterSettings> = {},
-  words: Record<string, RepEntry> = repWords
+  words: Record<string, RepEntry> = repWords,
+  includedKanji: ReadonlySet<string> = new Set(["水", "火", "日"])
 ) =>
   buildPracticeDeck({
     repWords: words,
-    getJlpt: (kanji) => jlptMap[kanji] ?? null,
+    includedKanji,
     getKeyword: (kanji) => (kanji === "日" ? "" : `${kanji}-keyword`),
     settings: { ...defaultSettings, ...overrides },
   });
@@ -50,26 +45,21 @@ describe("buildPracticeDeck", () => {
     });
   });
 
-  it("skips null entries, entries without word/reading, and unknown-JLPT kanji", () => {
+  it("skips invalid entries and kanji excluded by the worker filters", () => {
     const withBadEntries = {
       ...repWords,
       無: null as unknown as RepEntry, // no anchor word selected
       空: ["", "そら", "sky", ""] as RepEntry, // missing word
-      鳥: ["小鳥", "ことり", "bird", ""] as RepEntry, // no JLPT info (not in jlptMap)
+      鳥: ["小鳥", "ことり", "bird", ""] as RepEntry,
     };
 
     const deck = build({}, withBadEntries);
     expect(deck.map((item) => item.kanji)).toEqual(["水", "火", "日"]);
   });
 
-  it("filters by JLPT when a strict subset of levels is selected", () => {
-    const deck = build({ jlpt: ["n5"] });
+  it("keeps only kanji included by the worker search", () => {
+    const deck = build({}, repWords, new Set(["水", "日"]));
     expect(deck.map((item) => item.kanji)).toEqual(["水", "日"]);
-  });
-
-  it("applies no JLPT filter when all levels are selected", () => {
-    const deck = build({ jlpt: [...JLPT_TYPE_ARR] });
-    expect(deck.map((item) => item.kanji)).toEqual(["水", "火", "日"]);
   });
 
   it("keeps only bookmarked kanji when bookmarkedOnly is set", () => {

--- a/src/components/shared-practice/build-deck.ts
+++ b/src/components/shared-practice/build-deck.ts
@@ -1,4 +1,3 @@
-import { JLPTOptionsCount, JLTPTtypes } from "@/lib/jlpt";
 import { isBookmarked } from "@/lib/bookmarks";
 import { shuffle } from "@/lib/utils";
 import { randomFontIndex } from "@/hooks/use-change-font";
@@ -8,18 +7,15 @@ type RepEntry = [string, string, string, string];
 
 export const buildPracticeDeck = ({
   repWords,
-  getJlpt,
+  includedKanji,
   getKeyword,
   settings,
 }: {
   repWords: Record<string, RepEntry>;
-  getJlpt: (kanji: string) => JLTPTtypes | null;
+  includedKanji: ReadonlySet<string>;
   getKeyword: (kanji: string) => string;
   settings: DeckFilterSettings;
 }): PracticeItem[] => {
-  const jlptSet = new Set(settings.jlpt);
-  const applyJlpt = jlptSet.size > 0 && jlptSet.size < JLPTOptionsCount;
-
   const items: PracticeItem[] = [];
 
   for (const [kanji, entry] of Object.entries(repWords)) {
@@ -28,9 +24,7 @@ export const buildPracticeDeck = ({
     const [word, reading, englishGloss] = entry;
     if (!word || !reading) continue;
 
-    const jlpt = getJlpt(kanji);
-    if (jlpt == null) continue;
-    if (applyJlpt && !jlptSet.has(jlpt)) continue;
+    if (!includedKanji.has(kanji)) continue;
     if (settings.bookmarkedOnly && !isBookmarked(kanji, word)) continue;
 
     items.push({

--- a/src/components/shared-practice/constants.ts
+++ b/src/components/shared-practice/constants.ts
@@ -1,4 +1,5 @@
 import { JLPT_TYPE_ARR, JLTPTtypes } from "@/lib/jlpt";
+import { JOUYOU_GRADE_TYPE_ARR, JouyouGradeType } from "@/lib/jouyou-grade";
 import { DeckFilterSettings } from "./types";
 
 /** Words per practice session chunk (both practice modes). */
@@ -7,6 +8,7 @@ export const PRACTICE_SESSION_SIZE = 10;
 /** Deck-filter defaults shared by every practice mode's settings object. */
 export const DEFAULT_DECK_FILTER_SETTINGS: DeckFilterSettings = {
   jlpt: [...JLPT_TYPE_ARR] as JLTPTtypes[],
+  jouyouGrade: [...JOUYOU_GRADE_TYPE_ARR] as JouyouGradeType[],
   bookmarkedOnly: false,
   randomizeOrder: true,
   randomizeFont: false,

--- a/src/components/shared-practice/types.ts
+++ b/src/components/shared-practice/types.ts
@@ -1,4 +1,5 @@
 import { JLTPTtypes } from "@/lib/jlpt";
+import { JouyouGradeType } from "@/lib/jouyou-grade";
 
 /** Shared deck item used by recognition + production practice. */
 export type PracticeItem = {
@@ -21,6 +22,7 @@ export type PracticeSessionResult = {
 /** Settings fields needed to build a representative-word deck. */
 export type DeckFilterSettings = {
   jlpt: JLTPTtypes[];
+  jouyouGrade: JouyouGradeType[];
   bookmarkedOnly: boolean;
   randomizeOrder: boolean;
   randomizeFont: boolean;

--- a/src/components/shared-practice/use-practice-deck.ts
+++ b/src/components/shared-practice/use-practice-deck.ts
@@ -2,9 +2,15 @@ import { useMemo } from "react";
 import { useJsonFetch } from "@/hooks/use-json";
 import {
   useGetKanjiInfoFn,
-  useIsKanjiWorkerReady,
+  useKanjiSearch,
 } from "@/kanji-worker/kanji-worker-hooks";
 import assetsPaths from "@/lib/assets-paths";
+import {
+  defaultFilterSettings,
+  defaultSearchTextSettings,
+  defaultSortSettings,
+} from "@/lib/settings/search-settings-adapter";
+import { SearchSettings } from "@/lib/settings/settings";
 import { buildPracticeDeck } from "./build-deck";
 import { DeckFilterSettings, PracticeItem } from "./types";
 
@@ -15,24 +21,40 @@ type RepEntry = [string, string, string, string];
  * the identical data flow both practice InitialScreens used to duplicate.
  */
 export const usePracticeDeck = (settings: DeckFilterSettings) => {
-  const workerReady = useIsKanjiWorkerReady();
   const getInfo = useGetKanjiInfoFn();
   const { data: repWords, status: repStatus } = useJsonFetch<
     Record<string, RepEntry>
   >(assetsPaths.KANJI_REPRESENTATIVE_WORDS);
 
+  const searchSettings = useMemo<SearchSettings>(
+    () => ({
+      textSearch: defaultSearchTextSettings,
+      filterSettings: {
+        ...defaultFilterSettings,
+        jlpt: settings.jlpt ?? [],
+        jouyouGrade: settings.jouyouGrade ?? [],
+      },
+      sortSettings: defaultSortSettings,
+    }),
+    [settings.jlpt, settings.jouyouGrade]
+  );
+  const filteredKanji = useKanjiSearch(searchSettings);
+
   const deck: PracticeItem[] = useMemo(() => {
-    if (!workerReady || !getInfo || !repWords) return [];
+    if (!getInfo || !repWords || filteredKanji.status !== "success") return [];
     return buildPracticeDeck({
       repWords,
-      getJlpt: (kanji) => getInfo(kanji)?.jlpt ?? null,
+      includedKanji: new Set(filteredKanji.data),
       getKeyword: (kanji) => getInfo(kanji)?.keyword ?? "...",
       settings,
     });
-  }, [workerReady, getInfo, repWords, settings]);
+  }, [filteredKanji.data, filteredKanji.status, getInfo, repWords, settings]);
 
   const loading =
-    !workerReady || repStatus === "pending" || repStatus === "idle";
+    filteredKanji.status === "loading" ||
+    filteredKanji.status === "idle" ||
+    repStatus === "pending" ||
+    repStatus === "idle";
   const canStart = !loading && deck.length > 0;
 
   return { deck, loading, canStart };

--- a/src/kanji-worker/kanji-search.test.ts
+++ b/src/kanji-worker/kanji-search.test.ts
@@ -7,6 +7,7 @@ import {
 import { SearchSettings, SearchType } from "@/lib/settings/settings";
 import { SortKey } from "@/lib/options/options-types";
 import { JLTPTtypes } from "@/lib/jlpt";
+import { JOUYOU_GRADE_TYPE_ARR, JouyouGradeType } from "@/lib/jouyou-grade";
 import { filterKanji, searchKanji, sortKanji } from "./kanji-search";
 
 const mainInfo = (
@@ -67,7 +68,7 @@ const pool = {
       meanings: ["fire", "flame"],
       allOn: ["か"],
       allKunStripped: ["ひ"],
-      jouyouGrade: 1,
+      jouyouGrade: -1,
     }),
     山: extendedInfo({
       strokes: 3,
@@ -87,16 +88,21 @@ const settings = ({
   text = "",
   primary = "none",
   secondary = "none",
+  jlpt = [],
+  jouyouGrade = [],
 }: {
   type?: SearchType;
   text?: string;
   primary?: SortKey;
   secondary?: SortKey;
+  jlpt?: JLTPTtypes[];
+  jouyouGrade?: JouyouGradeType[];
 }): SearchSettings => ({
   textSearch: { type, text },
   filterSettings: {
     strokeRange: { min: 1, max: 99 },
-    jlpt: [],
+    jlpt,
+    jouyouGrade,
     freq: { source: "none", rankRange: { min: 1, max: 99999 } },
   },
   sortSettings: { primary, secondary },
@@ -163,6 +169,51 @@ describe("filterKanji", () => {
     );
     // 氷 is similar but not in the pool, so only 水 survives.
     expect(result).toEqual(["水"]);
+  });
+
+  it("filters by one or more Jōyō grades", () => {
+    expect(
+      filterKanji(allKanji, settings({ jouyouGrade: ["1"] }), pool)
+    ).toEqual(["水"]);
+    expect(
+      filterKanji(allKanji, settings({ jouyouGrade: ["1", "2"] }), pool)
+    ).toEqual(["水", "山"]);
+  });
+
+  it("filters for kanji without an assigned Jōyō grade", () => {
+    expect(
+      filterKanji(allKanji, settings({ jouyouGrade: ["none"] }), pool)
+    ).toEqual(["火"]);
+  });
+
+  it("treats empty and all-grade selections as unrestricted", () => {
+    expect(filterKanji(allKanji, settings({ jouyouGrade: [] }), pool)).toEqual(
+      allKanji
+    );
+    expect(
+      filterKanji(
+        allKanji,
+        settings({ jouyouGrade: [...JOUYOU_GRADE_TYPE_ARR] }),
+        pool
+      )
+    ).toEqual(allKanji);
+  });
+
+  it("combines JLPT and Jōyō-grade filters", () => {
+    expect(
+      filterKanji(
+        allKanji,
+        settings({ jlpt: ["n5"], jouyouGrade: ["1"] }),
+        pool
+      )
+    ).toEqual(["水"]);
+    expect(
+      filterKanji(
+        allKanji,
+        settings({ jlpt: ["n4"], jouyouGrade: ["1"] }),
+        pool
+      )
+    ).toEqual([]);
   });
 });
 

--- a/src/kanji-worker/kanji-search.ts
+++ b/src/kanji-worker/kanji-search.ts
@@ -1,5 +1,7 @@
 import wanakana from "@/lib/wanakana-adapter";
 import { JLPTOptionsCount, JLPTRank, JLTPTtypes } from "@/lib/jlpt";
+import { JouyouGradeOptionsCount, toJouyouGradeType } from "@/lib/jouyou-grade";
+import { matchesSelectionFilter } from "@/lib/selection-filter";
 import {
   KanjiExtendedInfo,
   KanjiMainInfo,
@@ -64,6 +66,7 @@ export const filterByKanjiSimple = (
   kanjiPool: DataPool
 ) => {
   const jlptFilters = new Set(settings.filterSettings.jlpt);
+  const gradeFilters = new Set(settings.filterSettings.jouyouGrade);
   const minStrokes = settings.filterSettings.strokeRange.min;
   const maxStrokes = settings.filterSettings.strokeRange.max;
   const freqFilter = settings.filterSettings.freq;
@@ -74,10 +77,7 @@ export const filterByKanjiSimple = (
       if (info == null) {
         return false;
       }
-      if ([0, JLPTOptionsCount].includes(jlptFilters.size)) {
-        return true;
-      }
-      return jlptFilters.has(info.jlpt);
+      return matchesSelectionFilter(jlptFilters, JLPTOptionsCount, info.jlpt);
     })
     .filter((kanji) => {
       // Main/extended can briefly diverge (load race) or permanently diverge
@@ -88,7 +88,11 @@ export const filterByKanjiSimple = (
       }
       const withinRange =
         maxStrokes >= exInfo.strokes && exInfo.strokes >= minStrokes;
-      return withinRange;
+      const grade = toJouyouGradeType(exInfo.jouyouGrade);
+      const matchesGrade =
+        grade != null &&
+        matchesSelectionFilter(gradeFilters, JouyouGradeOptionsCount, grade);
+      return withinRange && matchesGrade;
     })
     .filter((kanji) => {
       if (freqFilter.source === "none") {

--- a/src/lib/jouyou-grade.ts
+++ b/src/lib/jouyou-grade.ts
@@ -1,0 +1,32 @@
+export const JOUYOU_GRADE_TYPE_ARR = [
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "9",
+  "none",
+] as const;
+
+export type JouyouGradeType = (typeof JOUYOU_GRADE_TYPE_ARR)[number];
+
+export const JouyouGradeOptions: {
+  label: string;
+  value: JouyouGradeType;
+}[] = [
+  ...JOUYOU_GRADE_TYPE_ARR.filter((grade) => grade !== "none").map((grade) => ({
+    label: `Grade ${grade}`,
+    value: grade,
+  })),
+  { label: "Not in Jōyō", value: "none" },
+];
+
+export const JouyouGradeOptionsCount = JOUYOU_GRADE_TYPE_ARR.length;
+
+export const toJouyouGradeType = (rawGrade: number): JouyouGradeType | null => {
+  const grade = rawGrade === -1 ? "none" : rawGrade.toString();
+  return JOUYOU_GRADE_TYPE_ARR.includes(grade as JouyouGradeType)
+    ? (grade as JouyouGradeType)
+    : null;
+};

--- a/src/lib/results-utils.ts
+++ b/src/lib/results-utils.ts
@@ -1,18 +1,24 @@
 import { MAX_STROKE_COUNT } from "@/lib/options/constants";
 import { JLPTOptions } from "@/lib/jlpt";
+import { JouyouGradeOptions } from "@/lib/jouyou-grade";
+import { isSelectionFilterActive } from "@/lib/selection-filter";
 import { FilterSettings, SearchSettings } from "@/lib/settings/settings";
 import { dedupe, isKanji } from "@/lib/utils";
 import { GetBasicKanjiInfo } from "@/lib/kanji/kanji-worker-types";
 import { K_MEANING_KEY } from "@/lib/options/options-constants";
 
 export const hasNoFilters = (settings: SearchSettings) => {
-  const { strokeRange, freq, jlpt } = settings.filterSettings;
+  const { strokeRange, freq, jlpt, jouyouGrade } = settings.filterSettings;
   const fullRangeStrokes =
     strokeRange.min <= 1 && strokeRange.max >= MAX_STROKE_COUNT;
   const fullRangeFreq = freq.source === "none";
-  const allJLPT = jlpt.length === 0 || jlpt.length === JLPTOptions.length;
+  const allJLPT = !isSelectionFilterActive(jlpt.length, JLPTOptions.length);
+  const allGrades = !isSelectionFilterActive(
+    jouyouGrade.length,
+    JouyouGradeOptions.length
+  );
 
-  return fullRangeStrokes && fullRangeFreq && allJLPT;
+  return fullRangeStrokes && fullRangeFreq && allJLPT && allGrades;
 };
 
 const alphaSort = (a: string, b: string) => {
@@ -94,6 +100,11 @@ export const isEqualFilters = (
   if (a.jlpt.length !== b.jlpt.length) return false;
   for (let i = 0; i < a.jlpt.length; i++) {
     if (a.jlpt[i] !== b.jlpt[i]) return false;
+  }
+
+  if (a.jouyouGrade.length !== b.jouyouGrade.length) return false;
+  for (let i = 0; i < a.jouyouGrade.length; i++) {
+    if (a.jouyouGrade[i] !== b.jouyouGrade[i]) return false;
   }
 
   if (a.freq.source !== b.freq.source) return false;

--- a/src/lib/selection-filter.ts
+++ b/src/lib/selection-filter.ts
@@ -1,0 +1,11 @@
+export const isSelectionFilterActive = (
+  selectedCount: number,
+  optionCount: number
+) => selectedCount > 0 && selectedCount < optionCount;
+
+export const matchesSelectionFilter = <T>(
+  selected: Set<T>,
+  optionCount: number,
+  value: T
+) =>
+  !isSelectionFilterActive(selected.size, optionCount) || selected.has(value);

--- a/src/lib/settings/search-settings-adapter.test.ts
+++ b/src/lib/settings/search-settings-adapter.test.ts
@@ -35,6 +35,7 @@ describe("search settings ↔ URL params round-trip", () => {
       filterSettings: {
         strokeRange: { min: 3, max: 10 },
         jlpt: ["n5", "n4"],
+        jouyouGrade: ["1", "6", "none"],
         freq: { source: "rank-netflix", rankRange: { min: 5, max: 100 } },
       },
       sortSettings: { primary: "strokes", secondary: "keyword" },
@@ -83,5 +84,13 @@ describe("search settings ↔ URL params round-trip", () => {
     });
     toSearchParams(params, "sortSettings", defaultSortSettings);
     expect(params.toString()).toBe("");
+  });
+
+  it("ignores invalid Jōyō-grade values from the URL", () => {
+    const params = new URLSearchParams("filter-jouyou-grade=1,invalid,none");
+    expect(toSearchSettings(params).filterSettings.jouyouGrade).toEqual([
+      "1",
+      "none",
+    ]);
   });
 });

--- a/src/lib/settings/search-settings-adapter.ts
+++ b/src/lib/settings/search-settings-adapter.ts
@@ -9,6 +9,12 @@ import {
 } from "@/lib/settings/settings";
 import { MAX_FREQ_RANK, MAX_STROKE_COUNT } from "@/lib/options/constants";
 import { JLPT_TYPE_ARR, JLPTOptionsCount, JLTPTtypes } from "@/lib/jlpt";
+import {
+  JOUYOU_GRADE_TYPE_ARR,
+  JouyouGradeOptionsCount,
+  JouyouGradeType,
+} from "@/lib/jouyou-grade";
+import { isSelectionFilterActive } from "@/lib/selection-filter";
 import { FrequencyType, SortKey } from "../options/options-types";
 import { translateMap } from "../search-input-maps";
 import { FREQ_RANK_OPTIONS } from "../options/options-constants";
@@ -19,6 +25,7 @@ import { translateValue } from "../wanakana-adapter";
 const defaultFilterSettings: FilterSettings = {
   strokeRange: { min: 1, max: MAX_STROKE_COUNT },
   jlpt: [],
+  jouyouGrade: [],
   freq: {
     source: "none",
     rankRange: { min: 1, max: MAX_FREQ_RANK },
@@ -45,11 +52,19 @@ const toSearchType = (val?: string | null): SearchType => {
   return defaultSearchType;
 };
 
-const toJLPT = (jlptString?: string | null) => {
-  return (jlptString ?? "").split(",").filter((item) => {
-    return JLPT_TYPE_ARR.includes(item as JLTPTtypes);
-  }) as JLTPTtypes[];
-};
+const toSelection = <T extends string>(
+  rawValue: string | null,
+  allowedValues: readonly T[]
+) =>
+  (rawValue ?? "")
+    .split(",")
+    .filter((item): item is T => allowedValues.includes(item as T));
+
+const toJLPT = (jlptString: string | null) =>
+  toSelection<JLTPTtypes>(jlptString, JLPT_TYPE_ARR);
+
+const toJouyouGrade = (gradeString: string | null) =>
+  toSelection<JouyouGradeType>(gradeString, JOUYOU_GRADE_TYPE_ARR);
 
 const toSortKey = (sortKeyStr?: string | null) => {
   if (sortKeyStr != null && ALL_SORT_OPTIONS.includes(sortKeyStr as SortKey)) {
@@ -96,6 +111,7 @@ const toSearchSettings = (sp: URLSearchParams): SearchSettings => {
         ),
       },
       jlpt: toJLPT(sp.get(p.filterSettings.jlpt)),
+      jouyouGrade: toJouyouGrade(sp.get(p.filterSettings.jouyouGrade)),
       freq: {
         source: toFrequencySrc(sp.get(p.filterSettings.freq.source)),
         rankRange: {
@@ -171,7 +187,13 @@ const writeFilterSettings = (prev: URLSearchParams, newVal: FilterSettings) => {
     prev,
     p.jlpt,
     newVal.jlpt.join(","),
-    newVal.jlpt.length === 0 || newVal.jlpt.length === JLPTOptionsCount
+    !isSelectionFilterActive(newVal.jlpt.length, JLPTOptionsCount)
+  );
+  setOrDelete(
+    prev,
+    p.jouyouGrade,
+    newVal.jouyouGrade.join(","),
+    !isSelectionFilterActive(newVal.jouyouGrade.length, JouyouGradeOptionsCount)
   );
 
   // No frequency source means the rank range is meaningless — drop all three.

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -1,4 +1,5 @@
 import { JLTPTtypes } from "../jlpt";
+import { JouyouGradeType } from "../jouyou-grade";
 import { FrequencyType, SortKey } from "../options/options-types";
 
 export const SEARCH_TYPE_ARR = [
@@ -25,6 +26,7 @@ export type TextSearch = {
 export type FilterSettings = {
   strokeRange: { min: number; max: number };
   jlpt: JLTPTtypes[];
+  jouyouGrade: JouyouGradeType[];
   freq: {
     source: FrequencyType;
     rankRange: { min: number; max: number };

--- a/src/lib/settings/url-params.ts
+++ b/src/lib/settings/url-params.ts
@@ -7,6 +7,7 @@ export const URL_PARAMS = {
   filterSettings: {
     strokeRange: { min: "filter-stroke-min", max: "filter-stroke-max" },
     jlpt: "filter-jlpt",
+    jouyouGrade: "filter-jouyou-grade",
     freq: {
       source: "filter-freq-source",
       rankRange: { min: "filter-freq-rank-min", max: "filter-freq-rank-max" },

--- a/src/providers/search-settings-hooks.tsx
+++ b/src/providers/search-settings-hooks.tsx
@@ -2,6 +2,7 @@ import { createContextComponents, useContextWithCatch } from "./helpers";
 import { SearchSettings } from "@/lib/settings/settings";
 import { MAX_FREQ_RANK, MAX_STROKE_COUNT } from "@/lib/options/constants";
 import { JLPT_TYPE_ARR } from "@/lib/jlpt";
+import { JOUYOU_GRADE_TYPE_ARR } from "@/lib/jouyou-grade";
 
 export const searchSettings = createContextComponents<SearchSettings>({
   textSearch: {
@@ -11,6 +12,7 @@ export const searchSettings = createContextComponents<SearchSettings>({
   filterSettings: {
     strokeRange: { min: 1, max: MAX_STROKE_COUNT },
     jlpt: JLPT_TYPE_ARR.map((r) => r),
+    jouyouGrade: JOUYOU_GRADE_TYPE_ARR.map((grade) => grade),
     freq: {
       source: "none" as const,
       rankRange: { min: 1, max: MAX_FREQ_RANK },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add reusable JLPT/Jōyō categorical filter controls and shared selection semantics
- support Jōyō-grade filtering in list search, URL settings, and the web worker
- apply the same worker-backed filters to reading and writing practice decks
- truncate long search text in the sort/filter dialog footer (200 chars + `...`)
- use `PracticeButton` for Clear all / Apply in the sort/filter dialog

## Testing
- Vitest: 208 passed
- Typecheck: passed
- ESLint: passed with 16 pre-existing warnings
- Focused Playwright specs: passed (14 scenarios total across initial run and corrected practice rerun)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8614-985c-7e43-b54d-cba89c3f0f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8614-985c-7e43-b54d-cba89c3f0f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

