### PR TITLE
Polish UX: Jouyou badge, control-bar fallbacks, and filter layout

### DIFF
--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -28,7 +28,7 @@ test.describe("practice modes", () => {
     { name: "reading", route: "/reading-practice" },
     { name: "writing", route: "/writing-practice" },
   ]) {
-    test(`${name} practice: Jōyō-grade filter narrows the deck`, async ({
+    test(`${name} practice: Jouyou-grade filter narrows the deck`, async ({
       page,
     }) => {
       await page.goto(route);

--- a/e2e/sort-filter.spec.ts
+++ b/e2e/sort-filter.spec.ts
@@ -42,7 +42,7 @@ test.describe("sort and filter", () => {
     await expect(page.getByText(/\d+ Items/)).toBeVisible({ timeout: 30_000 });
   });
 
-  test("Jōyō-grade filter from the dialog updates the URL", async ({
+  test("Jouyou-grade filter from the dialog updates the URL", async ({
     page,
   }) => {
     await page.goto("/");

--- a/src/components/common/FilterMultiSelect.tsx
+++ b/src/components/common/FilterMultiSelect.tsx
@@ -26,7 +26,7 @@ export const FilterMultiSelect = <T extends string>({
 
   return (
     <div>
-      <Label className="text-xs font-thin" htmlFor={fieldId}>
+      <Label className="text-xs" htmlFor={fieldId}>
         {label}
       </Label>
       <MultiSelect

--- a/src/components/common/JouyouGradeBadge.tsx
+++ b/src/components/common/JouyouGradeBadge.tsx
@@ -1,0 +1,24 @@
+import { JouyouGradeListItems, toJouyouGrade } from "@/lib/jouyou-grade";
+import { GenericPopover } from "./GenericPopover";
+
+export const JouyouGradeBadge = ({ jouyouGrade }: { jouyouGrade: number }) => {
+  const grade = toJouyouGrade(jouyouGrade);
+  const meta = JouyouGradeListItems[grade];
+
+  return (
+    <GenericPopover
+      trigger={
+        <button className="inline-flex h-6 items-center justify-center rounded-full border px-2.5 text-xs font-semibold text-nowrap m-1 bg-foreground text-background hover:bg-[#2effff] hover:text-black">
+          <span className={`h-2 w-2 block ${meta.cn} !rounded-full mr-1`} />
+          Grade {meta.label}
+        </button>
+      }
+      content={
+        <div className="w-64 px-4 py-3 text-xs">
+          The Japanese school grade level where this kanji is officially
+          introduced in the Jouyou curriculum.
+        </div>
+      }
+    />
+  );
+};

--- a/src/components/common/RefreshPageBtn.tsx
+++ b/src/components/common/RefreshPageBtn.tsx
@@ -1,13 +1,14 @@
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { RefreshCw } from "lucide-react";
 
-export const RefreshPageBtn = () => (
+export const RefreshPageBtn = ({ cnOverride }: { cnOverride?: string }) => (
   <Button
     variant="outline"
     size="iconXl"
     onClick={() => window.location.reload()}
     aria-label="Refresh page"
   >
-    <RefreshCw className="w-[1.2rem] h-[1.2rem]" />
+    <RefreshCw className={cn("w-[1.2rem] h-[1.2rem]", cnOverride)} />
   </Button>
 );

--- a/src/components/common/StrokeCountField.tsx
+++ b/src/components/common/StrokeCountField.tsx
@@ -15,7 +15,7 @@ export const StrokeCountField = ({
 
   return (
     <div className="w-full">
-      <Label className="text-xs font-thin" htmlFor={fieldId}>
+      <Label className="text-xs" htmlFor={fieldId}>
         Stroke Count
       </Label>
       <DualRangeSlider

--- a/src/components/error/BugIconErrorBoundary.tsx
+++ b/src/components/error/BugIconErrorBoundary.tsx
@@ -1,13 +1,7 @@
-import { Bug } from "lucide-react";
 import ErrorBoundary from "./ErrorBoundary";
 import { ReactNode } from "react";
-
-const BugIconFallback = () => (
-  <div className="flex items-center justify-center w-8 h-8 rounded-xl border border-muted text-muted-foreground">
-    <Bug className="w-4 h-4" />
-  </div>
-);
+import { ReportBugIconBtn } from "../common/ReportBugIconBtn";
 
 export const BugIconErrorBoundary = ({ children }: { children: ReactNode }) => (
-  <ErrorBoundary fallback={<BugIconFallback />}>{children}</ErrorBoundary>
+  <ErrorBoundary fallback={<ReportBugIconBtn />}>{children}</ErrorBoundary>
 );

--- a/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/BookmarksBreakdown.tsx
@@ -132,7 +132,7 @@ export const BookmarksBreakdown = () => {
       const meta = JouyouGradeListItems[grade];
       return {
         key: String(grade),
-        label: meta.label !== "Not in Jōyō" ? meta.label : "~",
+        label: meta.label !== "Not in Jouyou" ? meta.label : "~",
         cn: meta.cn,
         bookmarked: next[grade].bookmarked,
         total: next[grade].total,
@@ -149,7 +149,7 @@ export const BookmarksBreakdown = () => {
 
   const bands = showGrade ? gradeBands : jlptBands;
   const description = showGrade
-    ? "How much of each jōyō grade you've bookmarked. Bookmark a word from a kanji’s detail drawer to start filling these bars."
+    ? "How much of each jouyou grade you've bookmarked. Bookmark a word from a kanji’s detail drawer to start filling these bars."
     : "How much of each JLPT band you've bookmarked. Bookmark a word from a kanji’s detail drawer to start filling these bars.";
 
   return (

--- a/src/components/screens/ListScreen/ControlBar/ControlBar.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ControlBar.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-import { ReportBugIconBtn } from "@/components/common/ReportBugIconBtn";
 
 import { SettledSearchInput } from "./SearchInput/SettledSearchInput";
 import { SettledSortAndFilter } from "./SortAndFilter/SettledSortAndFilter";
@@ -7,25 +6,23 @@ import LazyItemPresentation, {
   ItemPresentationLoadingFallback,
 } from "./ItemPresentation/LazyItemPresentation";
 import { ErrorBoundary } from "@/components/error";
+import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
+import { SearchInputErrorFallback } from "./SearchInput/SearchInputErrorFallback";
 
 export const ControlBar = () => {
   return (
     <>
       <ErrorBoundary
         details="SettledSearchInput in ControlBar"
-        fallback={
-          <div className="h-full flex items-center">
-            <ReportBugIconBtn cnOverride="h-9" />
-          </div>
-        }
+        fallback={<SearchInputErrorFallback />}
       >
         <SettledSearchInput />
       </ErrorBoundary>
       <ErrorBoundary
         details="SettledSortAndFilter in ControlBar"
         fallback={
-          <div className="h-full flex items-center">
-            <ReportBugIconBtn cnOverride="h-9" />
+          <div className="flex items-center h-9">
+            <RefreshPageBtn />
           </div>
         }
       >
@@ -34,8 +31,8 @@ export const ControlBar = () => {
       <ErrorBoundary
         details="ItemPresentationSettings in ControlBar"
         fallback={
-          <div className="h-full flex items-center">
-            <ReportBugIconBtn cnOverride="h-9" />
+          <div className="flex items-center h-9">
+            <RefreshPageBtn />
           </div>
         }
       >

--- a/src/components/screens/ListScreen/ControlBar/ControlBarErrorFallback.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ControlBarErrorFallback.tsx
@@ -1,0 +1,32 @@
+import { Flower, Settings2 } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { SearchInputErrorFallback } from "./SearchInput/SearchInputErrorFallback";
+
+const reloadPage = () => window.location.reload();
+
+export const ControlBarErrorFallback = () => (
+  <>
+    <SearchInputErrorFallback />
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      className="h-9 w-9 shrink-0 text-muted-foreground opacity-80 transition-opacity hover:opacity-100"
+      onClick={reloadPage}
+      aria-label="Controls failed to load. Refresh page."
+    >
+      <Settings2 />
+    </Button>
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      className="h-9 w-9 shrink-0 text-muted-foreground opacity-80 transition-opacity hover:opacity-100"
+      onClick={reloadPage}
+      aria-label="Controls failed to load. Refresh page."
+    >
+      <Flower />
+      <span className="sr-only">Card Presentation Settings</span>
+    </Button>
+  </>
+);

--- a/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
@@ -85,7 +85,7 @@ const CardStateSettings = () => {
         options={[
           { value: "jlpt", label: "JLPT Level" },
           { value: "study-status", label: "Study Status" },
-          { value: "grade", label: "Jōyō Grade" },
+          { value: "grade", label: "Jouyou Grade" },
           { value: "none", label: "None" },
         ]}
       />

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInputErrorFallback.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInputErrorFallback.tsx
@@ -1,0 +1,30 @@
+import { Search } from "@/components/icons";
+import { cn } from "@/lib/utils";
+import { RefreshCw } from "lucide-react";
+
+export const SearchInputErrorFallback = () => (
+  <section className="relative flex-1 min-w-0">
+    <button
+      type="button"
+      onClick={() => window.location.reload()}
+      aria-label="Search failed to load. Refresh page."
+      className={cn(
+        "flex w-full items-center rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm",
+        "h-9 pl-7 pr-[105px] text-left text-muted-foreground",
+        "transition-colors hover:border-ring/60 hover:bg-accent/40",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      )}
+    >
+      <span className="truncate">Reload to search again</span>
+    </button>
+
+    <Search className="pointer-events-none absolute left-2 top-2 size-4 translate-y-0.5 select-none opacity-50" />
+
+    <div
+      className="pointer-events-none absolute right-2 top-2.5 flex items-center gap-1.5"
+      aria-hidden
+    >
+      <RefreshCw className="size-4 shrink-0 text-muted-foreground opacity-70" />
+    </div>
+  </section>
+);

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
@@ -20,17 +20,15 @@ export const FilterSectionLayout = ({
   return (
     <section className="text-start">
       <UppercaseHeading title="Filters" icon={<FilterX size={15} />} />
-      <div className="grid w-full grid-cols-1 gap-4 pb-4 sm:pb-6 xl:grid-cols-3">
+      <div className="grid w-full grid-cols-1 gap-4 pb-4 xl:grid-cols-3">
         <div>{strokeCountField}</div>
         <div>{jlptField}</div>
         <div>{jouyouGradeField}</div>
       </div>
       {toggleFiltersField != null && (
-        <div className="grid w-full grid-cols-1 gap-3 pb-8 sm:grid-cols-2 sm:gap-4">
-          {toggleFiltersField}
-        </div>
+        <div className="flex w-full gap-8 pb-4">{toggleFiltersField}</div>
       )}
-      <div className="py-2 mt-4 text-xs font-extrabold uppercase md:mt-0">
+      <div className="py-2 text-xs font-extrabold uppercase md:mt-0">
         Frequency Ranking
       </div>
       <div className="flex flex-col w-full md:flex-row md:space-x-4">

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterToggleRow.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterToggleRow.tsx
@@ -12,18 +12,18 @@ export const FilterToggleRow = ({
   checked: boolean;
   onChange: (checked: boolean) => void;
 }) => (
-  <div className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 sm:gap-4">
-    <Label
-      htmlFor={id}
-      className="min-w-0 flex-1 text-sm leading-snug cursor-pointer"
-    >
-      {label}
-    </Label>
+  <div className="flex items-center gap-3 rounded-md py-2.5 ">
     <Switch
       id={id}
       checked={checked}
       onCheckedChange={onChange}
       className="shrink-0"
     />
+    <Label
+      htmlFor={id}
+      className="flex-1 min-w-0 text-sm leading-snug cursor-pointer"
+    >
+      {label}
+    </Label>
   </div>
 );

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.test.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/use-sort-and-filter-form.test.tsx
@@ -23,7 +23,7 @@ describe("useSortAndFilterForm", () => {
     expect(result.current.isDisabled).toBe(false);
   });
 
-  it("tracks Jōyō-grade edits in the filter values", () => {
+  it("tracks Jouyou-grade edits in the filter values", () => {
     const { result } = renderHook(() => useSortAndFilterForm(initial));
 
     act(() => result.current.setJouyouGrade(["1", "none"]));

--- a/src/components/screens/ListScreen/ListScreen.tsx
+++ b/src/components/screens/ListScreen/ListScreen.tsx
@@ -5,8 +5,8 @@ import { ErrorBoundary } from "@/components/error";
 import { ControlBar } from "./ControlBar/";
 import LoadingKanjis from "./KanjiList/LoadingKanjis";
 
-import { LinksOutItems } from "@/components/common/LinksOutItems";
 import { SuspendedKanjiList } from "./KanjiList/LazyKanjiList";
+import { ControlBarErrorFallback } from "./ControlBar/ControlBarErrorFallback";
 import { ItemCountBadge } from "./ControlBar/ItemCountBadge";
 
 const Layout = ({
@@ -20,7 +20,7 @@ const Layout = ({
     <>
       <div className="fixed-viewport-layer fix-scroll-layout-shift-right fixed w-full pt-12 pb-2 z-40 bg-background">
         <section className="mx-auto max-w-screen-xl flex border-0 space-x-1 sticky pt-1 pl-2 pr-1 w-full ">
-          <ErrorBoundary fallback={<LinksOutItems />}>
+          <ErrorBoundary fallback={<ControlBarErrorFallback />}>
             <ControlBar />
             {badge}
           </ErrorBoundary>

--- a/src/components/screens/SpeedKatakanaScreen/Game.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/Game.tsx
@@ -69,10 +69,10 @@ export const Game = ({
   const current = game.current;
 
   return (
-    <div className="flex flex-col w-full h-full gap-4 mx-auto [@media(min-height:900px)]:justify-center animate-fade-in-fast">
+    <div className="flex flex-col w-full h-full gap-4 mx-auto [@media(min-height:700px)]:justify-center animate-fade-in-fast">
       <EndSession onClick={onEnd} />
 
-      <div className="flex flex-col items-center justify-center flex-1 min-h-0 [@media(min-height:900px)]:flex-none gap-3 text-center">
+      <div className="flex flex-col items-center justify-center flex-1 min-h-0 [@media(min-height:700px)]:flex-none gap-3 text-center">
         <div className="flex items-center justify-center gap-1 pt-4">
           <span className="px-2 text-xs font-bold tabular-nums">
             {game.index + 1} / {game.wordCount}

--- a/src/components/screens/SpeedKatakanaScreen/Game.tsx
+++ b/src/components/screens/SpeedKatakanaScreen/Game.tsx
@@ -69,10 +69,10 @@ export const Game = ({
   const current = game.current;
 
   return (
-    <div className="flex flex-col w-full h-full gap-4 mx-auto [@media(min-height:700px)]:justify-center animate-fade-in-fast">
+    <div className="flex flex-col w-full h-full gap-4 mx-auto [@media(min-height:900px)]:justify-center animate-fade-in-fast">
       <EndSession onClick={onEnd} />
 
-      <div className="flex flex-col items-center justify-center flex-1 min-h-0 [@media(min-height:700px)]:flex-none gap-3 text-center">
+      <div className="flex flex-col items-center justify-center flex-1 min-h-0 [@media(min-height:900px)]:flex-none gap-3 text-center">
         <div className="flex items-center justify-center gap-1 pt-4">
           <span className="px-2 text-xs font-bold tabular-nums">
             {game.index + 1} / {game.wordCount}

--- a/src/components/sections/KanjiDetails/General.tsx
+++ b/src/components/sections/KanjiDetails/General.tsx
@@ -11,6 +11,7 @@ import { BasicLoading } from "@/components/common/BasicLoading";
 import { RomajiBadge } from "@/components/dependent/kana/RomajiBadge";
 import { ReactNode } from "react";
 import { JLPTBadge } from "@/components/common/jlpt/JLPTBadge";
+import { JouyouGradeBadge } from "@/components/common/JouyouGradeBadge";
 import { GenericPopover } from "@/components/common/GenericPopover";
 import { InfoIcon } from "@/components/icons";
 import { ExternalTextLink } from "@/components/common/ExternalTextLink";
@@ -97,12 +98,6 @@ export const General = ({ kanji }: { kanji: string }) => {
     description: string;
   }[] = [
     {
-      label: "Grade",
-      value: data.jouyouGrade,
-      description:
-        "The Japanese school grade level where this kanji is officially introduced in the jōyō curriculum.",
-    },
-    {
       label: "Strokes",
       value: data.strokes,
       description:
@@ -167,6 +162,9 @@ export const General = ({ kanji }: { kanji: string }) => {
     <>
       <div className="mt-6 text-left">
         <JLPTBadge jlpt={data.jlpt} />
+        {hasData(data.jouyouGrade) && (
+          <JouyouGradeBadge jouyouGrade={data.jouyouGrade!} />
+        )}
         {indexBadges.map(({ label, value, description }) =>
           hasData(value) ? (
             <PrimaryBadgeWithPopover

--- a/src/kanji-worker/kanji-search.test.ts
+++ b/src/kanji-worker/kanji-search.test.ts
@@ -172,7 +172,7 @@ describe("filterKanji", () => {
     expect(result).toEqual(["水"]);
   });
 
-  it("filters by one or more Jōyō grades", () => {
+  it("filters by one or more Jouyou grades", () => {
     expect(
       filterKanji(allKanji, settings({ jouyouGrade: ["1"] }), pool)
     ).toEqual(["水"]);
@@ -181,7 +181,7 @@ describe("filterKanji", () => {
     ).toEqual(["水", "山"]);
   });
 
-  it("filters for kanji without an assigned Jōyō grade", () => {
+  it("filters for kanji without an assigned Jouyou grade", () => {
     expect(
       filterKanji(allKanji, settings({ jouyouGrade: ["none"] }), pool)
     ).toEqual(["火"]);
@@ -200,7 +200,7 @@ describe("filterKanji", () => {
     ).toEqual(allKanji);
   });
 
-  it("combines JLPT and Jōyō-grade filters", () => {
+  it("combines JLPT and Jouyou-grade filters", () => {
     expect(
       filterKanji(
         allKanji,

--- a/src/kanji-worker/kanji-worker-hooks.tsx
+++ b/src/kanji-worker/kanji-worker-hooks.tsx
@@ -166,7 +166,7 @@ const fetchJouyouGradeMap = () => {
   return jouyouGradeMapPromise;
 };
 
-/** Kanji → jōyō school grade from the extended cache (ready once worker is). */
+/** Kanji → jouyou school grade from the extended cache (ready once worker is). */
 export const useJouyouGradeMap = (enabled = true) => {
   const ready = useIsKanjiWorkerReady();
 

--- a/src/lib/jouyou-grade.ts
+++ b/src/lib/jouyou-grade.ts
@@ -1,4 +1,4 @@
-/** Jōyō school-grade bands used in kanji_extended.json. */
+/** Jouyou school-grade bands used in kanji_extended.json. */
 
 export const JOUYOU_GRADE_ARR = [1, 2, 3, 4, 5, 6, 9, -1] as const;
 export type JouyouGrade = (typeof JOUYOU_GRADE_ARR)[number];
@@ -53,7 +53,7 @@ export const JouyouGradeListItems: Record<
     cn: "bg-gray-400",
     cnBorder: "border-gray-400",
     color: "gray",
-    label: "Not in Jōyō",
+    label: "Not in Jouyou",
   },
 };
 

--- a/src/lib/settings/search-settings-adapter.test.ts
+++ b/src/lib/settings/search-settings-adapter.test.ts
@@ -88,7 +88,7 @@ describe("search settings ↔ URL params round-trip", () => {
     expect(params.toString()).toBe("");
   });
 
-  it("ignores invalid Jōyō-grade values from the URL", () => {
+  it("ignores invalid Jouyou-grade values from the URL", () => {
     const params = new URLSearchParams("filter-jouyou-grade=1,invalid,none");
     expect(toSearchSettings(params).filterSettings.jouyouGrade).toEqual([
       "1",


### PR DESCRIPTION
## Summary
- Add a dedicated Jouyou grade badge on kanji details (alongside JLPT) and normalize “Jouyou” spelling across UI and tests.
- Improve list control-bar error fallbacks with reload affordances instead of bug-only icons.
- Polish sort/filter layout: simpler labels, tighter toggle rows, and adjusted section spacing.

## Test plan
- [ ] Open a kanji detail drawer and confirm Jouyou grade appears as a badge next to JLPT (when available), with popover copy.
- [ ] Open Sort & Filter and verify filter field labels, toggle row layout, and spacing look correct on mobile and desktop.
- [ ] Force or simulate a control-bar/search error fallback and confirm reload affordances work.
- [ ] Spot-check Jouyou-grade filter behavior and related copy still match expectations.


Made with [Cursor](https://cursor.com)