### PR TITLE
Polish study notes tips and share local-storage warning

### DIFF
--- a/src/components/common/LocalStorageWarning.tsx
+++ b/src/components/common/LocalStorageWarning.tsx
@@ -1,0 +1,11 @@
+import { cn } from "@/lib/utils";
+
+export const LOCAL_STORAGE_WARNING = "⚠️ Local storage only. Data may be lost.";
+
+export const LocalStorageWarning = ({ className }: { className?: string }) => {
+  return (
+    <p className={cn("mx-auto text-xs text-muted-foreground", className)}>
+      {LOCAL_STORAGE_WARNING}
+    </p>
+  );
+};

--- a/src/components/screens/DashboardScreen/DashboardScreen.tsx
+++ b/src/components/screens/DashboardScreen/DashboardScreen.tsx
@@ -1,4 +1,5 @@
 import useHtmlDocumentTitle from "@/hooks/use-html-document-title";
+import { LocalStorageWarning } from "@/components/common/LocalStorageWarning";
 import { ScreenShell } from "@/components/common/ScreenShell";
 import { StatsOverview } from "./StatsOverview";
 import { ActivityCalendarHeatmap } from "./ActivityCalendarHeatmap";
@@ -17,10 +18,7 @@ const DashboardScreen = () => {
             Your Progress
           </h1>
         )}
-        <p className="mx-auto mt-2 text-sm text-muted-foreground">
-          ⚠️ Saved only on this device. No backup. Your data may be lost at any
-          time.
-        </p>
+        <LocalStorageWarning className="mt-2 text-sm" />
       </header>
 
       <StatsOverview />

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
@@ -1,7 +1,37 @@
 import { forwardRef } from "react";
+import { Button } from "@/components/ui/button";
+import { CheckCircle, Clipboard } from "@/components/icons";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
 
-const OPTIONAL_SYNTAX = `:vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`;
+export const OPTIONAL_VOCAB_SYNTAX = `:vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`;
+
+const VocabSyntaxCopyButton = () => {
+  const { copy, status } = useCopyToClipboard(1200);
+  const copied = status === "copied";
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="iconXl"
+      className="h-7 w-7 shrink-0 rounded-md"
+      aria-label={copied ? "Copied vocab syntax" : "Copy vocab syntax"}
+      title={copied ? "Copied" : "Copy"}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void copy(OPTIONAL_VOCAB_SYNTAX, event);
+      }}
+    >
+      {copied ? (
+        <CheckCircle className="size-3.5" />
+      ) : (
+        <Clipboard className="size-3.5" />
+      )}
+    </Button>
+  );
+};
 
 /** Shared edit-mode tips shown above the study notes textarea. */
 export const StudyNotesEditorTips = forwardRef<
@@ -11,13 +41,25 @@ export const StudyNotesEditorTips = forwardRef<
   return (
     <div
       ref={ref}
-      className={cn("text-xs leading-snug text-muted-foreground", className)}
+      className={cn(
+        "space-y-2.5 text-xs leading-snug text-muted-foreground",
+        className
+      )}
     >
-      Fun fact! Japanese text is clickable when your notes are finally
-      displayed.
-      <br />
-      Optional Syntax:{" "}
-      <code className="break-all text-[0.7rem]">{OPTIONAL_SYNTAX}</code>
+      <p>
+        Fun fact! Japanese text is clickable when your notes are finally
+        displayed.
+      </p>
+
+      <div className="space-y-1.5">
+        <p className="font-medium text-foreground/80">Optional syntax</p>
+        <div className="flex items-start gap-1.5 rounded-lg border border-border/70 bg-muted/50 p-1.5 pl-2.5">
+          <code className="min-w-0 flex-1 break-all font-mono text-[0.7rem] leading-relaxed text-foreground/90">
+            {OPTIONAL_VOCAB_SYNTAX}
+          </code>
+          <VocabSyntaxCopyButton />
+        </div>
+      </div>
     </div>
   );
 });

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
@@ -1,10 +1,9 @@
-import { forwardRef } from "react";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, Clipboard } from "@/components/icons";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
 
