### PR TITLE
Polish sort and filter form layout

### DIFF
--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/FilterContentLayout.tsx
@@ -20,14 +20,25 @@ export const FilterSectionLayout = ({
   return (
     <section className="text-start">
       <UppercaseHeading title="Filters" icon={<FilterX size={15} />} />
-      <div className="grid w-full grid-cols-1 gap-4 pb-4 xl:grid-cols-3">
-        <div>{strokeCountField}</div>
+      <div className="grid w-full grid-cols-1 gap-4 pb-4 md:grid-cols-2">
         <div>{jlptField}</div>
         <div>{jouyouGradeField}</div>
       </div>
-      {toggleFiltersField != null && (
-        <div className="flex w-full gap-8 pb-4">{toggleFiltersField}</div>
-      )}
+
+      <div
+        className={
+          toggleFiltersField != null
+            ? "flex w-full flex-col gap-4 pb-4 lg:flex-row lg:items-center lg:gap-8"
+            : "pb-4"
+        }
+      >
+        <div className="w-full min-w-0 lg:flex-1">{strokeCountField}</div>
+        {toggleFiltersField != null && (
+          <div className="flex flex-col w-full min-w-0 sm:flex-row sm:items-center sm:gap-8 lg:flex-1 lg:pt-4">
+            {toggleFiltersField}
+          </div>
+        )}
+      </div>
       <div className="py-2 text-xs font-extrabold uppercase md:mt-0">
         Frequency Ranking
       </div>

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/ItemCount.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/ItemCount.tsx
@@ -88,9 +88,16 @@ const ItemCountComputed = ({ settings }: { settings: SearchSettings }) => {
   const { data: clientFiltered, isLoading: clientLoading } =
     useClientFilteredKanjis(workerSearch.data, settings.filterSettings);
 
+  // Keep layout height stable while counts load so the dialog doesn't bounce.
   if (needsClient) {
     if (clientLoading || clientFiltered == null || workerSearch.error) {
-      return null;
+      return (
+        <span className="invisible" aria-hidden>
+          A total of 0 of {KANJI_COUNT} Kanji characters match your applied
+          filters.
+          <br />
+        </span>
+      );
     }
     return (
       <MatchCountMessage settings={settings} count={clientFiltered.length} />
@@ -98,7 +105,13 @@ const ItemCountComputed = ({ settings }: { settings: SearchSettings }) => {
   }
 
   if (workerCount.data == null || workerCount.error) {
-    return null;
+    return (
+      <span className="invisible" aria-hidden>
+        A total of 0 of {KANJI_COUNT} Kanji characters match your applied
+        filters.
+        <br />
+      </span>
+    );
   }
 
   return <MatchCountMessage settings={settings} count={workerCount.data} />;

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterForm.tsx
@@ -62,7 +62,7 @@ export const SortAndFilterSettingsForm = ({
               {isCommunityOrder(sortValues.primary) && (
                 <div
                   key={`disclaimer-${sortValues.primary}`}
-                  className="text-xs mt-1 text-left px-3 animate-fade-in"
+                  className="px-3 mt-1 text-xs text-left animate-fade-in"
                 >
                   {orderDisclaimer}
                 </div>
@@ -90,7 +90,7 @@ export const SortAndFilterSettingsForm = ({
                 {isCommunityOrder(sortValues.secondary) && (
                   <div
                     key={`disclaimer-${sortValues.secondary}`}
-                    className="text-xs mt-1 text-left px-3 animate-fade-in"
+                    className="px-3 mt-1 text-xs text-left animate-fade-in"
                   >
                     {orderDisclaimer}
                   </div>
@@ -152,7 +152,7 @@ export const SortAndFilterSettingsForm = ({
             <>
               <FilterToggleRow
                 id="filter-bookmarked-only"
-                label="Bookmarks only"
+                label="Bookmarked only"
                 checked={filterValues.bookmarkedOnly}
                 onChange={form.setBookmarkedOnly}
               />
@@ -167,16 +167,22 @@ export const SortAndFilterSettingsForm = ({
         />
       </div>
       <div className="px-2 pt-4 mt-4 border-t">
-        {!isDisabled && (
-          <ItemCount
-            settings={{ ...initialValue, filterSettings: filterValues }}
-          />
-        )}
-        {isDisabled && (
-          <div className="flex items-center justify-end w-full text-xs">
-            There are no changes to apply yet.
-          </div>
-        )}
+        <div className="flex min-h-12 items-center justify-end">
+          {!isDisabled ? (
+            <div key="item-count" className="w-full animate-fade-in-slow">
+              <ItemCount
+                settings={{ ...initialValue, filterSettings: filterValues }}
+              />
+            </div>
+          ) : (
+            <div
+              key="no-changes"
+              className="flex w-full items-center justify-end text-xs animate-fade-in-slow"
+            >
+              There are no changes to apply yet.
+            </div>
+          )}
+        </div>
         <div className="flex justify-end px-0 pt-2 space-x-1">
           <PracticeButton
             variant="secondary"

--- a/src/index.css
+++ b/src/index.css
@@ -192,6 +192,10 @@ button {
   animation: fade-in 0.2s ease-out;
 }
 
+.animate-fade-in-slow {
+  animation: fade-in 0.8s ease-out;
+}
+
 @keyframes fade-in {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary
- Rearrange filter fields so stroke count sits with bookmark/anchor toggles in a responsive row, with JLPT/Jouyou in a two-column grid.
- Keep the dialog footer height stable while match counts load, and fade between the count and “no changes” states.
- Rename the bookmark filter label to “Bookmarked only” and add a slower fade-in utility for the footer.

## Test plan
- [ ] Open Sort & Filter and confirm filter fields layout correctly at mobile, `md`, and `lg` widths
- [ ] Toggle filters and confirm the match-count line doesn’t collapse/bounce the dialog while loading
- [ ] With no pending changes, confirm “There are no changes to apply yet.” appears without layout jump
- [ ] Apply changes and confirm the fade between footer states looks smooth


Made with [Cursor](https://cursor.com)