### PR TITLE
Add a "Color by" settings popover to the Speed Katakana heatmap

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+pnpm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -112,12 +112,16 @@ vocab_furigana.json
 vocab_meaning.json
 ```
 
-Regenerate the files the app actually serves, then delete the `tar.gz` since
-it is no longer needed:
+Delete the `tar.gz` since it is no longer needed:
+
+```
+rm kanji-heatmap-data.tar.gz
+```
+
+Regenerate the files the app actually serves
 
 ```bash
 pnpm run generate-json
-rm kanji-heatmap-data.tar.gz
 ```
 
 `generate-json` reads `./raw-data` and writes `./public/json/v2` plus
@@ -130,38 +134,14 @@ that does not round-trip, a sort field that is not a number).
 `generate-json` prints the size and entry count of everything it writes, so
 the quickest check is to run it and read the output.
 
-To measure the files independently — inputs and served output, raw and
-gzipped, which is what matters over the wire — paste this:
+For raw and gzipped sizes (per file, plus v2 eager/lazy totals):
 
 ```bash
-for f in raw-data/*.json public/json/*.json public/json/v2/*.json docs/data/*.json; do
-  printf "%7s %7s  %s\n" \
-    "$(( $(stat -c%s "$f") / 1024 ))K" \
-    "$(( $(gzip -9 -c "$f" | wc -c) / 1024 ))K" \
-    "$f"
-done | sort -k3
-```
-
-Columns are raw, gzipped, path. (On macOS, `stat -c%s` is `stat -f%z`.)
-
-Totals per directory, and the eager/lazy split that
-`docs/notes/kanji-worker-data-redesign.md` documents:
-
-```bash
-# gzipped total of everything served from public/json/v2, summed per file
-# (each is fetched separately, so the per-file sum is what goes over the wire —
-# don't `cat` them together first, that compresses across files and overstates)
-for f in public/json/v2/*.json; do gzip -9 -c "$f" | wc -c; done |
-  awk '{t+=$1} END {printf "%.0f KB gz total\n", t/1024}'
-
-# the one file loaded before first paint — everything else is lazy
-gzip -9 -c public/json/v2/kanji_main.json | wc -c |
-  awk '{printf "%.0f KB gz eager\n", $1/1024}'
+./scripts/print-file-sizes.sh
 ```
 
 §5 of `docs/notes/kanji-worker-data-redesign.md` lists the expected size and
-entry count of every generated file, so these commands verify the design note
-rather than trusting it.
+entry count of every generated file.
 
 ### Regenerating derived JSON
 
@@ -184,7 +164,7 @@ is one file per kanji (see also `./src/lib/assets-paths.ts`):
 - `/kanji-words/v4/<KANJI>.json`
 
 These paths are used in development only. In production the same data is
-served from `https://assets.pikapikagems.com`, so the site works without them;
+served from a cloud storage, so the site works without them;
 locally, the vocabulary sections of the kanji drawer stay empty until you
 populate the two directories.
 

--- a/scripts/print-file-sizes.sh
+++ b/scripts/print-file-sizes.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+shopt -s nullglob
+
+file_size_kb() {
+  echo $(( $(wc -c <"$1" | tr -d " ") / 1024 ))
+}
+
+gzip_size_kb() {
+  echo $(( $(gzip -9 -c "$1" | wc -c | tr -d " ") / 1024 ))
+}
+
+patterns=(
+  raw-data/*.json
+  public/json/*.json
+  public/json/v2/*.json
+  docs/data/*.json
+)
+
+echo "    raw      gz  path"
+echo "  -----  ------  ----"
+
+for pattern in "${patterns[@]}"; do
+  for f in $pattern; do
+    printf "%6sK %6sK  %s\n" \
+      "$(file_size_kb "$f")" \
+      "$(gzip_size_kb "$f")" \
+      "$f"
+  done
+done | sort -k3
+
+echo
+echo "public/json/v2 totals (per-file gz sum — what goes over the wire):"
+
+for f in public/json/v2/*.json; do
+  gzip -9 -c "$f" | wc -c
+done | awk '{ t += $1 } END { printf "%.0f KB gz total\n", t / 1024 }'
+
+gzip -9 -c public/json/v2/kanji_main.json | wc -c |
+  awk '{ printf "%.0f KB gz eager\n", $1 / 1024 }'

--- a/src/components/common/GradientLegend.tsx
+++ b/src/components/common/GradientLegend.tsx
@@ -14,7 +14,10 @@ export const GradientLegend = ({
   moreLabel?: string;
 } = {}) => {
   return (
-    <div className="flex my-3 space-x-1 items-center w-full">
+    <div
+      className="flex items-center w-full my-3 space-x-1 animate-fade-in"
+      key={lessLabel + moreLabel}
+    >
       <div className="text-xs">{lessLabel}</div>
       {Array.from({ length: freqCategoryCount }).map((_, item) => {
         const cn = freqCategoryCn[item as FreqCategory];

--- a/src/components/common/GradientLegend.tsx
+++ b/src/components/common/GradientLegend.tsx
@@ -3,9 +3,10 @@ import {
   freqCategoryCn,
   freqCategoryCount,
 } from "@/lib/freq/freq-category";
-import { FreqSquare } from "./FreqSquare";
+import { FreqSquare } from "./freq/FreqSquare";
 
-export const FreqGradient = ({
+/** Opacity-gradient legend (e.g. "Less…More", "Slow…Fast") for any heatmap. */
+export const GradientLegend = ({
   lessLabel = "Less",
   moreLabel = "More",
 }: {

--- a/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
@@ -17,7 +17,7 @@ import { ActivityKindFiltersRow } from "./ActivityKindFiltersRow";
 import { DurationNav } from "./DurationNav";
 import { CalendarGrid } from "./CalendarGrid";
 import { DashboardPanel } from "./DashboardPanel";
-import { FreqGradient } from "@/components/common/freq/FreqGradient";
+import { GradientLegend } from "@/components/common/GradientLegend";
 
 export const ActivityCalendarHeatmap = () => {
   const { byDay } = useActivityData();
@@ -63,7 +63,7 @@ export const ActivityCalendarHeatmap = () => {
       </div>
       <div className="flex items-center justify-center w-full mt-6">
         <div>
-          <FreqGradient />
+          <GradientLegend />
         </div>
       </div>
     </DashboardPanel>

--- a/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaBreakdown.tsx
@@ -13,7 +13,7 @@ import { useStorageRevision } from "@/hooks/use-storage-value";
 import { SectionHeading } from "./SectionHeading";
 import { SegmentedBandBar } from "./SegmentedBandBar";
 import { DashboardPanel } from "./DashboardPanel";
-import { FreqGradient } from "@/components/common/freq/FreqGradient";
+import { GradientLegend } from "@/components/common/GradientLegend";
 
 const levelBandCounts = (level: number): number[] => {
   const bands = Array.from({ length: CHALLENGES_PER_LEVEL }, (_, i) => {
@@ -59,7 +59,7 @@ export const SpeedKatakanaBreakdown = () => {
       </div>
       <div className="flex items-center justify-center w-full mt-5">
         <div>
-          <FreqGradient lessLabel="Slow" moreLabel="Fast" />
+          <GradientLegend lessLabel="Slow" moreLabel="Fast" />
         </div>
       </div>
     </DashboardPanel>

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmap.tsx
@@ -1,26 +1,40 @@
 import { speedKatakanaPageMeta } from "@/lib/pages/practice-pages";
 import { STATS_KEY_PREFIX } from "@/components/screens/SpeedKatakanaScreen/storage";
 import { useStorageRevision } from "@/hooks/use-storage-value";
-import { FreqGradient } from "@/components/common/freq/FreqGradient";
+import { useHeatmapCellMetric } from "@/hooks/use-heatmap-cell-metric";
+import { GradientLegend } from "@/components/common/GradientLegend";
+import {
+  HEATMAP_METRIC_GRADIENT_LABELS,
+  HEATMAP_METRIC_LABELS,
+} from "@/lib/activity";
 import { SectionHeading } from "./SectionHeading";
 import { DashboardPanel } from "./DashboardPanel";
 import { SpeedKatakanaHeatmapGrid } from "./SpeedKatakanaHeatmapGrid";
+import { SpeedKatakanaHeatmapSettingsPopover } from "./SpeedKatakanaHeatmapSettingsPopover";
 
 export const SpeedKatakanaHeatmap = () => {
   const revision = useStorageRevision(
     (key) => key == null || key.startsWith(STATS_KEY_PREFIX)
   );
+  const [metric] = useHeatmapCellMetric();
+  const gradientLabels = HEATMAP_METRIC_GRADIENT_LABELS[metric];
 
   return (
     <DashboardPanel>
       <SectionHeading
         title={speedKatakanaPageMeta.shortLabel}
-        description="Each cell is one challenge set (10 katakana words). Brighter cells mean a higher best CPM at over 70% accuracy. Columns are levels 1–20; rows are sets within each level."
+        description={`Each cell is one challenge set (10 katakana words). Cells are currently colored by "${HEATMAP_METRIC_LABELS[metric]}" — brighter cells mean a higher value. Columns are levels 1–20; rows are sets within each level.`}
       />
-      <SpeedKatakanaHeatmapGrid key={revision} />
+      <div className="flex justify-end mb-1">
+        <SpeedKatakanaHeatmapSettingsPopover />
+      </div>
+      <SpeedKatakanaHeatmapGrid key={revision} metric={metric} />
       <div className="flex items-center justify-center w-full">
         <div>
-          <FreqGradient lessLabel="Slow" moreLabel="Fast" />
+          <GradientLegend
+            lessLabel={gradientLabels.less}
+            moreLabel={gradientLabels.more}
+          />
         </div>
       </div>
     </DashboardPanel>

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmap.tsx
@@ -25,11 +25,11 @@ export const SpeedKatakanaHeatmap = () => {
         title={speedKatakanaPageMeta.shortLabel}
         description={`Each cell is one challenge set (10 katakana words). Cells are currently colored by "${HEATMAP_METRIC_LABELS[metric]}" — brighter cells mean a higher value. Columns are levels 1–20; rows are sets within each level.`}
       />
-      <div className="flex justify-end mb-1">
+      <div className="flex justify-center mb-6 animate-fade-in">
         <SpeedKatakanaHeatmapSettingsPopover />
       </div>
       <SpeedKatakanaHeatmapGrid key={revision} metric={metric} />
-      <div className="flex items-center justify-center w-full">
+      <div className="flex flex-col items-center justify-center w-full">
         <div>
           <GradientLegend
             lessLabel={gradientLabels.less}

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapGrid.tsx
@@ -12,7 +12,12 @@ import {
 } from "@/components/screens/SpeedKatakanaScreen/storage";
 import { Link } from "@/components/dependent/routing";
 import { Button } from "@/components/ui/button";
-import { CPM_BAND_LABELS, cpmToBand } from "@/lib/activity";
+import {
+  HEATMAP_METRIC_BAND_LABELS,
+  HeatmapCellMetric,
+  metricToBand,
+  metricValueText,
+} from "@/lib/activity";
 import { HeatmapCell, HeatmapGrid } from "./HeatmapGrid";
 import { heatmapFillCn } from "./heatmap-fill";
 
@@ -21,11 +26,13 @@ const CELL_PX = 20;
 const SetDetail = ({
   setNumber,
   stats,
+  metric,
   band,
 }: {
   setNumber: number;
   stats: ChallengeSetStats | null;
-  band: ReturnType<typeof cpmToBand>;
+  metric: HeatmapCellMetric;
+  band: ReturnType<typeof metricToBand>;
 }) => {
   const level = levelOf(setNumber);
   const position = positionInLevel(setNumber);
@@ -37,19 +44,17 @@ const SetDetail = ({
       </div>
       {stats ? (
         <>
-          {band > 0 ? (
-            <div className="text-muted-foreground">{CPM_BAND_LABELS[band]}</div>
-          ) : (
-            <div className="text-muted-foreground">
-              No run above 70% accuracy
-            </div>
-          )}
-          <div className="flex justify-between gap-4">
-            <span>Best CPM</span>
-            <span className="font-bold tabular-nums">{stats.bestCpm}</span>
+          <div className="text-muted-foreground">
+            {band === 0 && metric === "bestSpeedOver70"
+              ? "No run above 70% accuracy"
+              : HEATMAP_METRIC_BAND_LABELS[metric][band]}
           </div>
           <div className="flex justify-between gap-4">
-            <span>Best CPM (&gt;70%)</span>
+            <span>Best speed</span>
+            <span className="font-bold tabular-nums">{stats.bestCpm} CPM</span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span>Best speed (&gt;70%)</span>
             <span className="font-bold tabular-nums">
               {stats.bestCpmWithAccuracyOver70 ?? "—"}
             </span>
@@ -61,8 +66,16 @@ const SetDetail = ({
             </span>
           </div>
           <div className="flex justify-between gap-4">
-            <span>Latest CPM</span>
-            <span className="font-bold tabular-nums">{stats.latestCpm}</span>
+            <span>Current speed</span>
+            <span className="font-bold tabular-nums">
+              {stats.latestCpm} CPM
+            </span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span>Current accuracy</span>
+            <span className="font-bold tabular-nums">
+              {stats.latestAccuracy}%
+            </span>
           </div>
           <div className="flex justify-between gap-4">
             <span>Attempts</span>
@@ -86,23 +99,34 @@ const SetDetail = ({
   );
 };
 
-const ChallengeSetCell = ({ setNumber }: { setNumber: number }) => {
+const ChallengeSetCell = ({
+  setNumber,
+  metric,
+}: {
+  setNumber: number;
+  metric: HeatmapCellMetric;
+}) => {
   const stats = readSetStats(setNumber);
-  const band = cpmToBand(stats?.bestCpmWithAccuracyOver70);
+  const band = metricToBand(stats, metric);
   const level = levelOf(setNumber);
   const pos = positionInLevel(setNumber);
   const challengeLabel = `Challenge ${level}-${pos} (#${setNumber})`;
 
-  const label = stats?.bestCpmWithAccuracyOver70
-    ? `${challengeLabel}: ${stats.bestCpmWithAccuracyOver70} CPM`
-    : `${challengeLabel}: not attempted`;
+  const label = `${challengeLabel}: ${metricValueText(stats, metric)}`;
 
   return (
     <HeatmapCell
       cellPx={CELL_PX}
       fillCn={heatmapFillCn(band)}
       label={label}
-      detail={<SetDetail setNumber={setNumber} stats={stats} band={band} />}
+      detail={
+        <SetDetail
+          setNumber={setNumber}
+          stats={stats}
+          metric={metric}
+          band={band}
+        />
+      }
     />
   );
 };
@@ -111,7 +135,11 @@ const ChallengeSetCell = ({ setNumber }: { setNumber: number }) => {
  * Fixed-size grid: 20 columns (levels) × 10 rows (sets per level).
  * Column flow fills each level top-to-bottom, then the next level.
  */
-export const SpeedKatakanaHeatmapGrid = () => {
+export const SpeedKatakanaHeatmapGrid = ({
+  metric,
+}: {
+  metric: HeatmapCellMetric;
+}) => {
   return (
     <HeatmapGrid
       cellPx={CELL_PX}
@@ -125,7 +153,13 @@ export const SpeedKatakanaHeatmapGrid = () => {
       {Array.from({ length: LEVELS }, (_, levelIndex) =>
         Array.from({ length: CHALLENGES_PER_LEVEL }, (_, posIndex) => {
           const setNumber = setFromLevelAndPos(levelIndex + 1, posIndex + 1);
-          return <ChallengeSetCell key={setNumber} setNumber={setNumber} />;
+          return (
+            <ChallengeSetCell
+              key={setNumber}
+              setNumber={setNumber}
+              metric={metric}
+            />
+          );
         })
       )}
     </HeatmapGrid>

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapSettingsPopover.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapSettingsPopover.tsx
@@ -1,0 +1,84 @@
+import { useId } from "react";
+import { GenericPopover } from "@/components/common/GenericPopover";
+import { Settings2 } from "@/components/icons";
+import { cn } from "@/lib/utils";
+import {
+  HEATMAP_CELL_METRICS,
+  HEATMAP_METRIC_LABELS,
+  HeatmapCellMetric,
+} from "@/lib/activity";
+import { useHeatmapCellMetric } from "@/hooks/use-heatmap-cell-metric";
+
+const MetricRadioOption = ({
+  name,
+  metric,
+  checked,
+  onChange,
+}: {
+  name: string;
+  metric: HeatmapCellMetric;
+  checked: boolean;
+  onChange: (metric: HeatmapCellMetric) => void;
+}) => {
+  const inputId = useId();
+  return (
+    <div className="flex items-center space-x-2">
+      <input
+        type="radio"
+        id={inputId}
+        name={name}
+        checked={checked}
+        onChange={() => onChange(metric)}
+        className="h-4 w-4 shrink-0 accent-primary"
+      />
+      <label htmlFor={inputId} className="text-sm font-medium leading-none">
+        {HEATMAP_METRIC_LABELS[metric]}
+      </label>
+    </div>
+  );
+};
+
+export const SpeedKatakanaHeatmapSettingsPopover = ({
+  className,
+}: {
+  className?: string;
+}) => {
+  const [metric, setMetric] = useHeatmapCellMetric();
+  const groupName = useId();
+
+  return (
+    <GenericPopover
+      trigger={
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center gap-1 text-xs leading-loose underline cursor-pointer decoration-dotted underline-offset-8",
+            className
+          )}
+        >
+          <strong>Color by</strong>
+          <Settings2 size={14} />
+        </button>
+      }
+      content={
+        <div className="p-5 space-y-3 text-left w-64">
+          <div className="text-xs font-extrabold uppercase text-muted-foreground">
+            Color cells by
+          </div>
+          <div className="space-y-2.5">
+            {HEATMAP_CELL_METRICS.map((option) => (
+              <MetricRadioOption
+                key={option}
+                name={groupName}
+                metric={option}
+                checked={metric === option}
+                onChange={setMetric}
+              />
+            ))}
+          </div>
+        </div>
+      }
+      contentClassName="m-0 w-[calc(100vw-2rem)] max-w-sm p-0"
+    />
+  );
+};

--- a/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapSettingsPopover.tsx
+++ b/src/components/screens/DashboardScreen/SpeedKatakanaHeatmapSettingsPopover.tsx
@@ -22,16 +22,19 @@ const MetricRadioOption = ({
 }) => {
   const inputId = useId();
   return (
-    <div className="flex items-center space-x-2">
+    <div className="flex space-x-2">
       <input
         type="radio"
         id={inputId}
         name={name}
         checked={checked}
         onChange={() => onChange(metric)}
-        className="h-4 w-4 shrink-0 accent-primary"
+        className="w-4 h-4 shrink-0 accent-primary"
       />
-      <label htmlFor={inputId} className="text-sm font-medium leading-none">
+      <label
+        htmlFor={inputId}
+        className="text-xs font-medium leading-none translate-y-0.5"
+      >
         {HEATMAP_METRIC_LABELS[metric]}
       </label>
     </div>
@@ -50,18 +53,21 @@ export const SpeedKatakanaHeatmapSettingsPopover = ({
     <GenericPopover
       trigger={
         <button
+          key={metric}
           type="button"
           className={cn(
-            "inline-flex items-center gap-1 text-xs leading-loose underline cursor-pointer decoration-dotted underline-offset-8",
+            "inline-flex items-center gap-1 animate-fade-in-slow text-xs leading-loose underline cursor-pointer decoration-dotted underline-offset-8",
             className
           )}
         >
-          <strong>Color by</strong>
+          <strong>
+            Colored by {HEATMAP_METRIC_LABELS[metric].toLowerCase()}
+          </strong>
           <Settings2 size={14} />
         </button>
       }
       content={
-        <div className="p-5 space-y-3 text-left w-64">
+        <div className="p-5 space-y-3 text-left">
           <div className="text-xs font-extrabold uppercase text-muted-foreground">
             Color cells by
           </div>
@@ -78,7 +84,7 @@ export const SpeedKatakanaHeatmapSettingsPopover = ({
           </div>
         </div>
       }
-      contentClassName="m-0 w-[calc(100vw-2rem)] max-w-sm p-0"
+      contentClassName="m-0 p-0 max-w-56"
     />
   );
 };

--- a/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ItemPresentation/ItemPresentationContent.tsx
@@ -9,7 +9,7 @@ import { DottedSeparator } from "@/components/ui/dotted-separator";
 
 import { LabeledCheckbox } from "@/components/common/LabeledCheckbox";
 import { FrequencyRankDataSource } from "@/components/common/freq/FrequencyRankDataSource";
-import { FreqGradient } from "@/components/common/freq/FreqGradient";
+import { GradientLegend } from "@/components/common/GradientLegend";
 import { ItemTypeSwitch } from "@/components/common/ItemTypeSwitch";
 import { JLPTBordersMeanings } from "@/components/common/jlpt/JLPTBorderMeanings";
 import { StudyStatusBorderMeanings } from "@/components/common/StudyStatusBorderMeanings";
@@ -48,7 +48,7 @@ const BackgroundColorSection = () => {
       />
       {shouldAttachMeaning && (
         <div className="animate-fade-in">
-          <FreqGradient />
+          <GradientLegend />
           <FrequencyRankDataSource
             value={initialState}
             setValue={(v) => {

--- a/src/hooks/use-heatmap-cell-metric.ts
+++ b/src/hooks/use-heatmap-cell-metric.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_HEATMAP_CELL_METRIC, HeatmapCellMetric } from "@/lib/activity";
+import { useLocalStorage } from "./use-local-storage";
+
+const STORAGE_KEY = "speed-katakana-heatmap-metric";
+
+type MetricSettings = { metric: HeatmapCellMetric };
+
+/** Persisted choice of which stat colors the Speed Katakana heatmap cells. */
+export const useHeatmapCellMetric = () => {
+  const [{ metric }, setItem] = useLocalStorage<MetricSettings>(STORAGE_KEY, {
+    metric: DEFAULT_HEATMAP_CELL_METRIC,
+  });
+
+  const setMetric = (next: HeatmapCellMetric) => setItem("metric", next);
+
+  return [metric, setMetric] as const;
+};

--- a/src/lib/activity/heatmap-metric.ts
+++ b/src/lib/activity/heatmap-metric.ts
@@ -1,0 +1,137 @@
+import type { FreqCategory } from "@/lib/freq/freq-category";
+import type { ChallengeSetStats } from "@/components/screens/SpeedKatakanaScreen/storage";
+import { cpmToBand, CPM_BAND_LABELS } from "./cpm-band";
+
+/** Which stat a Speed Katakana heatmap cell's color represents. */
+export type HeatmapCellMetric =
+  | "bestSpeedOver70"
+  | "attemptCount"
+  | "bestAccuracy"
+  | "bestSpeed"
+  | "currentAccuracy"
+  | "currentSpeed";
+
+export const DEFAULT_HEATMAP_CELL_METRIC: HeatmapCellMetric = "bestSpeedOver70";
+
+export const HEATMAP_CELL_METRICS: HeatmapCellMetric[] = [
+  "bestSpeedOver70",
+  "attemptCount",
+  "bestAccuracy",
+  "bestSpeed",
+  "currentAccuracy",
+  "currentSpeed",
+];
+
+export const HEATMAP_METRIC_LABELS: Record<HeatmapCellMetric, string> = {
+  bestSpeedOver70: "Best speed with accuracy over 70%",
+  attemptCount: "Attempt count",
+  bestAccuracy: "Best accuracy",
+  bestSpeed: "Best speed",
+  currentAccuracy: "Current accuracy",
+  currentSpeed: "Current speed",
+};
+
+/** Gradient legend endpoint words ("Less"/"More" vs "Slow"/"Fast"). */
+export const HEATMAP_METRIC_GRADIENT_LABELS: Record<
+  HeatmapCellMetric,
+  { less: string; more: string }
+> = {
+  bestSpeedOver70: { less: "Slow", more: "Fast" },
+  bestSpeed: { less: "Slow", more: "Fast" },
+  currentSpeed: { less: "Slow", more: "Fast" },
+  attemptCount: { less: "Less", more: "More" },
+  bestAccuracy: { less: "Less", more: "More" },
+  currentAccuracy: { less: "Less", more: "More" },
+};
+
+const accuracyToBand = (accuracy: number | undefined): FreqCategory => {
+  const value = accuracy ?? 0;
+  if (value <= 0) return 0;
+  if (value < 50) return 1;
+  if (value < 70) return 2;
+  if (value < 90) return 3;
+  return 4;
+};
+
+const attemptCountToBand = (count: number | undefined): FreqCategory => {
+  const value = count ?? 0;
+  if (value <= 0) return 0;
+  if (value === 1) return 1;
+  if (value <= 3) return 2;
+  if (value <= 6) return 3;
+  return 4;
+};
+
+const ACCURACY_BAND_LABELS: Record<FreqCategory, string> = {
+  0: "Not attempted",
+  1: "<50% accuracy",
+  2: "50–69% accuracy",
+  3: "70–89% accuracy",
+  4: "90–100% accuracy",
+};
+
+const ATTEMPT_COUNT_BAND_LABELS: Record<FreqCategory, string> = {
+  0: "Not attempted",
+  1: "1 attempt",
+  2: "2–3 attempts",
+  3: "4–6 attempts",
+  4: "7+ attempts",
+};
+
+export const HEATMAP_METRIC_BAND_LABELS: Record<
+  HeatmapCellMetric,
+  Record<FreqCategory, string>
+> = {
+  bestSpeedOver70: CPM_BAND_LABELS,
+  bestSpeed: CPM_BAND_LABELS,
+  currentSpeed: CPM_BAND_LABELS,
+  bestAccuracy: ACCURACY_BAND_LABELS,
+  currentAccuracy: ACCURACY_BAND_LABELS,
+  attemptCount: ATTEMPT_COUNT_BAND_LABELS,
+};
+
+/** Band (0–4) a challenge set's cell should be painted, for the chosen metric. */
+export const metricToBand = (
+  stats: ChallengeSetStats | null,
+  metric: HeatmapCellMetric
+): FreqCategory => {
+  if (!stats) return 0;
+  switch (metric) {
+    case "bestSpeedOver70":
+      return cpmToBand(stats.bestCpmWithAccuracyOver70);
+    case "bestSpeed":
+      return cpmToBand(stats.bestCpm);
+    case "currentSpeed":
+      return cpmToBand(stats.latestCpm);
+    case "bestAccuracy":
+      return accuracyToBand(stats.bestAccuracy);
+    case "currentAccuracy":
+      return accuracyToBand(stats.latestAccuracy);
+    case "attemptCount":
+      return attemptCountToBand(stats.timesTaken);
+  }
+};
+
+/** Short "<value> <unit>" text for the chosen metric, e.g. for aria-labels. */
+export const metricValueText = (
+  stats: ChallengeSetStats | null,
+  metric: HeatmapCellMetric
+): string => {
+  if (!stats) return "not attempted";
+  switch (metric) {
+    case "bestSpeedOver70":
+      return stats.bestCpmWithAccuracyOver70 != null
+        ? `${stats.bestCpmWithAccuracyOver70} CPM`
+        : "no run above 70% accuracy";
+    case "bestSpeed":
+      return `${stats.bestCpm} CPM`;
+    case "currentSpeed":
+      return `${stats.latestCpm} CPM`;
+    case "bestAccuracy":
+      return `${stats.bestAccuracy}% accuracy`;
+    case "currentAccuracy":
+      return `${stats.latestAccuracy}% accuracy`;
+    case "attemptCount":
+      return `${stats.timesTaken} attempts`;
+  }
+};

--- a/src/lib/activity/index.ts
+++ b/src/lib/activity/index.ts
@@ -3,3 +3,4 @@ export * from "./dates";
 export * from "./storage";
 export * from "./queries";
 export * from "./cpm-band";
+export * from "./heatmap-metric";


### PR DESCRIPTION
Lets you choose which stat colors each heatmap cell (attempt count,
best/current accuracy, best/current speed, or best speed with accuracy
over 70%) via a radio-button popover styled like the study notes tips
popover, persisted in localStorage. The gradient legend now shows
Slow/Fast for speed metrics and Less/More otherwise, and the panel
description updates to name the active metric.

Also renames FreqGradient to GradientLegend since the component is now
used for several non-frequency heatmaps (activity calendar, speed
katakana) in addition to the kanji frequency legend.

## SessionStart hook + action needed from an admin

This PR also adds `.claude/hooks/session-start.sh` (registered in
`.claude/settings.json`), which runs `pnpm install` when a Claude Code
web session starts on this repo, so `eslint`/`tsc`/`vitest` are ready
to use instead of every session having to discover a missing
`node_modules` the hard way.

**The hook currently cannot succeed**, because `pnpm install` needs to
fetch the `kanjicanvas` dependency from `codeload.github.com` (it's a
`github:asdfjkl/kanjicanvas` tarball dependency, not published to
npm), and that host is not on this workspace's network egress
allowlist — the proxy returns `403 Forbidden`. Everything else in
`package.json` comes from npm and installs fine; this one host is the
only blocker, but pnpm won't finish linking `node_modules/.bin` until
the whole dependency graph resolves, so the block effectively leaves
all local tooling (lint/typecheck/test) unusable in every session
until it's fixed.

### Steps for an admin to fix this

1. Open the network/environment settings for this Claude Code
   workspace (see
   [Claude Code on the web docs](https://code.claude.com/docs/en/claude-code-on-the-web)
   for where environment network policy is configured).
2. Find the egress allowlist for the proxy sessions run behind (the
   in-session diagnostic is `curl -sS "$HTTPS_PROXY/__agentproxy/status"`,
   which currently reports `registry.npmjs.org`, `jsr.io`,
   `npm.jsr.io`, `pypi.org`, `files.pythonhosted.org`,
   `index.crates.io`, and `proxy.golang.org` as allowed, but not
   `codeload.github.com` or `github.com`).
3. Add `codeload.github.com` (and `github.com`, since other GitHub
   tarball/source dependencies could hit either host) to that
   allowlist.
4. Start a fresh Claude Code web session on this repo and confirm the
   hook succeeds: it should run `pnpm install` with no `403` errors,
   and `pnpm exec eslint . `/ `pnpm exec vitest run` / `pnpm exec tsc -b`
   should all be runnable afterward.
5. If your organization intentionally restricts fetching arbitrary
   GitHub source (as opposed to registry packages) as a security
   policy, the alternative is to change the `kanjicanvas` dependency
   in `package.json` to a published npm package or a vendored copy —
   that's a separate, larger change outside the scope of this PR and
   should be discussed with the maintainer first.

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_01MxJjuuFEDQqzjqYp2BchGV