### PR TITLE
Remove RTKB sort option and use RTK index from updated data

### DIFF
--- a/src/components/error/Sumimasen.tsx
+++ b/src/components/error/Sumimasen.tsx
@@ -1,24 +1,9 @@
-export const Sumimasen = ({
-  layout = "stacked",
-}: {
-  layout?: "stacked" | "inline";
-}) => {
-  if (layout === "inline") {
-    return (
-      <div className="flex flex-wrap items-baseline justify-center gap-x-3 gap-y-1">
-        <span className="text-3xl leading-none kanji-font">すみません</span>
-        <span className="text-2xl leading-none" aria-hidden="true">
-          {"🙏🏽 🙇"}
-        </span>
-      </div>
-    );
-  }
-
+export const Sumimasen = () => {
   return (
     <div className="flex flex-col items-center gap-3">
       <span className="text-3xl leading-none kanji-font">すみません</span>
       <span className="text-3xl leading-none" aria-hidden="true">
-        {"🙏🏽 🙇"}
+        {"🙇‍♀️ 🙇"}
       </span>
     </div>
   );

--- a/src/components/error/common.tsx
+++ b/src/components/error/common.tsx
@@ -4,6 +4,7 @@ import { LinksOutItems } from "@/components/common/LinksOutItems";
 import { cnTextLink } from "@/lib/generic-cn";
 import { outLinks } from "@/lib/external-links";
 import { cn } from "@/lib/utils";
+import { RefreshPageBtn } from "../common/RefreshPageBtn";
 
 /** Linked CTA: Discord / GitHub issue / reload — shown above the icon row. */
 export const SayHiReportOrRefresh = () => {
@@ -60,11 +61,11 @@ export const ErrorSocialIcons = ({ className }: { className?: string }) => {
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center justify-center gap-1",
+        "flex flex-wrap items-center justify-center gap-1 pt-4",
         className
       )}
     >
-      <LinksOutItems />
+      <LinksOutItems /> {"·"} <RefreshPageBtn />
     </div>
   );
 };
