### PR TITLE
Use a fixed 6/6 split for writing-practice candidate grid

### DIFF
--- a/src/components/common/BottomBar.tsx
+++ b/src/components/common/BottomBar.tsx
@@ -4,7 +4,6 @@ import { PikaPikaLinks } from "@/components/common/PikaPikaLinks";
 import { DotIcon } from "@/components/icons";
 import { DebugInfo } from "@/components/common/DebugInfo";
 import { RefreshPageBtn } from "@/components/common/RefreshPageBtn";
-import { ModeToggle } from "@/components/dependent/site-wide/ModeToggle";
 import { SettingsModal } from "@/components/dependent/site-wide/SettingsModal";
 
 export const BottomBar = ({
@@ -28,7 +27,6 @@ export const BottomBar = ({
         <DebugInfo />
         <RefreshPageBtn />
         <SettingsModal />
-        <ModeToggle />
         {includeNode}
       </div>
     </>

--- a/src/components/production-practice-v1/Game.tsx
+++ b/src/components/production-practice-v1/Game.tsx
@@ -165,7 +165,6 @@ export const Game = ({
     const isRealKanji = (k: string) => getKanjiInfo?.(k)?.jlpt != null;
     const grid = buildCandidateGrid({
       target: current.kanji,
-      inTop10: grade.inTop10,
       modelGuesses,
       similars,
       randomPool: randomKanjiPool,

--- a/src/components/production-practice-v1/build-candidates.test.ts
+++ b/src/components/production-practice-v1/build-candidates.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { buildCandidateGrid } from "./build-candidates";
+import {
+  CANDIDATE_COUNT,
+  MODEL_SEED_COUNT,
+  SIMILAR_SEED_COUNT,
+} from "./constants";
+
+const allReal = () => true;
+
+const build = (overrides: Partial<Parameters<typeof buildCandidateGrid>[0]>) =>
+  buildCandidateGrid({
+    target: "T",
+    modelGuesses: [],
+    similars: [],
+    randomPool: [],
+    isRealKanji: allReal,
+    ...overrides,
+  });
+
+describe("buildCandidateGrid", () => {
+  it("splits into the configured model/similar quotas when both pools are large", () => {
+    const modelGuesses = Array.from(
+      { length: MODEL_SEED_COUNT + 3 },
+      (_, i) => `M${i + 1}`
+    );
+    const similars = Array.from(
+      { length: SIMILAR_SEED_COUNT + 3 },
+      (_, i) => `S${i + 1}`
+    );
+
+    const grid = build({ modelGuesses, similars });
+
+    expect(grid).toHaveLength(CANDIDATE_COUNT);
+    expect(new Set(grid).size).toBe(CANDIDATE_COUNT);
+    expect(grid).toContain("T");
+
+    const modelHits = grid.filter((k) => k.startsWith("M"));
+    const similarHits = grid.filter((k) => k.startsWith("S"));
+    expect(modelHits).toHaveLength(MODEL_SEED_COUNT);
+    expect(similarHits).toHaveLength(SIMILAR_SEED_COUNT);
+    // Quota is filled from the front of each ranked list.
+    expect(modelHits.sort()).toEqual(
+      modelGuesses.slice(0, MODEL_SEED_COUNT).sort()
+    );
+    expect(similarHits.sort()).toEqual(
+      similars.slice(0, SIMILAR_SEED_COUNT).sort()
+    );
+  });
+
+  it("backfills from a pool's own overflow when the other pool falls short of its quota", () => {
+    const modelGuesses = Array.from({ length: 10 }, (_, i) => `M${i + 1}`);
+    const similars = ["S1", "S2"]; // short of SIMILAR_SEED_COUNT
+
+    const grid = build({ modelGuesses, similars });
+
+    expect(grid).toHaveLength(CANDIDATE_COUNT);
+    expect(grid).toEqual(expect.arrayContaining(["T", "S1", "S2"]));
+    // 1 target + 2 similars leaves 9 slots for model guesses (more than its quota).
+    const modelHits = grid.filter((k) => k.startsWith("M"));
+    expect(modelHits).toHaveLength(CANDIDATE_COUNT - 1 - similars.length);
+  });
+
+  it("does not let a kanji shared by both pools double-count against either quota", () => {
+    const modelGuesses = ["M1", "X"];
+    const similars = ["X", "S1", "S2", "S3", "S4", "S5", "S6"];
+
+    const grid = build({
+      modelGuesses,
+      similars,
+      randomPool: ["P1", "P2", "P3"],
+    });
+
+    expect(new Set(grid).size).toBe(grid.length);
+    expect(grid).toEqual(
+      expect.arrayContaining([
+        "T",
+        "M1",
+        "X",
+        "S1",
+        "S2",
+        "S3",
+        "S4",
+        "S5",
+        "S6",
+      ])
+    );
+  });
+
+  it("falls back to related lookalikes then the random pool when both seed pools are empty", () => {
+    const grid = build({
+      getSimilars: (k) => (k === "T" ? ["R1", "R2"] : []),
+      randomPool: Array.from({ length: 20 }, (_, i) => `P${i + 1}`),
+    });
+
+    expect(grid).toHaveLength(CANDIDATE_COUNT);
+    expect(grid).toEqual(expect.arrayContaining(["T", "R1", "R2"]));
+    expect(new Set(grid).size).toBe(CANDIDATE_COUNT);
+  });
+
+  it("drops candidates that fail the real-kanji check", () => {
+    const grid = build({
+      modelGuesses: ["not-real", "M1"],
+      isRealKanji: (k) => k !== "not-real",
+      randomPool: ["P1", "P2"],
+    });
+
+    expect(grid).not.toContain("not-real");
+    expect(grid).toEqual(expect.arrayContaining(["T", "M1"]));
+  });
+
+  it("always force-includes the target even if it fails the real-kanji check", () => {
+    const grid = build({ isRealKanji: () => false, randomPool: ["P1"] });
+    expect(grid).toContain("T");
+  });
+});

--- a/src/components/production-practice-v1/build-candidates.ts
+++ b/src/components/production-practice-v1/build-candidates.ts
@@ -1,5 +1,9 @@
 import { isKanji, shuffle } from "@/lib/utils";
-import { CANDIDATE_COUNT } from "./constants";
+import {
+  CANDIDATE_COUNT,
+  MODEL_SEED_COUNT,
+  SIMILAR_SEED_COUNT,
+} from "./constants";
 
 /**
  * Build a 12-kanji look-alike grid (always 4×3).
@@ -7,10 +11,11 @@ import { CANDIDATE_COUNT } from "./constants";
  *
  * Fill order before shuffle:
  *   1. target (always)
- *   2. seed — model guesses if in top 10, else database similars
- *   3. secondary — the other of those two
- *   4. related — similars of the model guesses / similars (lookalike neighbors)
- *   5. random deck — last resort only
+ *   2. up to MODEL_SEED_COUNT distinct recognizer top guesses
+ *   3. up to SIMILAR_SEED_COUNT distinct database similars of the target
+ *   4. overflow of either pool beyond its quota (whichever ran short)
+ *   5. related — similars of the model guesses / similars (lookalike neighbors)
+ *   6. random deck — last resort only
  *
  * Hard rule: only real kanji — no hiragana, katakana, or radicals-only glyphs.
  * Pass `isRealKanji` that checks kanji_main (e.g. `info?.jlpt != null`), not
@@ -18,7 +23,6 @@ import { CANDIDATE_COUNT } from "./constants";
  */
 export const buildCandidateGrid = ({
   target,
-  inTop10,
   modelGuesses,
   similars,
   randomPool,
@@ -26,7 +30,6 @@ export const buildCandidateGrid = ({
   isRealKanji = defaultIsRealKanji,
 }: {
   target: string;
-  inTop10: boolean;
   modelGuesses: string[];
   similars: string[];
   randomPool: string[];
@@ -40,21 +43,10 @@ export const buildCandidateGrid = ({
     getSimilars
   );
 
-  if (inTop10) {
-    return padCandidates(
-      modelGuesses,
-      target,
-      similars,
-      related,
-      randomPool,
-      isRealKanji
-    );
-  }
-
   return padCandidates(
+    modelGuesses,
     similars,
     target,
-    modelGuesses,
     related,
     randomPool,
     isRealKanji
@@ -84,9 +76,9 @@ const expandRelated = (
 };
 
 const padCandidates = (
-  seed: string[],
+  modelGuesses: string[],
+  similars: string[],
   target: string,
-  secondary: string[],
   related: string[],
   filler: string[],
   isRealKanji: (k: string) => boolean
@@ -101,9 +93,26 @@ const padCandidates = (
     out.push(k);
   };
 
+  // Fills at most `quota` *new* entries from `pool`, in order — duplicates
+  // (e.g. the target already sitting at rank 0) don't consume the quota.
+  const pushQuota = (pool: string[], quota: number) => {
+    let added = 0;
+    for (const k of pool) {
+      if (added >= quota) break;
+      const before = out.length;
+      push(k);
+      if (out.length > before) added++;
+    }
+  };
+
   push(target, true);
-  for (const k of seed) push(k);
-  for (const k of secondary) push(k);
+  pushQuota(modelGuesses, MODEL_SEED_COUNT);
+  pushQuota(similars, SIMILAR_SEED_COUNT);
+
+  // Backfill with whatever quota-limited entries didn't make the cut above
+  // (covers the case where one pool ran short of its quota).
+  for (const k of modelGuesses) push(k);
+  for (const k of similars) push(k);
   for (const k of related) push(k);
   for (const k of filler) push(k);
 

--- a/src/components/production-practice-v1/constants.ts
+++ b/src/components/production-practice-v1/constants.ts
@@ -7,6 +7,10 @@ import { ProductionPracticeSettings } from "./types";
 export const SESSION_SIZE = PRACTICE_SESSION_SIZE;
 /** Look-alike grid size: always 4×3. */
 export const CANDIDATE_COUNT = 12;
+/** Fixed distractor split (target takes the 12th slot): db similars... */
+export const SIMILAR_SEED_COUNT = 6;
+/** ...and recognizer top guesses fill the rest. */
+export const MODEL_SEED_COUNT = CANDIDATE_COUNT - 1 - SIMILAR_SEED_COUNT;
 /** Ranks that count as “in top 10” for session scoring. */
 export const GRADE_TOP_K = 10;
 /**

--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -66,10 +66,9 @@ export const KanjiDetailsBottom = ({ kanji }: { kanji: string }) => {
         text-to-speech, which may not work in some devices.
       </p>
       <p className="text-xs text-left">
-        {"⚠️"} We strive for accuracy, but mistakes can happen. If you find a
-        content issue, please report it{" "}
+        {"⚠️"} We strive for accuracy, but mistakes can happen. Found a content
+        issue? Report it{" "}
         <ExternalTextLink href={outLinks.githubContentIssue} text="here" /> 🐞🐛
-        . Always verify important information with official sources.
       </p>
 
       <BottomBar includeNode={<KanjiKeyboardShortcuts kanji={kanji} />} />

--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -66,7 +66,7 @@ export const KanjiDetailsBottom = ({ kanji }: { kanji: string }) => {
         text-to-speech, which may not work in some devices.
       </p>
       <p className="text-xs text-left">
-        {"⚠️"} We strive for accuracy, but mistakes can happen. If you find an
+        {"⚠️"} We strive for accuracy, but mistakes can happen. If you find a
         content issue, please report it{" "}
         <ExternalTextLink href={outLinks.githubContentIssue} text="here" /> 🐞🐛
         . Always verify important information with official sources.


### PR DESCRIPTION
Previously the look-alike grid was seeded entirely from one source
(recognizer guesses when the model got it right, otherwise db similars),
so curated similar-kanji distractors could be crowded out completely on
correct recognitions. Now every card reserves 6 slots for db similars and
5 for recognizer guesses (plus the target), falling back to overflow,
expanded lookalikes, then random deck kanji when a pool runs short.