### PR TITLE
Add JLPT/Grade toggle to dashboard bookmarks breakdown

### DIFF
--- a/.cursor/rules/avoid-react-effect-memo-callback-forwardref.mdc
+++ b/.cursor/rules/avoid-react-effect-memo-callback-forwardref.mdc
@@ -1,0 +1,47 @@
+---
+description: Avoid useEffect, useMemo, useCallback, and forwardRef unless truly necessary
+globs: **/*.{ts,tsx}
+alwaysApply: true
+---
+
+# Avoid unnecessary React hooks and forwardRef
+
+Prefer deriving values during render and using simpler React patterns. Do **not** reach for `useEffect`, `useMemo`, `useCallback`, or `forwardRef` by default.
+
+## useEffect — especially avoid
+
+Do **not** use `useEffect` unless you truly need it (syncing with an external system, subscriptions, timers, imperative DOM APIs, etc.).
+
+If there is no simpler alternative and you must use it, add a short comment at the effect explaining:
+
+1. Why the effect is required
+2. That there is no simpler way (e.g. not just “derive during render” or event handlers)
+
+```tsx
+// ❌ BAD — derived state / mirroring props
+useEffect(() => {
+  setFiltered(items.filter(fn));
+}, [items]);
+
+// ✅ GOOD — compute during render
+const filtered = items.filter(fn);
+
+// ✅ OK only when syncing with an external system, with a justifying comment
+// Needed: subscribe to the kanji worker; no render-time API for this.
+useEffect(() => {
+  const unsub = worker.subscribe(handler);
+  return unsub;
+}, [worker]);
+```
+
+## useMemo / useCallback
+
+Do **not** add `useMemo` or `useCallback` unless profiling or an existing repo pattern clearly requires them (e.g. a stable identity that a memoized child depends on). Prefer plain values and inline functions.
+
+If you must use them, add a brief comment why the memoization is necessary and why a simpler approach is insufficient.
+
+## forwardRef
+
+Do **not** use `forwardRef` unless a parent truly must get a DOM/component ref and there is no simpler alternative (e.g. lifting the node, composing without a ref).
+
+If you must use it, add a brief comment why the ref is required and why there is no simpler way.

--- a/src/components/common/JouyouGradeBorderMeanings.tsx
+++ b/src/components/common/JouyouGradeBorderMeanings.tsx
@@ -1,0 +1,21 @@
+import { JouyouGradeOptions } from "@/lib/jouyou-grade";
+import { SquareListItem } from "@/components/common/SquareListItem";
+
+export const JouyouGradeBordersMeanings = () => {
+  return (
+    <>
+      <ul className="flex flex-wrap my-2 w-54">
+        {JouyouGradeOptions.map((item) => {
+          return (
+            <SquareListItem
+              key={item.value}
+              cn={`${item.cn} m-1`}
+              color={item.color}
+              label={item.label}
+            />
+          );
+        })}
+      </ul>
+    </>
+  );
+};

--- a/src/components/common/JouyouGradeSelector.tsx
+++ b/src/components/common/JouyouGradeSelector.tsx
@@ -1,6 +1,18 @@
 import { JouyouGradeOptions, JouyouGradeType } from "@/lib/jouyou-grade";
 import { FilterMultiSelect } from "@/components/common/FilterMultiSelect";
 
+const JouyouGradeOptionsWithIcon = JouyouGradeOptions.map((entry) => {
+  return {
+    label: entry.label,
+    value: entry.value,
+    iconNode: (
+      <div
+        className={`h-3 w-3 -translate-y-[1px] rounded-sm mr-1 ${entry.cn}`}
+      />
+    ),
+  };
+});
+
 export const JouyouGradeSelector = ({
   selectedGrades,
   setSelectedGrades,
@@ -10,7 +22,7 @@ export const JouyouGradeSelector = ({
 }) => (
   <FilterMultiSelect
     label="Jōyō grade"
-    options={JouyouGradeOptions}
+    options={JouyouGradeOptionsWithIcon}
     selectedValues={selectedGrades}
     onValueChange={setSelectedGrades}
     placeholder="All grades selected"

--- a/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
@@ -1,36 +1,96 @@
-import { useMemo } from "react";
+import { useId, useMemo, useState } from "react";
 import {
   useGetKanjiInfoFn,
   useIsKanjiWorkerReady,
+  useJouyouGradeMap,
   useKanjiSearch,
 } from "@/kanji-worker/kanji-worker-hooks";
 import { toSearchSettings } from "@/lib/settings/search-settings-adapter";
 import { JLPT_TYPE_ARR, JLPTListItems, JLTPTtypes } from "@/lib/jlpt";
+import {
+  JOUYOU_GRADE_ARR,
+  JouyouGrade,
+  JouyouGradeListItems,
+  toJouyouGrade,
+} from "@/lib/jouyou-grade";
 import { useBookmarkedKanji } from "@/hooks/use-bookmarked-kanji";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import KaomojiAnimation from "@/components/common/KaomojiLoading";
 import { SectionHeading } from "./SectionHeading";
 import { DashboardPanel } from "./DashboardPanel";
 
 const ALL_KANJI_SEARCH = toSearchSettings(new URLSearchParams());
 
-type JlptCounts = Record<JLTPTtypes, { bookmarked: number; total: number }>;
+type BandCounts<T extends string | number> = Record<
+  T,
+  { bookmarked: number; total: number }
+>;
 
-const emptyCounts = (): JlptCounts =>
+type BreakdownBand = {
+  key: string;
+  label: string;
+  cn: string;
+  bookmarked: number;
+  total: number;
+};
+
+const emptyJlptCounts = (): BandCounts<JLTPTtypes> =>
   Object.fromEntries(
     JLPT_TYPE_ARR.map((k) => [k, { bookmarked: 0, total: 0 }])
-  ) as JlptCounts;
+  ) as BandCounts<JLTPTtypes>;
+
+const emptyGradeCounts = (): BandCounts<JouyouGrade> =>
+  Object.fromEntries(
+    JOUYOU_GRADE_ARR.map((k) => [k, { bookmarked: 0, total: 0 }])
+  ) as BandCounts<JouyouGrade>;
+
+const BreakdownRows = ({ bands }: { bands: BreakdownBand[] }) => (
+  <Table>
+    <TableBody>
+      {bands.map(({ key, label, cn, bookmarked: n, total }) => {
+        const pct = total > 0 ? (n / total) * 100 : 0;
+        return (
+          <TableRow key={key} className="p-0 my-1 text-left">
+            <TableCell className="p-0">
+              <div className="flex items-center justify-between py-1 pl-2 text-xs text-left ">
+                <span className={`h-3 w-3 inline-block ${cn} rounded-full`} />
+                <span className="mx-2 font-extrabold ">{label}</span>{" "}
+              </div>
+            </TableCell>
+            <TableCell className="w-full px-0 py-2">
+              <Progress
+                className="h-1"
+                value={pct}
+                primitiveCn="background-theme-color-with-opacity-100"
+              />
+            </TableCell>
+            <TableCell className="p-0 text-[10px]">
+              <span className="inline-block min-w-14 -mb-0_5 grow text-end">
+                {n} / {total}
+              </span>
+            </TableCell>
+          </TableRow>
+        );
+      })}
+    </TableBody>
+  </Table>
+);
 
 export const BookmarksBreakdown = () => {
   const ready = useIsKanjiWorkerReady();
   const getInfo = useGetKanjiInfoFn();
   const search = useKanjiSearch(ALL_KANJI_SEARCH);
+  const gradeMap = useJouyouGradeMap();
   const bookmarked = useBookmarkedKanji();
+  const [showGrade, setShowGrade] = useState(false);
+  const switchId = useId();
 
-  const counts = useMemo(() => {
-    const next = emptyCounts();
-    if (!ready || !getInfo || !search.data) return next;
+  const jlptBands = useMemo((): BreakdownBand[] => {
+    const next = emptyJlptCounts();
+    if (!ready || !getInfo || !search.data) return [];
 
     for (const kanji of search.data) {
       const jlpt = getInfo(kanji)?.jlpt ?? "none";
@@ -42,58 +102,85 @@ export const BookmarksBreakdown = () => {
       next[jlpt].bookmarked += 1;
     }
 
-    return next;
+    return JLPT_TYPE_ARR.map((jlpt) => {
+      const meta = JLPTListItems[jlpt];
+      return {
+        key: jlpt,
+        label: meta.label !== "Not in JLPT" ? meta.label : "~",
+        cn: meta.cn,
+        bookmarked: next[jlpt].bookmarked,
+        total: next[jlpt].total,
+      };
+    });
   }, [ready, getInfo, search.data, bookmarked]);
 
+  const gradeBands = useMemo((): BreakdownBand[] => {
+    const next = emptyGradeCounts();
+    if (!ready || !gradeMap.data || !search.data) return [];
+
+    for (const kanji of search.data) {
+      const grade = toJouyouGrade(gradeMap.data[kanji]);
+      next[grade].total += 1;
+    }
+
+    for (const kanji of bookmarked) {
+      const grade = toJouyouGrade(gradeMap.data[kanji]);
+      next[grade].bookmarked += 1;
+    }
+
+    return JOUYOU_GRADE_ARR.map((grade) => {
+      const meta = JouyouGradeListItems[grade];
+      return {
+        key: String(grade),
+        label: meta.label !== "Not in Jōyō" ? meta.label : "~",
+        cn: meta.cn,
+        bookmarked: next[grade].bookmarked,
+        total: next[grade].total,
+      };
+    });
+  }, [ready, gradeMap.data, search.data, bookmarked]);
+
   const loading =
-    !ready || search.status === "loading" || search.status === "idle";
+    !ready ||
+    search.status === "loading" ||
+    search.status === "idle" ||
+    (showGrade &&
+      (gradeMap.status === "loading" || gradeMap.status === "idle"));
+
+  const bands = showGrade ? gradeBands : jlptBands;
+  const description = showGrade
+    ? "How much of each jōyō grade you've bookmarked. Bookmark a word from a kanji’s detail drawer to start filling these bars."
+    : "How much of each JLPT band you've bookmarked. Bookmark a word from a kanji’s detail drawer to start filling these bars.";
 
   return (
     <DashboardPanel>
-      <SectionHeading
-        title="Bookmarks"
-        description="How much of each JLPT band you've bookmarked.  Bookmark a word from a kanji’s detail drawer to start filling these bars."
-      />
+      <SectionHeading title="Bookmarks" description={description} />
+      <div className="flex items-center justify-center gap-2 mb-4 text-xs text-muted-foreground">
+        <Label
+          htmlFor={switchId}
+          className={!showGrade ? "text-foreground font-semibold" : undefined}
+        >
+          JLPT
+        </Label>
+        <Switch
+          id={switchId}
+          checked={showGrade}
+          onCheckedChange={setShowGrade}
+          aria-label="Toggle between JLPT and grade breakdown"
+        />
+        <Label
+          htmlFor={switchId}
+          className={showGrade ? "text-foreground font-semibold" : undefined}
+        >
+          Grade
+        </Label>
+      </div>
       {loading ? (
         <div className="py-8">
           <KaomojiAnimation />
         </div>
       ) : (
-        <Table>
-          <TableBody>
-            {JLPT_TYPE_ARR.map((jlpt) => {
-              const { bookmarked: n, total } = counts[jlpt];
-              const pct = total > 0 ? (n / total) * 100 : 0;
-              const meta = JLPTListItems[jlpt];
-              return (
-                <TableRow key={jlpt} className="p-0 my-1 text-left">
-                  <TableCell className="p-0">
-                    <div className="flex items-center justify-between py-1 pl-2 text-xs text-left ">
-                      <span
-                        className={`h-3 w-3 inline-block ${meta.cn} rounded-full`}
-                      />
-                      <span className="mx-2 font-extrabold ">
-                        {meta.label !== "Not in JLPT" ? meta.label : "~"}
-                      </span>{" "}
-                    </div>
-                  </TableCell>
-                  <TableCell className="w-full px-0 py-2">
-                    <Progress
-                      className="h-1"
-                      value={pct}
-                      primitiveCn="background-theme-color-with-opacity-100"
-                    />
-                  </TableCell>
-                  <TableCell className="p-0 text-[10px]">
-                    <span className="inline-block min-w-14 -mb-0_5 grow text-end">
-                      {n} / {total}
-                    </span>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
+        <BreakdownRows bands={bands} />
       )}
     </DashboardPanel>
   );

--- a/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
@@ -13,6 +13,7 @@ import { FreqGradient } from "@/components/common/freq/FreqGradient";
 import { ItemTypeSwitch } from "@/components/common/ItemTypeSwitch";
 import { JLPTBordersMeanings } from "@/components/common/jlpt/JLPTBorderMeanings";
 import { StudyStatusBorderMeanings } from "@/components/common/StudyStatusBorderMeanings";
+import { JouyouGradeBordersMeanings } from "@/components/common/JouyouGradeBorderMeanings";
 import { FreqGradientInfoIcon } from "@/components/common/freq/FreqGradientInfoIcon";
 import { useBgSrc, useBgSrcDispatch } from "@/hooks/routing-hooks";
 import BasicSelect from "@/components/common/BasicSelect";
@@ -84,6 +85,7 @@ const CardStateSettings = () => {
         options={[
           { value: "jlpt", label: "JLPT Level" },
           { value: "study-status", label: "Study Status" },
+          { value: "grade", label: "Jōyō Grade" },
           { value: "none", label: "None" },
         ]}
       />
@@ -95,6 +97,11 @@ const CardStateSettings = () => {
       {cardState.borderColorMeaning === "study-status" && (
         <div key="study-status" className="animate-fade-in">
           <StudyStatusBorderMeanings />
+        </div>
+      )}
+      {cardState.borderColorMeaning === "grade" && (
+        <div key="grade" className="animate-fade-in">
+          <JouyouGradeBordersMeanings />
         </div>
       )}
     </>

--- a/src/components/sections/KanjiHoverItem/kanji-item-button-hooks.tsx
+++ b/src/components/sections/KanjiHoverItem/kanji-item-button-hooks.tsx
@@ -1,7 +1,11 @@
 import { JLPTListItems } from "@/lib/jlpt";
+import { JouyouGradeListItems, toJouyouGrade } from "@/lib/jouyou-grade";
 import { freqCategoryCn, getFreqCategory } from "@/lib/freq/freq-category";
 import { freqMap } from "@/lib/options/options-label-maps";
-import { useGetKanjiInfoFn } from "@/kanji-worker/kanji-worker-hooks";
+import {
+  useGetKanjiInfoFn,
+  useJouyouGradeMap,
+} from "@/kanji-worker/kanji-worker-hooks";
 import { useDeferredItemSettings } from "@/providers/item-settings-hooks";
 import { useBgSrc } from "@/hooks/routing-hooks";
 import { useGetRepresentativeWordFn } from "@/providers/kanji-representative-word-provider";
@@ -30,6 +34,7 @@ const getStudyStatusBorderCn = (
 const getBorderCn = (
   borderColorMeaning: BorderColorMeaning,
   jlpt: JLTPTtypes,
+  grade: number | undefined,
   kanji: string,
   representativeWord: string | null,
   dontIncludeFreq: boolean,
@@ -41,6 +46,9 @@ const getBorderCn = (
       : `border-theme-color-with-opacity-${25 * freqRankCategory}`;
 
   if (borderColorMeaning === "jlpt") return JLPTListItems[jlpt].cnBorder;
+  if (borderColorMeaning === "grade") {
+    return JouyouGradeListItems[toJouyouGrade(grade)].cnBorder;
+  }
   if (borderColorMeaning === "study-status") {
     return getStudyStatusBorderCn(kanji, representativeWord) ?? fallback;
   }
@@ -53,6 +61,7 @@ export const useItemBtnCn = (kanji: string) => {
   const bgSrc = useBgSrc();
   const itemType = useItemType();
   const { borderColorMeaning } = useDeferredItemSettings();
+  const gradeMap = useJouyouGradeMap(borderColorMeaning === "grade");
 
   const kanjiInfo = getInfo?.(kanji);
 
@@ -83,6 +92,7 @@ export const useItemBtnCn = (kanji: string) => {
   const border = getBorderCn(
     borderColorMeaning,
     jlpt,
+    gradeMap.data?.[kanji],
     kanji,
     representativeWord,
     dontIncludeFreq,

--- a/src/kanji-worker/kanji-worker-hooks.tsx
+++ b/src/kanji-worker/kanji-worker-hooks.tsx
@@ -146,23 +146,37 @@ export const useKanjiSearch = (searchSettings: SearchSettings) => {
   };
 };
 
+/** Shared across hook instances so list cells don't each hit the worker. */
+let jouyouGradeMapCache: Record<string, number> | null = null;
+let jouyouGradeMapPromise: Promise<Record<string, number>> | null = null;
+
+const fetchJouyouGradeMap = () => {
+  if (jouyouGradeMapCache) {
+    return Promise.resolve(jouyouGradeMapCache);
+  }
+  if (!jouyouGradeMapPromise) {
+    jouyouGradeMapPromise = requestWorker({
+      type: "jouyou-grade-map",
+    }).then((data) => {
+      jouyouGradeMapCache = data as Record<string, number>;
+      return jouyouGradeMapCache;
+    });
+  }
+  return jouyouGradeMapPromise;
+};
+
 /** Kanji → jōyō school grade from the extended cache (ready once worker is). */
