### PR TITLE
Fix fixed-position drift and drawer bottom gap on iOS Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,7 @@
     />
     <meta
       name="viewport"
-      viewport-fit="cover"
-      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <title>Kanji Heatmap</title>
     <style>

--- a/src/index.css
+++ b/src/index.css
@@ -69,14 +69,24 @@
   box-sizing: border-box;
 }
 
+/*
+ * The document root owns the page scroll (not <body>). A body-level scroll
+ * container (height:100vh + overflow) turns the whole page into a "moving
+ * canvas" on iOS, which makes position:fixed UI drift/judder while scrolling —
+ * most visibly on Chrome for iOS/iPadOS. Scrolling the root keeps fixed
+ * elements pinned to the visual viewport. overflow-y:scroll here reserves the
+ * scrollbar gutter to avoid layout shift on desktop.
+ */
+html {
+  overflow-y: scroll;
+}
+
 body {
   min-height: 100dvh;
-  height: 100vh;
   width: 100%;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  overflow-y: scroll;
 }
 
 p,


### PR DESCRIPTION
Two viewport/scroll bugs surfaced on iPad iOS 26 Chrome (Safari, Firefox
and the standalone PWA were unaffected):

1. viewport-fit=cover was written as a standalone attribute on the
   <meta name="viewport"> tag instead of inside the content string, so
   the browser ignored it. That left env(safe-area-inset-*) at 0 and, on
   iOS 26, the layout viewport ending above the bottom safe area — which
   mispositioned the bottom-anchored FAB/floating island and left a gap
   under the kanji drawer (bottom:0 not reaching the true viewport
   bottom). Moved viewport-fit=cover into content.

2. <body> was the scroll container (height:100vh + overflow-y:scroll),
   turning the page into a "moving canvas" that makes position:fixed UI
   drift/judder while scrolling on iOS Chrome. Handed the page scroll to
   the document root so fixed elements pin to the visual viewport;
   overflow-y:scroll moved to <html> to keep the desktop scrollbar gutter.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VbMbmca46GcGZypbzWZVs9