### PR TITLE
Fix reading-practice keyboard bob, Clear All, and settings load shift

### DIFF
--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -125,14 +125,15 @@ export const Game = ({
   };
 
   return (
-    <div className="relative flex flex-col w-full h-full gap-5 [@media(pointer:fine)]:justify-center [@media(pointer:fine)]:gap-8 md:justify-center md:gap-8 [@media(min-height:900px)]:justify-center [@media(min-height:900px)]:gap-8">
+    <div className="relative flex flex-col w-full h-full gap-5 [@media(pointer:fine)]:justify-center [@media(pointer:fine)]:gap-8">
       <EndSession onClick={onEnd} />
       {/*
-        Touch layout: keep the prompt + input as a top-anchored cluster with a
-        fixed gap. A bottom spacer absorbs visual-viewport height changes so
-        the keyboard opening/closing does not shove content around.
+        Coarse-pointer (touch) layout: keep the prompt + input as a
+        top-anchored cluster with a fixed gap. A bottom spacer absorbs
+        visual-viewport height changes so the keyboard opening/closing does
+        not shove content around. Fine-pointer devices center instead.
       */}
-      <div className="flex flex-col items-center shrink-0 px-4 pt-8 text-center [@media(pointer:fine)]:pt-8 md:pt-8 [@media(min-height:900px)]:pt-8">
+      <div className="flex flex-col items-center shrink-0 px-4 pt-8 text-center">
         <div
           className={current.fontIndex === null ? "kanji-font" : ""}
           style={
@@ -158,7 +159,7 @@ export const Game = ({
         />
       </div>
 
-      <div className="flex flex-col gap-3 shrink-0 px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] [@media(pointer:fine)]:pb-0 md:pb-0">
+      <div className="flex flex-col gap-3 shrink-0 px-3 pb-[max(0.5rem,env(safe-area-inset-bottom))] [@media(pointer:fine)]:pb-0">
         {feedback == null ? (
           <>
             <Input
@@ -208,12 +209,12 @@ export const Game = ({
       </div>
 
       {/*
-        Bottom spacer on coarse-pointer / short screens only. Height changes
-        from the on-screen keyboard are absorbed here instead of stretching
-        the gap between the gloss and the input.
+        Bottom spacer on coarse-pointer devices only. Height changes from the
+        on-screen keyboard are absorbed here instead of stretching the gap
+        between the gloss and the input.
       */}
       <div
-        className="flex-1 min-h-0 [@media(pointer:fine)]:hidden md:hidden [@media(min-height:900px)]:hidden"
+        className="flex-1 min-h-0 [@media(pointer:fine)]:hidden"
         aria-hidden="true"
       />
     </div>

--- a/src/components/screens/ListScreen/ControlBar/ControlBar.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ControlBar.tsx
@@ -1,17 +1,12 @@
-import { lazy, Suspense } from "react";
-import KaoMojiLoadingSpinner from "@/components/common/KaomojiLoading";
+import { Suspense } from "react";
 import { ReportBugIconBtn } from "@/components/common/ReportBugIconBtn";
 
-import ItemPresentationSettingsPopover from "./ItemPresentation/ItemPresentationPopover";
 import { SettledSearchInput } from "./SearchInput/SettledSearchInput";
 import { SettledSortAndFilter } from "./SortAndFilter/SettledSortAndFilter";
+import LazyItemPresentation, {
+  ItemPresentationLoadingFallback,
+} from "./ItemPresentation/LazyItemPresentation";
 import { ErrorBoundary } from "@/components/error";
-
-const ItemPresentationSettingsContent = lazy(() =>
-  import("./ItemPresentation/ItemPresentationContent").then((m) => ({
-    default: m.ItemPresentationSettingsContent,
-  }))
-);
 
 export const ControlBar = () => {
   return (
@@ -44,23 +39,9 @@ export const ControlBar = () => {
           </div>
         }
       >
-        <ItemPresentationSettingsPopover>
-          <ErrorBoundary details="ItemPresentationSettingsContent in ControlBar">
-            <Suspense
-              fallback={
-                <div
-                  className="py-8 text-sm text-center text-muted-foreground"
-                  role="status"
-                >
-                  <KaoMojiLoadingSpinner />
-                  Loading...
-                </div>
-              }
-            >
-              <ItemPresentationSettingsContent />
-            </Suspense>
-          </ErrorBoundary>
-        </ItemPresentationSettingsPopover>
+        <Suspense fallback={<ItemPresentationLoadingFallback />}>
+          <LazyItemPresentation />
+        </Suspense>
       </ErrorBoundary>
     </>
   );

--- a/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationPopover.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationPopover.tsx
@@ -1,14 +1,16 @@
-import { useState, ReactNode } from "react";
+import { useState } from "react";
 import { Flower } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { GenericPopover } from "@/components/common/GenericPopover";
+import { ErrorBoundary } from "@/components/error";
+import { ItemPresentationSettingsContent } from "./ItemPresentationContent";
 
 const ItemPresentationSettingsPopover = ({
-  children,
+  initiallyOpen = false,
 }: {
-  children: ReactNode;
+  initiallyOpen?: boolean;
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(initiallyOpen);
   return (
     <GenericPopover
       open={isOpen}
@@ -29,7 +31,13 @@ const ItemPresentationSettingsPopover = ({
         </Button>
       }
       // Mount the settings form only while open.
-      content={isOpen ? children : null}
+      content={
+        isOpen ? (
+          <ErrorBoundary details="ItemPresentationSettingsContent in ItemPresentationPopover">
+            <ItemPresentationSettingsContent />
+          </ErrorBoundary>
+        ) : null
+      }
     />
   );
 };

--- a/src/components/screens/ListScreen/ControlBar/ItemPresentation/LazyItemPresentation.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemPresentation/LazyItemPresentation.tsx
@@ -1,0 +1,48 @@
+import { lazy, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Flower } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+
+const ItemPresentationSettingsPopover = lazy(
+  () => import("./ItemPresentationPopover")
+);
+
+export const ItemPresentationLoadingFallback = () => (
+  <Button
+    variant="outline"
+    size="icon"
+    className="h-9 w-9 shrink-0"
+    aria-label="Loading item presentation settings"
+    disabled
+  >
+    <Loader2 className="animate-spin" />
+  </Button>
+);
+
+/**
+ * Keeps item-presentation settings out of the list-screen chunk until opened.
+ * While the chunk loads, Suspense shows {@link ItemPresentationLoadingFallback}
+ * in place of the trigger so the control bar does not shift.
+ */
+const LazyItemPresentation = () => {
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  if (!shouldLoad) {
+    return (
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-9 w-9 shrink-0"
+        onClick={() => setShouldLoad(true)}
+        onMouseEnter={() => setShouldLoad(true)}
+      >
+        <Flower />
+        <span className="sr-only">Card Presentation Settings</span>
+      </Button>
+    );
+  }
+
+  return <ItemPresentationSettingsPopover initiallyOpen />;
+};
+
+export default LazyItemPresentation;

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/LazySortAndFilter.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/LazySortAndFilter.tsx
@@ -1,0 +1,66 @@
+import { lazy, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { SearchSettings } from "@/lib/settings/settings";
+import { Button } from "@/components/ui/button";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { SortAndFilterButton } from "./SortAndFilterButton";
+
+const SortAndFilterSettingsDialog = lazy(() =>
+  import("./SortAndFilterDialog").then((m) => ({
+    default: m.SortAndFilterSettingsDialog,
+  }))
+);
+
+export const SortAndFilterLoadingFallback = () => (
+  <Button
+    variant="outline"
+    size="icon"
+    className="relative h-9 w-9 shrink-0"
+    aria-label="Loading sort and filter settings"
+    disabled
+  >
+    <Loader2 className="animate-spin" />
+  </Button>
+);
+
+/**
+ * Keeps the sort/filter dialog out of the list-screen chunk until opened.
+ * While the chunk loads, Suspense shows {@link SortAndFilterLoadingFallback}
+ * in place of the trigger so the control bar does not shift.
+ */
+const LazySortAndFilter = ({
+  initialValue,
+  onSettle,
+}: {
+  onSettle: (x: SearchSettings) => void;
+  initialValue: SearchSettings;
+}) => {
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  if (!shouldLoad) {
+    return (
+      <HoverCard openDelay={0} closeDelay={0}>
+        <HoverCardTrigger asChild>
+          <SortAndFilterButton onClick={() => setShouldLoad(true)} />
+        </HoverCardTrigger>
+        <HoverCardContent className="z-50 w-24 p-2 text-xs border rounded-md shadow-md outline-none bg-popover text-popover-foreground">
+          Sort and Filter Settings
+        </HoverCardContent>
+      </HoverCard>
+    );
+  }
+
+  return (
+    <SortAndFilterSettingsDialog
+      initiallyOpen
+      initialValue={initialValue}
+      onSettle={onSettle}
+    />
+  );
+};
+
+export default LazySortAndFilter;

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SettledSortAndFilter.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SettledSortAndFilter.tsx
@@ -1,22 +1,25 @@
+import { Suspense } from "react";
 import {
   useSearchSettings,
   useSearchSettingsDispatch,
 } from "@/providers/search-settings-hooks";
-import { SortAndFilterSettingsDialog } from "./SortAndFilterDialog";
+import LazySortAndFilter, {
+  SortAndFilterLoadingFallback,
+} from "./LazySortAndFilter";
 
 export const SettledSortAndFilter = () => {
   const searchSettings = useSearchSettings();
   const dispatch = useSearchSettingsDispatch();
 
   return (
-    <>
-      <SortAndFilterSettingsDialog
+    <Suspense fallback={<SortAndFilterLoadingFallback />}>
+      <LazySortAndFilter
         initialValue={searchSettings}
         onSettle={(value) => {
           dispatch("filterSettings", value.filterSettings);
           dispatch("sortSettings", value.sortSettings);
         }}
       />
-    </>
+    </Suspense>
   );
 };

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterDialog.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterDialog.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from "react";
+import { useState } from "react";
 import { SearchSettings } from "@/lib/settings/settings";
 import { ErrorBoundary } from "@/components/error";
 import {
@@ -15,22 +15,18 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { SortAndFilterButton } from "./SortAndFilterButton";
-import KaoMojiLoadingSpinner from "@/components/common/KaomojiLoading";
-
-const SortAndFilterSettingsForm = lazy(() =>
-  import("./SortAndFilterForm").then((m) => ({
-    default: m.SortAndFilterSettingsForm,
-  }))
-);
+import { SortAndFilterSettingsForm } from "./SortAndFilterForm";
 
 export const SortAndFilterSettingsDialog = ({
   initialValue,
   onSettle,
+  initiallyOpen = false,
 }: {
   onSettle: (x: SearchSettings) => void;
   initialValue: SearchSettings;
+  initiallyOpen?: boolean;
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(initiallyOpen);
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -61,22 +57,13 @@ export const SortAndFilterSettingsDialog = ({
         </DialogHeader>
         {isOpen && (
           <ErrorBoundary>
-            <Suspense
-              fallback={
-                <div className="py-8 text-sm text-center text-muted-foreground">
-                  <KaoMojiLoadingSpinner />
-                  Loading...
-                </div>
-              }
-            >
-              <SortAndFilterSettingsForm
-                initialValue={initialValue}
-                onSettle={(val) => {
-                  onSettle(val);
-                  setIsOpen(false);
-                }}
-              />
-            </Suspense>
+            <SortAndFilterSettingsForm
+              initialValue={initialValue}
+              onSettle={(val) => {
+                onSettle(val);
+                setIsOpen(false);
+              }}
+            />
           </ErrorBoundary>
         )}
       </DialogContent>

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
@@ -31,7 +31,8 @@ export const SortAndFilterSettingsForm = ({
   initialValue: SearchSettings;
 }) => {
   const form = useSortAndFilterForm(initialValue);
-  const { sortValues, filterValues, isDisabled, isGroup } = form;
+  const { sortValues, filterValues, isDisabled, isClearDisabled, isGroup } =
+    form;
 
   return (
     <form
@@ -162,6 +163,7 @@ export const SortAndFilterSettingsForm = ({
         <div className="flex justify-end px-0 pt-2 space-x-1">
           <PracticeButton
             variant="secondary"
+            disabled={isClearDisabled}
             onClick={(e) => {
               e.preventDefault();
               form.resetToDefaults();

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.ts
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.ts
@@ -98,6 +98,10 @@ export const useSortAndFilterForm = (initialValue: SearchSettings) => {
   );
 
   const isDisabled = noChangeInFilterValues && noChangeInSortValues;
+  const isClearDisabled =
+    sortValues.primary === defaultSortSettings.primary &&
+    sortValues.secondary === defaultSortSettings.secondary &&
+    isEqualFilters(filterValues, defaultFilterSettings);
   const isGroup = isGroupSort(sortValues.primary);
 
   const buildSettings = (): SearchSettings => ({
@@ -110,6 +114,7 @@ export const useSortAndFilterForm = (initialValue: SearchSettings) => {
     sortValues,
     filterValues,
     isDisabled,
+    isClearDisabled,
     isGroup,
     setPrimarySort,
     setSecondarySort,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three UX fixes for reading practice and the list-screen control bar:

1. **Reading practice (`/reading-practice`)** — Vertical centering now depends only on `@media(pointer:fine)` / coarse pointer, not `md:` or `min-height:900px`. Large touch screens (e.g. iPad) stay top-anchored with the bottom spacer so the on-screen keyboard no longer makes content bob.

2. **Sort and Filtering “Clear all”** — Disabled when sort and filters are already at defaults.

3. **Settings load shift** — Sort/Filter and Item Presentation now use the same lazy-gate + icon-button spinner pattern as the header hamburger menu. Removed the old in-panel `KaoMojiLoadingSpinner` / “Loading…” Suspense fallbacks.

## Test plan

- [ ] On an iPad (or coarse-pointer device), open a reading-practice session and focus the input: content should stay put when the keyboard opens/closes
- [ ] On a mouse/trackpad (fine pointer), reading practice should still center vertically
- [ ] Open Sort and Filtering with no active sort/filters: Clear all is disabled
- [ ] Change any filter or sort: Clear all enables; Clear all then Apply restores defaults
- [ ] First open of Sort/Filter and Item Presentation: trigger icon shows a spinner (no control-bar / panel layout jump), then the panel opens
- [ ] Subsequent opens work normally without reloading flicker
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f89c9-e47b-7a6a-b827-da46bff3b171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f89c9-e47b-7a6a-b827-da46bff3b171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