-export const useJouyouGradeMap = () => {
+export const useJouyouGradeMap = (enabled = true) => {
   const ready = useIsKanjiWorkerReady();
 
   const state = useWorkerQuery<Record<string, number>>(
-    ready
-      ? () =>
-          requestWorker({
-            type: "jouyou-grade-map",
-          }) as Promise<Record<string, number>>
-      : null,
-    [ready]
+    ready && enabled ? fetchJouyouGradeMap : null,
+    [ready, enabled]
   );
 
   return {
     status: state.status,
-    data: state.data,
+    data: state.data ?? jouyouGradeMapCache ?? undefined,
     error: (state.error as string | undefined) ?? null,
   };
 };

--- a/src/kanji-worker/kanji-worker-hooks.tsx
+++ b/src/kanji-worker/kanji-worker-hooks.tsx
@@ -146,6 +146,27 @@ export const useKanjiSearch = (searchSettings: SearchSettings) => {
   };
 };
 
+/** Kanji → jōyō school grade from the extended cache (ready once worker is). */
+export const useJouyouGradeMap = () => {
+  const ready = useIsKanjiWorkerReady();
+
+  const state = useWorkerQuery<Record<string, number>>(
+    ready
+      ? () =>
+          requestWorker({
+            type: "jouyou-grade-map",
+          }) as Promise<Record<string, number>>
+      : null,
+    [ready]
+  );
+
+  return {
+    status: state.status,
+    data: state.data,
+    error: (state.error as string | undefined) ?? null,
+  };
+};
+
 export const useKanjiSearchCount = (searchSettings: SearchSettings) => {
   const ready = useIsKanjiWorkerReady();
 

--- a/src/kanji-worker/kanji-worker.ts
+++ b/src/kanji-worker/kanji-worker.ts
@@ -279,6 +279,17 @@ const HANDLERS: Record<KanjiWorkerRequestName, Handler> = {
       .then(() => reply.ok(KANJI_INFO_MAIN_CACHE))
       .catch(reply.err);
   },
+  "jouyou-grade-map": (_payload, reply) => {
+    if (Object.keys(KANJI_INFO_EXTENDED_CACHE).length === 0) {
+      reply.err({ message: "Extended kanji cache not initialized" });
+      return;
+    }
+    const grades: Record<string, number> = {};
+    for (const kanji of Object.keys(KANJI_INFO_EXTENDED_CACHE)) {
+      grades[kanji] = KANJI_INFO_EXTENDED_CACHE[kanji].jouyouGrade;
+    }
+    reply.ok(grades);
+  },
   "part-keyword-map": (_payload, reply) => {
     fetchPartKeywordInfo()
       .then((r) => {

--- a/src/lib/jouyou-grade.ts
+++ b/src/lib/jouyou-grade.ts
@@ -1,0 +1,65 @@
+/** Jōyō school-grade bands used in kanji_extended.json. */
+
+export const JOUYOU_GRADE_ARR = [1, 2, 3, 4, 5, 6, 9, -1] as const;
+export type JouyouGrade = (typeof JOUYOU_GRADE_ARR)[number];
+
+export const JouyouGradeListItems: Record<
+  JouyouGrade,
+  { cn: string; label: string; cnBorder: string }
+> = {
+  1: {
+    cn: "bg-green-500",
+    cnBorder: "border-green-500",
+    label: "1",
+  },
+  2: {
+    cn: "bg-lime-500",
+    cnBorder: "border-lime-500",
+    label: "2",
+  },
+  3: {
+    cn: "bg-yellow-400",
+    cnBorder: "border-yellow-400",
+    label: "3",
+  },
+  4: {
+    cn: "bg-cyan-400",
+    cnBorder: "border-cyan-400",
+    label: "4",
+  },
+  5: {
+    cn: "bg-blue-400",
+    cnBorder: "border-blue-400",
+    label: "5",
+  },
+  6: {
+    cn: "bg-pink-400",
+    cnBorder: "border-pink-400",
+    label: "6",
+  },
+  9: {
+    cn: "bg-orange-400",
+    cnBorder: "border-orange-400",
+    label: "9",
+  },
+  [-1]: {
+    cn: "bg-gray-400",
+    cnBorder: "border-gray-400",
+    label: "Not in Jōyō",
+  },
+};
+
+export const toJouyouGrade = (raw: number | null | undefined): JouyouGrade => {
+  if (
+    raw === 1 ||
+    raw === 2 ||
+    raw === 3 ||
+    raw === 4 ||
+    raw === 5 ||
+    raw === 6 ||
+    raw === 9
+  ) {
+    return raw;
+  }
+  return -1;
+};

--- a/src/lib/jouyou-grade.ts
+++ b/src/lib/jouyou-grade.ts
@@ -5,46 +5,54 @@ export type JouyouGrade = (typeof JOUYOU_GRADE_ARR)[number];
 
 export const JouyouGradeListItems: Record<
   JouyouGrade,
-  { cn: string; label: string; cnBorder: string }
+  { cn: string; color: string; label: string; cnBorder: string }
 > = {
   1: {
     cn: "bg-green-500",
     cnBorder: "border-green-500",
+    color: "green",
     label: "1",
   },
   2: {
     cn: "bg-lime-500",
     cnBorder: "border-lime-500",
+    color: "lime",
     label: "2",
   },
   3: {
     cn: "bg-yellow-400",
     cnBorder: "border-yellow-400",
+    color: "yellow",
     label: "3",
   },
   4: {
     cn: "bg-cyan-400",
     cnBorder: "border-cyan-400",
+    color: "cyan",
     label: "4",
   },
   5: {
     cn: "bg-blue-400",
     cnBorder: "border-blue-400",
+    color: "blue",
     label: "5",
   },
   6: {
     cn: "bg-pink-400",
     cnBorder: "border-pink-400",
+    color: "pink",
     label: "6",
   },
   9: {
     cn: "bg-orange-400",
     cnBorder: "border-orange-400",
+    color: "orange",
     label: "9",
   },
   [-1]: {
     cn: "bg-gray-400",
     cnBorder: "border-gray-400",
+    color: "gray",
     label: "Not in Jōyō",
   },
 };
@@ -78,16 +86,17 @@ export const JOUYOU_GRADE_TYPE_ARR = [
 
 export type JouyouGradeType = (typeof JOUYOU_GRADE_TYPE_ARR)[number];
 
-export const JouyouGradeOptions: {
-  label: string;
-  value: JouyouGradeType;
-}[] = [
-  ...JOUYOU_GRADE_TYPE_ARR.filter((grade) => grade !== "none").map((grade) => ({
-    label: `Grade ${grade}`,
+export const jouyouGradeTypeToGrade = (grade: JouyouGradeType): JouyouGrade =>
+  grade === "none" ? -1 : (Number(grade) as JouyouGrade);
+
+export const JouyouGradeOptions = JOUYOU_GRADE_TYPE_ARR.map((grade) => {
+  const item = JouyouGradeListItems[jouyouGradeTypeToGrade(grade)];
+  return {
+    ...item,
+    label: grade === "none" ? item.label : `Grade ${grade}`,
     value: grade,
-  })),
-  { label: "Not in Jōyō", value: "none" },
-];
+  };
+});
 
 export const JouyouGradeOptionsCount = JOUYOU_GRADE_TYPE_ARR.length;
 

--- a/src/lib/kanji/kanji-worker-types.ts
+++ b/src/lib/kanji/kanji-worker-types.ts
@@ -123,6 +123,7 @@ export type KanjiWorkerRequestName =
   | "initialize-segmented-vocab-map"
   | "initialize-decomposition-map"
   | "kanji-main-map"
+  | "jouyou-grade-map"
   | "phonetic-map"
   | "part-keyword-map"
   | "retrieve-vocab-info";

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -44,7 +44,7 @@ export type SearchSettings = {
   sortSettings: SortSettings;
 };
 
-export type BorderColorMeaning = "jlpt" | "study-status" | "none";
+export type BorderColorMeaning = "jlpt" | "study-status" | "grade" | "none";
 
 export type ItemSettings = {
   cardType: "compact" | "expanded";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a **JLPT / Grade** switch on the dashboard Bookmarks section so you can flip between JLPT-band and jōyō-grade progress bars.
- Grade rows reuse the same layout as JLPT (color dot, label, thin progress bar, `n / total`).
- Grades come from the worker via a new `jouyou-grade-map` request (`1`–`6`, `9`, and `~` for non-jōyō).

## Test plan
- [ ] Open `/dashboard` and confirm Bookmarks still shows the JLPT breakdown by default.
- [ ] Toggle to **Grade** and confirm bars for grades 1–6, 9, and `~` with matching styling.
- [ ] Bookmark a few words spanning different grades/JLPT levels and confirm counts update in both modes.
- [ ] Confirm the section info popover text updates for the active mode.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f866e-61cc-7bd3-9d06-2fe4f7c918c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f866e-61cc-7bd3-9d06-2fe4f7c918c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

