### PR TITLE
Align Speed Katakana title top padding with practice screens

### DIFF
--- a/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/InitialScreen.tsx
@@ -76,7 +76,7 @@ export const InitialScreen = ({ onStart }: { onStart: () => void }) => {
     <div className="relative flex flex-col w-full h-full animate-fade-in">
       <LeavePractice />
       <div className="flex-1 min-h-0 pl-4 pr-2 overflow-auto">
-        <div className="flex flex-col justify-center w-full max-w-lg min-h-full gap-6 px-1 mx-auto">
+        <div className="flex flex-col w-full max-w-lg gap-6 px-1 py-6 mx-auto">
           <div className="flex flex-col items-center gap-1 px-6">
             <h1 className="pt-4 text-lg font-bold text-center">
               {speedKatakanaPageMeta.heading}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Aligns the **Speed Katakana** start-screen title with `/reading-practice` and `/writing-practice`.

### Change
- Add `py-6` on the Speed Katakana content container (same as the shared practice initial screen)
- Remove `justify-center` / `min-h-full` so the title sits at the top with matching padding instead of being vertically centered

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8a1c-1d47-7216-97c1-03b819ff3ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8a1c-1d47-7216-97c1-03b819ff3ec8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

