### PR TITLE
Keep Similar search type after Japanese IME kanji confirm

### DIFF
--- a/src/lib/search-input-logic.ts
+++ b/src/lib/search-input-logic.ts
@@ -34,6 +34,11 @@ export const inferSearchTypeFromText = (
     return null;
   }
   if (hasKanji(text)) {
+    // Similar is intentionally kanji-based — keep it instead of jumping
+    // to multi-kanji when IME confirms a kanji candidate.
+    if (currentType === "similar") {
+      return null;
+    }
     return "multi-kanji";
   }
   if (wanakana.isKana(text)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When search type is **Similar Shapes** and a Japanese IME confirms a kanji candidate (Enter), the input was auto-switching to **Multi-Kanji**.

That auto-switch is still correct for other types. For `similar`, `inferSearchTypeFromText` now keeps the current type (same idea as paste, which already stayed on similar).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8649-7069-77ce-84be-7362b6a91302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8649-7069-77ce-84be-7362b6a91302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