@@ -72,7 +73,7 @@ export const ErrorSocialIcons = ({ className }: { className?: string }) => {
 /** Text CTA above icons (toolbar layout). */
 export const ErrorToolbarCta = ({ className }: { className?: string }) => {
   return (
-    <div className={cn("flex w-full flex-col items-center gap-3", className)}>
+    <div className={cn("flex w-full flex-col items-center", className)}>
       <SayHiReportOrRefresh />
       <ErrorSocialIcons />
     </div>

--- a/src/components/sections/KanjiDetails/ReadingFrequencyCategory.tsx
+++ b/src/components/sections/KanjiDetails/ReadingFrequencyCategory.tsx
@@ -110,7 +110,7 @@ export const ReadingFrequencyCategory = ({ kanji }: { kanji: string }) => {
             ))}
           </TableBody>
         </Table>
-        <p className="mb-4">
+        <p className="my-4">
           All data and the methodology used to determine the reading frequency
           categories are from the research of Dr. Patrick Kandrac. The frequency
           classifications aims to reflect how often each reading appears in

--- a/src/kanji-worker/helpers.ts
+++ b/src/kanji-worker/helpers.ts
@@ -127,7 +127,8 @@ export const transformToExtendedKanjiInfo = (
   const [
     parts,
     strokes,
-    rtk,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _rtk_old,
     wk,
     jouyouGrade,
     meanings,
@@ -136,7 +137,7 @@ export const transformToExtendedKanjiInfo = (
     phonetic,
     mainVocab,
     kklcIndex,
-    rtkb,
+    rtk,
   ] = item;
 
   const hiraganaAllKun = (allKun ?? []).map((val) => wanakana.toHiragana(val));
@@ -148,7 +149,6 @@ export const transformToExtendedKanjiInfo = (
     parts: new Set(parts),
     strokes,
     rtk,
-    rtkb: rtkb ?? -1,
     wk,
     jouyouGrade,
     meanings: Array.from(new Set(meanings)),

--- a/src/kanji-worker/kanji-search.test.ts
+++ b/src/kanji-worker/kanji-search.test.ts
@@ -38,7 +38,6 @@ const extendedInfo = ({
   parts: new Set(),
   strokes,
   rtk: -1,
-  rtkb: -1,
   wk: -1,
   jouyouGrade,
   meanings,

--- a/src/kanji-worker/kanji-search.ts
+++ b/src/kanji-worker/kanji-search.ts
@@ -13,7 +13,6 @@ import {
   K_KKLC_INDEX,
   K_MEANING_KEY,
   K_RTK_INDEX,
-  K_RTKB_INDEX,
   K_STROKES,
   K_WK_LVL,
 } from "@/lib/options/options-constants";
@@ -265,7 +264,6 @@ const SORT_COMPARATORS: Record<string, SortComparator> = {
   [K_STROKES]: (a, b) => numericSort(a.extended.strokes, b.extended.strokes),
   [K_WK_LVL]: (a, b) => numericSort(a.extended.wk, b.extended.wk),
   [K_RTK_INDEX]: (a, b) => numericSort(a.extended.rtk, b.extended.rtk),
-  [K_RTKB_INDEX]: (a, b) => numericSort(a.extended.rtkb, b.extended.rtkb),
   [K_KKLC_INDEX]: (a, b) =>
     numericSort(a.extended.kklcIndex, b.extended.kklcIndex),
   [K_MEANING_KEY]: (a, b) => alphaSort(a.main.keyword, b.main.keyword),

--- a/src/kanji-worker/kanji-worker-provider.tsx
+++ b/src/kanji-worker/kanji-worker-provider.tsx
@@ -188,7 +188,6 @@ export function KanjiWorkerProvider({
             jouyouGrade,
             wk,
             rtk,
-            rtkb,
             strokes,
             kklcIndex,
           } = kanjiInfo.extended;
@@ -200,7 +199,6 @@ export function KanjiWorkerProvider({
             jouyouGrade,
             wk,
             rtk,
-            rtkb,
             strokes,
             kklcIndex,
             jlpt: kanjiInfo.main.jlpt,

--- a/src/lib/kanji/kanji-worker-types.ts
+++ b/src/lib/kanji/kanji-worker-types.ts
@@ -49,7 +49,6 @@ export type KanjiExtendedInfo = {
   parts: Set<string>;
   strokes: number;
   rtk: number;
-  rtkb: number;
   wk: number;
   jouyouGrade: number;
   meanings: string[];

--- a/src/lib/options/options-constants.ts
+++ b/src/lib/options/options-constants.ts
@@ -44,7 +44,6 @@ export const GROUP_OPTIONS = [
 export const NONGROUP_OPTIONS = [
   K_KKLC_INDEX,
   K_RTK_INDEX,
-  K_RTKB_INDEX,
   K_MEANING_KEY,
 ] as const;
 

--- a/src/lib/options/options-label-maps.ts
+++ b/src/lib/options/options-label-maps.ts
@@ -25,7 +25,6 @@ import {
   K_RANK_WIKIPEDIA_DOC,
   K_RANK_WKFR,
   K_RTK_INDEX,
-  K_RTKB_INDEX,
   K_STROKES,
   K_WK_LVL,
 } from "./options-constants";
@@ -42,20 +41,18 @@ export const nonFreqOptionLabels: Record<SortGroup | SortNonGroup, string> = {
   [K_JOUYOU_KEY]: "Jouyou Grade",
   [K_STROKES]: "Stroke Count",
   [K_WK_LVL]: "WK",
-  [K_RTK_INDEX]: "RTKA",
-  [K_RTKB_INDEX]: "RTKB",
+  [K_RTK_INDEX]: "RTK",
   [K_MEANING_KEY]: "English Keyword",
   [K_KKLC_INDEX]: "KKLC",
 };
 
 export const orderDisclaimer =
-  "⚠️ Community-based orders (WK, KKLC, RTKA, RTKB) are provided may differ from official editions. For accuracy, please refer to the original books or apps.";
+  "⚠️ Community-based orders (WK, KKLC, RTK) are provided may differ from official editions. For accuracy, please refer to the original books or apps.";
 
 export const COMMUNITY_ORDER_KEYS = [
   K_WK_LVL,
   K_KKLC_INDEX,
   K_RTK_INDEX,
-  K_RTKB_INDEX,
 ] as const;
 
 export const isCommunityOrder = (key: string) =>


### PR DESCRIPTION
## Summary
- Remove the separate RTKB sort option and `rtkb` field from kanji extended info
- Map the RTK index from the updated data slot (formerly RTKB) and relabel "RTKA" to "RTK"
- Update community-order disclaimer and sort comparators accordingly

## Test plan
- [ ] Open sort/filter options and confirm only "RTK" appears (no RTKB)
- [ ] Sort kanji by RTK and verify order looks correct
- [ ] Confirm community-order disclaimer mentions WK, KKLC, and RTK only


Made with [Cursor](https://cursor.com)