### PR TITLE
Set up development environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Kanji Heatmap is a client-side React + Vite single-page app (no backend of its own). Kanji data is served as static JSON from `public/json`. Standard commands live in `package.json` and setup/data docs live in `README.md` — refer to those rather than duplicating them.
+
+### Running the app
+
+- `pnpm run dev` — Vite dev server on port **5174**. All core features (kanji grid, search, filtering, detail views, study notes, games) work here.
+- `pnpm run dev:cf` — Vite on port **5173** with the `@cloudflare/vite-plugin` enabled. Use this port when developing.
+- The dev server binds to localhost only. Use `--host` if you need to reach it from outside the VM.
+
+### Cloudflare Pages Functions caveat (non-obvious)
+
+- The API proxies in `functions/api/` (Jisho, Jotoba, Google Handwriting) are **Cloudflare Pages Functions**. They are NOT served by `@cloudflare/vite-plugin` in either dev script, so `GET /api/jisho` etc. return 404 during local dev. These features also require outbound access to external services (`jisho.org`, Jotoba, Google) that may be blocked in the VM. Treat them as optional — the rest of the app is fully functional without them.
+
+### Checks
+
+- Lint/typecheck/test/build commands are in `package.json` (`lint`, `typecheck`, `test`, `build`). CI (`.github/workflows/ci.yml`) additionally runs `pnpm format:check`.
+- The production build must be run with `CF_PAGES=1 pnpm build` (matching CI); this env var disables the Cloudflare vite plugin so the build matches the real Cloudflare Pages environment.
+- E2E tests (`pnpm test:e2e`) need Chromium: run `pnpm exec playwright install chromium` first (browser binaries are not installed by `pnpm install`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # AGENTS.md
 
+## Coding conventions
+
+The source of truth is `.cursor/rules/*.mdc` (auto-applied by Cursor). Follow them even if you are a tool that does not load those files:
+
+- Tests: do NOT add or change automated tests unless the user explicitly asks. See `tests-only-when-asked.mdc`.
+- React hooks: avoid `useEffect`, `useMemo`, `useCallback`, and `forwardRef` unless truly necessary and there is no simpler way; if you must use one, add a short comment explaining why. Prefer deriving values during render. See `avoid-react-effect-memo-callback-forwardref.mdc`.
+- Single responsibility: one screen → one component (no `variant` enums stuffed into a "god" screen); route phases with a linear early-return chain rather than stacked `{phase === … && …}` blocks. Prefer early exits in conditionals generally. See `react-single-responsibility-screens.mdc`.
+- Formatting: run Prettier on the exact files you edit (`pnpm exec prettier --write <paths>`); do not run a full-repo format unless asked. Match `.prettierrc.json`. See `prettier-format.mdc`.
+
 ## Cursor Cloud specific instructions
 
 Kanji Heatmap is a client-side React + Vite single-page app (no backend of its own). Kanji data is served as static JSON from `public/json`. Standard commands live in `package.json` and setup/data docs live in `README.md` — refer to those rather than duplicating them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Kanji Heatmap (Vite + React) app and documents durable, non-obvious startup caveats for future cloud agents.

- Verified the full dev workflow: install, lint, typecheck, unit tests, format check, build, and dev server.
- Ran a hello-world task end-to-end: searched for a kanji reading and opened its detail view.
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section.

## Environment

- Node 22 + pnpm 10 (already present via nvm).
- Update script: `pnpm install`.

## Verification

| Step | Command | Result |
| --- | --- | --- |
| Lint | `pnpm lint` | pass |
| Typecheck | `pnpm typecheck` | pass |
| Unit tests | `pnpm test` | 208 passed (30 files) |
| Format | `pnpm format:check` | pass |
| Build | `CF_PAGES=1 pnpm build` | pass |
| Run | `pnpm run dev:cf` (port 5173) | app loads, search + detail view work |

## Notes

The API proxies in `functions/api/` (Jisho/Jotoba/handwriting) are Cloudflare Pages Functions that are not served by `@cloudflare/vite-plugin` in local dev (they 404) and depend on external services. They are optional per the README; the rest of the app is fully functional. Documented in `AGENTS.md`.

## Demo

[kanji_heatmap_search_and_details_demo.mp4](https://cursor.com/agents/bc-988e61e3-4d96-4228-8aa6-bcc0b3df7be5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkanji_heatmap_search_and_details_demo.mp4)

[Kanji detail view for water](https://cursor.com/agents/bc-988e61e3-4d96-4228-8aa6-bcc0b3df7be5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkanji_water_detail_view.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-988e61e3-4d96-4228-8aa6-bcc0b3df7be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-988e61e3-4d96-4228-8aa6-bcc0b3df7be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

