### PR TITLE
Remove randomize font from writing practice

### DIFF
--- a/src/components/production-practice-v1/InitialScreen.tsx
+++ b/src/components/production-practice-v1/InitialScreen.tsx
@@ -18,7 +18,11 @@ export const InitialScreen = ({
     SETTINGS_KEY,
     DEFAULT_SETTINGS
   );
-  const { deck, loading, canStart } = usePracticeDeck(settings);
+  // Writing practice never randomizes fonts (unlike reading / speed katakana).
+  const { deck, loading, canStart } = usePracticeDeck({
+    ...settings,
+    randomizeFont: false,
+  });
 
   useEnterAction(canStart ? () => onStart(deck) : null, canStart);
 
@@ -28,6 +32,7 @@ export const InitialScreen = ({
       description={productionPracticePageMeta.description}
       filters={settings}
       onFilterChange={setSetting}
+      showRandomizeFont={false}
       deckSize={deck.length}
       loading={loading}
       canStart={canStart}

--- a/src/components/shared-practice/PracticeInitialScreen.tsx
+++ b/src/components/shared-practice/PracticeInitialScreen.tsx
@@ -10,8 +10,8 @@ import { DeckFilterSettings } from "./types";
 
 /**
  * Shared scaffold for the practice-mode start screens: heading, the
- * "Kanji to include" filters, the two shared session toggles (with
- * mode-specific options injected below them), and the sticky start footer.
+ * "Kanji to include" filters, shared session toggles (with mode-specific
+ * options injected below them), and the sticky start footer.
  */
 export const PracticeInitialScreen = ({
   heading,
@@ -19,6 +19,7 @@ export const PracticeInitialScreen = ({
   filters,
   onFilterChange,
   sessionOptions,
+  showRandomizeFont = true,
   deckSize,
   loading,
   canStart,
@@ -33,6 +34,8 @@ export const PracticeInitialScreen = ({
   ) => void;
   /** Mode-specific controls rendered below the shared session toggles. */
   sessionOptions?: ReactNode;
+  /** Reading practice keeps this; writing practice hides it. */
+  showRandomizeFont?: boolean;
   deckSize: number;
   loading: boolean;
   canStart: boolean;
@@ -88,12 +91,14 @@ export const PracticeInitialScreen = ({
             checked={filters.randomizeOrder}
             onChange={(v) => onFilterChange("randomizeOrder", v)}
           />
-          <ToggleRow
-            id="randomize-font"
-            label="Randomize font"
-            checked={filters.randomizeFont}
-            onChange={(v) => onFilterChange("randomizeFont", v)}
-          />
+          {showRandomizeFont && (
+            <ToggleRow
+              id="randomize-font"
+              label="Randomize font"
+              checked={filters.randomizeFont}
+              onChange={(v) => onFilterChange("randomizeFont", v)}
+            />
+          )}
           {sessionOptions}
         </section>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the **Randomize font** option from `/writing-practice` while keeping it on `/reading-practice` and `/speed-katakana`.

### Changes
- `PracticeInitialScreen` accepts `showRandomizeFont` (default `true`) so reading practice stays unchanged.
- Writing practice passes `showRandomizeFont={false}` and forces `randomizeFont: false` when building the deck, so an old localStorage setting cannot re-enable it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8a1c-1d47-7216-97c1-03b819ff3ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8a1c-1d47-7216-97c1-03b819ff3ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

