### PR TITLE
Improve mobile Study Notes help

### DIFF
--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesEditorTips.tsx
@@ -5,6 +5,17 @@ import { cn } from "@/lib/utils";
 
 export const OPTIONAL_VOCAB_SYNTAX = `:vocab[日本]{kana="にほん" definition="Japan"}`;
 
+const STUDY_NOTES_TIP_COPY = {
+  usefulExtras:
+    "Markdown works here, plus some useful extras. Write Japanese text like 火山 or かざん and it’ll be clickable in View mode. If you’d like to supply a reading and definition, copy the optional syntax below.",
+  playful:
+    "Your notes can do more than Markdown! Japanese text becomes clickable in View mode—give 火山 or かざん a try. For custom readings and definitions, use the optional syntax below.",
+} as const;
+
+/** Change this key to switch between the available tip copy. */
+const ACTIVE_STUDY_NOTES_TIP_COPY: keyof typeof STUDY_NOTES_TIP_COPY =
+  "usefulExtras";
+
 const VocabSyntaxCopyButton = () => {
   const { copy, status } = useCopyToClipboard(1200);
   const copied = status === "copied";
@@ -36,10 +47,7 @@ const VocabSyntaxCopyButton = () => {
 export const StudyNotesEditorTips = ({ className }: { className?: string }) => {
   return (
     <div className={cn("space-y-2.5 text-sm font-bold text-left", className)}>
-      <p>
-        Fun fact! Japanese text is clickable when your notes are finally
-        displayed. Try the optional syntax! 👇
-      </p>
+      <p>{STUDY_NOTES_TIP_COPY[ACTIVE_STUDY_NOTES_TIP_COPY]}</p>
 
       <div className="space-y-1.5">
         <div className="flex items-start gap-1.5 rounded-lg border border-border/70 bg-muted/50 p-1.5 pl-2.5">

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
@@ -1,5 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { CircleX } from "@/components/icons";
+import { CircleX, InfoIcon } from "@/components/icons";
+import { GenericPopover } from "@/components/common/GenericPopover";
+import { LocalStorageWarning } from "@/components/common/LocalStorageWarning";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,7 +13,6 @@ import {
 } from "@/components/ui/dialog";
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { cn } from "@/lib/utils";
-import { LocalStorageWarning } from "@/components/common/LocalStorageWarning";
 import { MarkdownEditor } from "./MarkdownEditor";
 import { StudyNotesEditorTips } from "./StudyNotesEditorTips";
 
@@ -69,9 +70,27 @@ export const StudyNotesFullscreenEditor = ({
               <span className="text-2xl leading-none kanji-font">{kanji}</span>
               <span>Study Notes</span>
             </DialogTitle>
-            <DialogDescription asChild>
-              <StudyNotesEditorTips />
+            <DialogDescription className="sr-only">
+              Write personal study notes for {kanji}.
             </DialogDescription>
+            <GenericPopover
+              trigger={
+                <button
+                  type="button"
+                  className="inline-flex items-center self-start gap-1 leading-loose underline cursor-pointer decoration-dotted underline-offset-8"
+                >
+                  <strong>Tips and optional syntax</strong>
+                  <InfoIcon size={14} />
+                </button>
+              }
+              content={
+                <div className="p-3 space-y-3 text-left">
+                  <StudyNotesEditorTips />
+                  <LocalStorageWarning className="pt-3 text-left border-t border-border" />
+                </div>
+              }
+              contentClassName="z-[70] m-0 w-[calc(100vw-2rem)] max-w-sm p-0"
+            />
             <DialogPrimitive.Close asChild className="absolute top-2 right-2">
               <Button
                 variant="ghost"
@@ -83,7 +102,7 @@ export const StudyNotesFullscreenEditor = ({
               </Button>
             </DialogPrimitive.Close>
           </DialogHeader>
-          <div className="flex flex-col flex-1 min-h-0 px-3 pt-3">
+          <div className="flex flex-col flex-1 min-h-0 px-3 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
             <MarkdownEditor
               value={value}
               maxLength={maxLength}
@@ -91,9 +110,6 @@ export const StudyNotesFullscreenEditor = ({
               fill
               autoFocus
             />
-          </div>
-          <div className="pb-[max(0.75rem,env(safe-area-inset-bottom))]">
-            <LocalStorageWarning className="pb-2" />
           </div>
         </DialogPrimitive.Content>
       </DialogPortal>

--- a/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
+++ b/src/components/sections/KanjiDetails/KanjiStudyNotes/StudyNotesFullscreenEditor.tsx
@@ -65,7 +65,7 @@ export const StudyNotesFullscreenEditor = ({
           }}
           onKeyDown={(event) => event.stopPropagation()}
         >
-          <DialogHeader className="relative gap-1 px-4 py-3 pr-16 text-left border-b shrink-0 border-border">
+          <DialogHeader className="relative gap-1 px-4 py-3 pr-16 text-left shrink-0">
             <DialogTitle className="flex items-center gap-2 text-base">
               <span className="text-2xl leading-none kanji-font">{kanji}</span>
               <span>Study Notes</span>
@@ -77,16 +77,16 @@ export const StudyNotesFullscreenEditor = ({
               trigger={
                 <button
                   type="button"
-                  className="inline-flex items-center self-start gap-1 leading-loose underline cursor-pointer decoration-dotted underline-offset-8"
+                  className="inline-flex items-center self-start gap-1 text-xs leading-loose underline cursor-pointer decoration-dotted underline-offset-8"
                 >
                   <strong>Tips and optional syntax</strong>
                   <InfoIcon size={14} />
                 </button>
               }
               content={
-                <div className="p-3 space-y-3 text-left">
+                <div className="p-5 space-y-3 text-left">
                   <StudyNotesEditorTips />
-                  <LocalStorageWarning className="pt-3 text-left border-t border-border" />
+                  <LocalStorageWarning className="p-2 text-center" />
                 </div>
               }
               contentClassName="z-[70] m-0 w-[calc(100vw-2rem)] max-w-sm p-0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the fixed mobile Study Notes tips with an on-demand popover
- match the primary data sources trigger styling and info icon
- increase popover padding, center the storage warning, and remove divider borders
- provide two selectable copy variants through a single constant
- keep the existing desktop notes layout and mobile safe-area spacing

## Validation
- Prettier completed on both changed files
- `git diff --check`
- No automated tests created or modified
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8b34-8216-7006-bb73-1c62be25c823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8b34-8216-7006-bb73-1c62be25c823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