-export const OPTIONAL_VOCAB_SYNTAX = `:vocab[日本語]{kana="にほんご" definition="Japanese language (my own definition)"}`;
+export const OPTIONAL_VOCAB_SYNTAX = `:vocab[日本]{kana="にほん" definition="Japan"}`;
 
 const VocabSyntaxCopyButton = () => {
   const { copy, status } = useCopyToClipboard(1200);
@@ -15,7 +14,7 @@ const VocabSyntaxCopyButton = () => {
       type="button"
       variant="outline"
       size="iconXl"
-      className="h-7 w-7 shrink-0 rounded-md"
+      className="rounded-md h-7 w-7 shrink-0"
       aria-label={copied ? "Copied vocab syntax" : "Copy vocab syntax"}
       title={copied ? "Copied" : "Copy"}
       onClick={(event) => {
@@ -34,27 +33,17 @@ const VocabSyntaxCopyButton = () => {
 };
 
 /** Shared edit-mode tips shown above the study notes textarea. */
-export const StudyNotesEditorTips = forwardRef<
-  HTMLDivElement,
-  { className?: string }
->(function StudyNotesEditorTips({ className }, ref) {
+export const StudyNotesEditorTips = ({ className }: { className?: string }) => {
   return (
-    <div
-      ref={ref}
-      className={cn(
-        "space-y-2.5 text-xs leading-snug text-muted-foreground",
-        className
-      )}
-    >
+    <div className={cn("space-y-2.5 text-sm font-bold text-left", className)}>
       <p>
         Fun fact! Japanese text is clickable when your notes are finally
-        displayed.
+        displayed. Try the optional syntax! 👇
       </p>
 
       <div className="space-y-1.5">
-        <p className="font-medium text-foreground/80">Optional syntax</p>
         <div className="flex items-start gap-1.5 rounded-lg border border-border/70 bg-muted/50 p-1.5 pl-2.5">
-          <code className="min-w-0 flex-1 break-all font-mono text-[0.7rem] leading-relaxed text-foreground/90">
+          <code className="flex-1 min-w-0 font-mono text-sm leading-relaxed text-left break-all text-foreground/80">
             {OPTIONAL_VOCAB_SYNTAX}
           </code>
           <VocabSyntaxCopyButton />
@@ -62,4 +51,4 @@ export const StudyNotesEditorTips = forwardRef<
       </div>
     </div>
   );
-});
+};

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { cn } from "@/lib/utils";
+import { LocalStorageWarning } from "@/components/common/LocalStorageWarning";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { StudyNotesEditorTips } from "./StudyNotesEditorTips";
 
@@ -63,7 +64,7 @@ export const StudyNotesFullscreenEditor = ({
           }}
           onKeyDown={(event) => event.stopPropagation()}
         >
-          <DialogHeader className="relative shrink-0 gap-1 border-b border-border px-4 py-3 pr-16 text-left">
+          <DialogHeader className="relative gap-1 px-4 py-3 pr-16 text-left border-b shrink-0 border-border">
             <DialogTitle className="flex items-center gap-2 text-base">
               <span className="text-2xl leading-none kanji-font">{kanji}</span>
               <span>Study Notes</span>
@@ -82,7 +83,7 @@ export const StudyNotesFullscreenEditor = ({
               </Button>
             </DialogPrimitive.Close>
           </DialogHeader>
-          <div className="flex min-h-0 flex-1 flex-col px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-3">
+          <div className="flex flex-col flex-1 min-h-0 px-3 pt-3">
             <MarkdownEditor
               value={value}
               maxLength={maxLength}
@@ -90,6 +91,9 @@ export const StudyNotesFullscreenEditor = ({
               fill
               autoFocus
             />
+          </div>
+          <div className="pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+            <LocalStorageWarning className="pb-2" />
           </div>
         </DialogPrimitive.Content>
       </DialogPortal>

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { LocalStorageWarning } from "@/components/common/LocalStorageWarning";
 import { PracticeButton } from "@/components/ui/practice-button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCoarsePointer } from "@/hooks/use-coarse-pointer";
@@ -107,6 +108,7 @@ const KanjiStudyNotes = ({ kanji }: { kanji: string }) => {
                 maxLength={MAX_STUDY_NOTE_LENGTH}
                 onChange={persistNotes}
               />
+              <LocalStorageWarning className="pb-2" />
             </>
           )}
         </TabsContent>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improves the study notes edit tip for optional `:vocab[...]` syntax, and shares the device-only storage warning across dashboard and notes.

### Changes
- Clearer optional vocab tip with a compact monospace strip and clipboard copy button
- Shorter example snippet (`:vocab[日本]{...}`) and tighter tip copy
- New shared `LocalStorageWarning` used on Dashboard and study notes (inline + fullscreen)

Shared via `StudyNotesEditorTips` (desktop edit mode + fullscreen mobile editor).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f865b-fc8e-7ba3-bc48-ec8bb7271f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f865b-fc8e-7ba3-bc48-ec8bb7271f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>