### PR TITLE
Reuse SampleVocabulary loading skeleton for Reading Usefulness

### DIFF
--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -1,4 +1,5 @@
 import { lazy, ReactNode, Suspense } from "react";
+import { Loader2 } from "lucide-react";
 import { useGetKanjiInfoFn } from "@/kanji-worker/kanji-worker-hooks";
 import { ErrorBoundary } from "@/components/error";
 import SimpleAccordion from "@/components/common/SimpleAccordion";
@@ -19,6 +20,16 @@ import { BottomBar } from "@/components/common/BottomBar";
 import { useKanjiRepresentativeWord } from "@/providers/kanji-representative-word-provider";
 import { KanjiWordStatusActions } from "./KanjiWordStatusActions";
 import { StrokeAnimationLoadingScreen } from "./StrokeAnimationLoadingScreen";
+
+const StudyNotesLoadingFallback = () => (
+  <div
+    className="flex w-full h-48 items-center justify-center"
+    role="status"
+    aria-label="Loading"
+  >
+    <Loader2 className="size-7 animate-spin" />
+  </div>
+);
 
 export const RirikkuCTABadge = () => {
   return (
@@ -134,7 +145,7 @@ export const KanjiDetails = ({
       </SimpleAccordion>
       <SimpleAccordion trigger="⭐️ Personal Study Notes">
         <ErrorBoundary details="KanjiStudyNotes in KanjiDetails">
-          <Suspense fallback={<BasicLoading />}>
+          <Suspense fallback={<StudyNotesLoadingFallback />}>
             <KanjiStudyNotes key={kanji} kanji={kanji} />
           </Suspense>
         </ErrorBoundary>

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
@@ -1,0 +1,23 @@
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+const OPTIONAL_SYNTAX = `:vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`;
+
+/** Shared edit-mode tips shown above the study notes textarea. */
+export const StudyNotesEditorTips = forwardRef<
+  HTMLDivElement,
+  { className?: string }
+>(function StudyNotesEditorTips({ className }, ref) {
+  return (
+    <div
+      ref={ref}
+      className={cn("text-xs leading-snug text-muted-foreground", className)}
+    >
+      Fun fact! Japanese text is clickable when your notes are finally
+      displayed.
+      <br />
+      Optional Syntax:{" "}
+      <code className="break-all text-[0.7rem]">{OPTIONAL_SYNTAX}</code>
+    </div>
+  );
+});

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
@@ -12,6 +12,7 @@ import {
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { cn } from "@/lib/utils";
 import { MarkdownEditor } from "./MarkdownEditor";
+import { StudyNotesEditorTips } from "./StudyNotesEditorTips";
 
 interface StudyNotesFullscreenEditorProps {
   open: boolean;
@@ -67,8 +68,8 @@ export const StudyNotesFullscreenEditor = ({
               <span className="text-2xl leading-none kanji-font">{kanji}</span>
               <span>Study Notes</span>
             </DialogTitle>
-            <DialogDescription className="text-xs text-muted-foreground">
-              Markdown supported. Japanese text is clickable in View Mode.
+            <DialogDescription asChild>
+              <StudyNotesEditorTips />
             </DialogDescription>
             <DialogPrimitive.Close asChild className="absolute top-2 right-2">
               <Button
@@ -89,12 +90,6 @@ export const StudyNotesFullscreenEditor = ({
               fill
               autoFocus
             />
-            <p className="mt-2 shrink-0 text-xs leading-snug text-muted-foreground">
-              Optional:{" "}
-              <code className="break-all text-[0.7rem]">
-                {`:vocab[日本語]{kana="にほんご" definition="…"}`}
-              </code>
-            </p>
           </div>
         </DialogPrimitive.Content>
       </DialogPortal>

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
@@ -5,6 +5,7 @@ import { useCoarsePointer } from "@/hooks/use-coarse-pointer";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { MarkdownPreview } from "./MarkdownPreview";
+import { StudyNotesEditorTips } from "./StudyNotesEditorTips";
 import { StudyNotesFullscreenEditor } from "./StudyNotesFullscreenEditor";
 import { getKanjiStudyNotesStorageKey, MAX_STUDY_NOTE_LENGTH } from "./storage";
 
@@ -100,18 +101,12 @@ const KanjiStudyNotes = ({ kanji }: { kanji: string }) => {
             </div>
           ) : (
             <>
+              <StudyNotesEditorTips className="mb-3" />
               <MarkdownEditor
                 value={notes}
                 maxLength={MAX_STUDY_NOTE_LENGTH}
                 onChange={persistNotes}
               />
-              <p className="mt-3 text-xs leading-snug text-muted-foreground">
-                Fun fact! Japanese texts are clickable in View Mode. <br />
-                Optional special syntax:{" "}
-                <code className="text-[0.7rem] break-all">
-                  {`:vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`}
-                </code>
-              </p>
             </>
           )}
         </TabsContent>

--- a/src/components/sections/KanjiDetails/ReadingFrequencyCategory.tsx
+++ b/src/components/sections/KanjiDetails/ReadingFrequencyCategory.tsx
@@ -9,7 +9,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { BasicLoading } from "@/components/common/BasicLoading";
 import { DefaultErrorFallback } from "@/components/error";
 import { ExampleWordPopover } from "@/components/common/ExampleWordPopover";
 import {
@@ -26,6 +25,7 @@ import {
   readingTypeLabels,
 } from "@/lib/kanji-section-constants";
 import { ExternalTextLink } from "@/components/common/ExternalTextLink";
+import { TableSkeleton } from "./TableSkeleton";
 
 const FrequencyBadge = ({ frequency }: { frequency: FrequencyCategory }) => {
   const label = frequencyLabels[frequency];
@@ -74,7 +74,7 @@ export const ReadingFrequencyCategory = ({ kanji }: { kanji: string }) => {
   const { status, error, kanjiReadingData } = useKanjiReadingDetails(kanji);
 
   if (status === "pending" || status === "idle") {
-    return <BasicLoading />;
+    return <TableSkeleton />;
   }
 
   if (status === "error" || error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Reading Usefulness
The Reading Usefulness accordion (`ReadingFrequencyCategory`) was showing `BasicLoading`, which didn’t match the table content. It now reuses the same `TableSkeleton` loading screen as `SampleVocabulary`.

### Personal Study Notes loading
The Personal Study Notes Suspense fallback was also using the `BasicLoading` shimmer skeleton. It now uses a simple fixed-height container (`h-48`) with a centered spinning `Loader2` icon.

### Personal Study Notes editor tips
Shared tip copy now sits above the textarea in both the inline editor and the fullscreen “Start writing” modal:

- `Fun fact! Japanese text is clickable when your notes are finally displayed.`
- `Optional Syntax: :vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`

The optional syntax tip is no longer tucked under the textarea in the modal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8649-7069-77ce-84be-7362b6a91302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8649-7069-77ce-84be-7362b6a91302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

