### PR TITLE
Sept 2 polishing: practice UX, stroke settings, and UI cleanup

### DIFF
--- a/.cursor/rules/concise-answers.mdc
+++ b/.cursor/rules/concise-answers.mdc
@@ -1,0 +1,12 @@
+---
+description: Keep chat answers concise
+alwaysApply: true
+---
+
+# Concise answers
+
+Prefer short replies. Lead with the answer, then only the details that change a decision.
+
+- Skip recap of the question, long preambles, and exhaustive tables unless asked
+- Do not restate code or file lists the user already has
+- Use bullets over paragraphs; stop when the next sentence would be filler

--- a/.cursor/rules/inline-tailwind-classes.mdc
+++ b/.cursor/rules/inline-tailwind-classes.mdc
@@ -1,0 +1,26 @@
+---
+description: Colocate Tailwind className strings; do not extract _CN unless reused
+alwaysApply: true
+---
+
+# Inline Tailwind classes
+
+Do **not** extract Tailwind `className` strings into `_CN` (or similar) constants unless the **same** string is reused in multiple places.
+
+Colocate classes on the JSX / `className` (or the one function that returns them).
+
+```tsx
+// ❌ BAD — used only once
+const SHEET_CLOSE_BTN_CN = "p-4 border-2 border-dashed rounded-xl bg-background";
+<Button className={`${SHEET_CLOSE_BTN_CN} z-1000!`} />
+
+// ✅ GOOD — inline
+<Button className="p-4 border-2 border-dashed rounded-xl bg-background z-1000!" />
+
+// ✅ OK — shared across call sites, or the same token twice (classList add/remove)
+const SETTLE_CN = "animate-scroll-lock-settle";
+el.classList.remove(SETTLE_CN);
+el.classList.add(SETTLE_CN);
+```
+
+Reuse includes two uses in the same file. Do not duplicate the string just to “colocate.”

--- a/.cursor/rules/react-single-responsibility-screens.mdc
+++ b/.cursor/rules/react-single-responsibility-screens.mdc
@@ -24,20 +24,31 @@ export const ModelErrorScreen = ({ variant, ... }) => {
 
 ## 2. Parent phase routing → early returns
 
-In the parent that chooses which screen to show, prefer a **linear early-return chain** (or `renderPhase()` that returns once). Do not stack `{phase === … && …}` blocks in one JSX tree.
+In the component that chooses which screen to show, use a **linear early-return chain** as that component’s body. Wrap it with the layout shell **at the call site**. Do not hide the chain in `renderPhase()` (or similar) and invoke it inside the shell.
+
+Do not stack `{phase === … && …}` blocks in one JSX tree.
 
 ```tsx
-// ❌ BAD
-return (
-  <Shell>
-    {phase === "initial" && <InitialScreen />}
-    {phase === "loading" && <ModelLoadingScreen />}
-    {phase === "error" && <ModelError… />}
-  </Shell>
-);
+// ❌ BAD — inner render helper, shell wraps the call
+const MyComponent = () => {
+  const renderPhase = () => {
+    if (phase === "initial") return <InitialScreen … />;
+    if (phase === "loading-dakanji") return <ModelLoadingScreen message="…" />;
+    if (phase === "loading-backup") return <ModelLoadingScreen message="…" />;
+    if (phase === "error-lighter") return <ModelErrorLighterRecognizer … />;
+    if (phase === "error-none") return <ModelErrorNoRecognizer … />;
+    if (phase === "playing") return <Game … />;
+    if (phase === "ended") return <EndSession … />;
+    return null;
+  };
 
-// ✅ GOOD
-const renderPhase = () => {
+  return <Shell>{renderPhase()}</Shell>;
+};
+
+<MyComponent />;
+
+// ✅ GOOD — early returns are the component; shell wraps at the call site
+const MyComponent = () => {
   if (phase === "initial") return <InitialScreen … />;
   if (phase === "loading-dakanji") return <ModelLoadingScreen message="…" />;
   if (phase === "loading-backup") return <ModelLoadingScreen message="…" />;
@@ -48,7 +59,9 @@ const renderPhase = () => {
   return null;
 };
 
-return <Shell>{renderPhase()}</Shell>;
+<Shell>
+  <MyComponent />
+</Shell>;
 ```
 
 Prefer flat phase/status values that map 1:1 to screens (`loading-dakanji`, `error-lighter`) over nested `{ status, variant, tryingBackup }` when it keeps the if-chain readable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ The source of truth is `.cursor/rules/*.mdc` (auto-applied by Cursor). Follow th
 - React hooks: avoid `useEffect`, `useMemo`, `useCallback`, and `forwardRef` unless truly necessary and there is no simpler way; if you must use one, add a short comment explaining why. Prefer deriving values during render. See `avoid-react-effect-memo-callback-forwardref.mdc`.
 - Single responsibility: one screen → one component (no `variant` enums stuffed into a "god" screen); route phases with a linear early-return chain in that component’s body (wrap with the layout shell at the call site; do not use `renderPhase()`). Prefer early exits in conditionals generally. See `react-single-responsibility-screens.mdc`.
 - Formatting: run Prettier on the exact files you edit (`pnpm exec prettier --write <paths>`); do not run a full-repo format unless asked. Match `.prettierrc.json`. See `prettier-format.mdc`.
+- Tailwind: colocate `className` strings; do not extract `_CN` (or similar) constants unless the same string is reused in multiple places. See `inline-tailwind-classes.mdc`.
 
 ## Cursor Cloud specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ The source of truth is `.cursor/rules/*.mdc` (auto-applied by Cursor). Follow th
 
 - Tests: do NOT add or change automated tests unless the user explicitly asks. See `tests-only-when-asked.mdc`.
 - React hooks: avoid `useEffect`, `useMemo`, `useCallback`, and `forwardRef` unless truly necessary and there is no simpler way; if you must use one, add a short comment explaining why. Prefer deriving values during render. See `avoid-react-effect-memo-callback-forwardref.mdc`.
-- Single responsibility: one screen → one component (no `variant` enums stuffed into a "god" screen); route phases with a linear early-return chain rather than stacked `{phase === … && …}` blocks. Prefer early exits in conditionals generally. See `react-single-responsibility-screens.mdc`.
+- Single responsibility: one screen → one component (no `variant` enums stuffed into a "god" screen); route phases with a linear early-return chain in that component’s body (wrap with the layout shell at the call site; do not use `renderPhase()`). Prefer early exits in conditionals generally. See `react-single-responsibility-screens.mdc`.
 - Formatting: run Prettier on the exact files you edit (`pnpm exec prettier --write <paths>`); do not run a full-repo format unless asked. Match `.prettierrc.json`. See `prettier-format.mdc`.
 
 ## Cursor Cloud specific instructions

--- a/e2e/practice.spec.ts
+++ b/e2e/practice.spec.ts
@@ -150,14 +150,10 @@ test.describe("practice modes", () => {
     await expect(
       page.getByRole("heading", { name: "Recognition unavailable" })
     ).toBeVisible({ timeout: 30_000 });
-    await expect(
-      page.getByRole("button", { name: "Continue without recognition" })
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
 
-    await page
-      .getByRole("button", { name: "Continue without recognition" })
-      .click();
+    await page.getByRole("button", { name: "Continue" }).click();
 
     await expect(
       page.getByText("Playing without stroke grading", { exact: false })

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -14,17 +14,12 @@ import {
 export const BOTTOM_SHEET_CHROME_CN =
   "!select-text !duration-200 border-2 border-t-4 [border-top-style:dashed]";
 
-/** Visual style of the floating CircleX close button (shared with the
- * non-drawer loading shell, which needs a plain onClick button). */
-export const SHEET_CLOSE_BTN_CN =
-  "p-4 border-2 border-dashed rounded-xl bg-background";
-
 export const DrawerCloseButton = () => (
   <DrawerClose asChild className="absolute top-2 right-2">
     <Button
       variant="ghost"
       size="icon"
-      className={`${SHEET_CLOSE_BTN_CN} z-1000!`}
+      className="p-4 border-2 border-dashed rounded-xl bg-background z-1000!"
     >
       <CircleX className="size-8" />
     </Button>

--- a/src/components/common/DebugInfo.tsx
+++ b/src/components/common/DebugInfo.tsx
@@ -1,52 +1,40 @@
 import { Wifi, WifiOff, Info } from "lucide-react";
-import { useWindowSize } from "@/hooks/use-window-size";
-import { getUserAgentData } from "@/lib/ua-utils";
-import { useNetworkState } from "@/hooks/use-network-state";
+import { Copy, CheckCircle } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import {
+  formatDebugInfoForClipboard,
+  useDebugInfo,
+  type DebugInfoSnapshot,
+} from "@/hooks/use-debug-info";
 
-declare const __BUILD_TIMESTAMP__: string;
-
-const NetworkStatus = () => {
-  const { online, effectiveType, saveData } = useNetworkState();
-
-  return (
-    <div className="flex items-center gap-1.5">
-      {online ? (
-        <Wifi className="text-green-500 size-3" aria-label="Online" />
-      ) : (
-        <WifiOff
-          className="size-3 text-muted-foreground"
-          aria-label="Offline"
-        />
-      )}
-      <span className={online ? "text-green-500" : "text-muted-foreground"}>
-        {online ? "online" : "offline"}
-      </span>
-      {effectiveType && <span>{effectiveType}</span>}
-      {saveData && <>{"🐌"}</>}
-    </div>
-  );
-};
-
-const SwVersion = () => <span>v{__BUILD_TIMESTAMP__}</span>;
-
-const WindowDims = () => {
-  const [w, h] = useWindowSize(0);
-  return (
-    <span>
-      {w}×{h}
+const NetworkStatus = ({
+  online,
+  effectiveType,
+  saveData,
+}: Pick<DebugInfoSnapshot, "online" | "effectiveType" | "saveData">) => (
+  <div className="flex items-center gap-1.5">
+    {online ? (
+      <Wifi className="text-green-500 size-3" aria-label="Online" />
+    ) : (
+      <WifiOff className="size-3 text-muted-foreground" aria-label="Offline" />
+    )}
+    <span className={online ? "text-green-500" : "text-muted-foreground"}>
+      {online ? "online" : "offline"}
     </span>
-  );
-};
+    {effectiveType && <span>{effectiveType}</span>}
+    {saveData && <>{"🐌"}</>}
+  </div>
+);
 
-const DeviceSpecs = () => {
-  if (!navigator?.userAgent) return null;
-  const { browser, os, platform } = getUserAgentData(navigator.userAgent);
+const DeviceSpecs = ({ device }: { device: DebugInfoSnapshot["device"] }) => {
+  if (!device) return null;
+  const { browser, os, platform } = device;
   return (
     <div>
       <div>
@@ -59,36 +47,77 @@ const DeviceSpecs = () => {
   );
 };
 
-export const DebugInfo = () => (
-  <Popover>
-    <PopoverTrigger asChild>
-      <Button
-        variant="outline"
-        size="iconXl"
-        className="mr-1"
-        aria-label="Debug info"
-      >
-        <Info className="w-[1.2rem] h-[1.2rem]" />
-      </Button>
-    </PopoverTrigger>
-    <PopoverContent className="w-48 p-4 mr-2" side="top" align="start">
-      <div className="space-y-1 font-mono text-[8px]">
-        <div className="flex items-center justify-between">
-          <span className="text-muted-foreground">Network</span>
-          <NetworkStatus />
+const CopyDebugButton = ({ info }: { info: DebugInfoSnapshot }) => {
+  const { copy, status } = useCopyToClipboard();
+  const copied = status === "copied";
+
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center justify-center transition-colors rounded-md size-6 text-muted-foreground hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      title={copied ? "Copied" : "Copy to clipboard"}
+      aria-label={copied ? "Copied debug info" : "Copy debug info"}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void copy(formatDebugInfoForClipboard(info), e);
+      }}
+    >
+      {copied ? (
+        <CheckCircle className="size-3.5 text-green-500" />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+    </button>
+  );
+};
+
+export const DebugInfo = () => {
+  const info = useDebugInfo();
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="iconXl"
+          className="mr-1"
+          aria-label="Debug info"
+        >
+          <Info className="w-[1.2rem] h-[1.2rem]" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="p-4 mr-2 w-52" side="top" align="start">
+        <div className="space-y-1 font-mono text-[8px]">
+          <div className="flex items-center justify-between mb-3 border-b border-dotted">
+            <span className="text-[10px] uppercase font-medium tracking-wide text-muted-foreground">
+              Debug
+            </span>
+            <CopyDebugButton info={info} />
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Network</span>
+            <NetworkStatus
+              online={info.online}
+              effectiveType={info.effectiveType}
+              saveData={info.saveData}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground">Version</span>
+            <span>v{info.version}</span>
+          </div>
+          <div className="flex items-center justify-between pb-2">
+            <span className="text-muted-foreground">Viewport</span>
+            <span>
+              {info.viewportWidth}×{info.viewportHeight}
+            </span>
+          </div>
+          <div className="pt-2 border-t border-dotted">
+            <DeviceSpecs device={info.device} />
+          </div>
         </div>
-        <div className="flex items-center justify-between">
-          <span className="text-muted-foreground">Version</span>
-          <SwVersion />
-        </div>
-        <div className="flex items-center justify-between pb-2">
-          <span className="text-muted-foreground">Viewport</span>
-          <WindowDims />
-        </div>
-        <div className="pt-2 border-t border-dotted ">
-          <DeviceSpecs />
-        </div>
-      </div>
-    </PopoverContent>
-  </Popover>
-);
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/common/GenericPopover.tsx
+++ b/src/components/common/GenericPopover.tsx
@@ -13,6 +13,7 @@ export const GenericPopover = ({
   content,
   contentClassName = "w-auto p-0 m-0",
   showArrow = true,
+  modal = false,
   open,
   onOpenChange,
 }: {
@@ -21,12 +22,17 @@ export const GenericPopover = ({
   /** Merged over PopoverContent's base classes (w-72 p-4 …). */
   contentClassName?: string;
   showArrow?: boolean;
+  /**
+   * Needed inside Dialog/Drawer: otherwise the portaled content sits outside
+   * the overlay and cannot be clicked.
+   */
+  modal?: boolean;
   /** Pass both for a controlled popover; omit for uncontrolled. */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }) => {
   return (
-    <Popover open={open} onOpenChange={onOpenChange}>
+    <Popover modal={modal} open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent className={contentClassName} collisionPadding={16}>
         {showArrow && <PopoverCardArrow />}

--- a/src/components/common/KanjiDmak.tsx
+++ b/src/components/common/KanjiDmak.tsx
@@ -7,7 +7,9 @@ import { PlayCircle, Snail } from "@/components/icons";
 import { abandonDmak, installSafeDmakLoader } from "@/lib/dmak-safe-loader";
 import { resolveKanjiSvgBaseUri } from "@/lib/kanji-svg-url";
 import { StrokeOrderUnavailable } from "@/components/common/StrokeOrderUnavailable";
-import { AnimationSpeed, SPEEDS } from "./kanji-dmak-speeds";
+import { StrokeAnimationSettingsPopover } from "./StrokeAnimationSettingsPopover";
+import { useStrokeAnimationSettings } from "@/hooks/use-stroke-animation-settings";
+import { AnimationSpeed, dmakStepForSpeed } from "./kanji-dmak-speeds";
 
 // Stock dmak crashes on null kvg: root — install our guarded loader once.
 installSafeDmakLoader();
@@ -16,7 +18,7 @@ type SvgLoadStatus = "loading" | "ready" | "error";
 
 export const KanjiDMAK = ({
   kanji,
-  step = SPEEDS.slow.rate,
+  step,
   size,
   staticMode = false,
   gridShow = true,
@@ -25,7 +27,7 @@ export const KanjiDMAK = ({
   kanji: string;
   step?: number;
   size: number;
-  // when true: draws all strokes instantly with stroke-order numbers visible
+  // when true: draws all strokes instantly
   staticMode?: boolean;
   gridShow?: boolean;
   /** Fired when the SVG becomes unavailable or recovers (e.g. hint blur). */
@@ -36,6 +38,7 @@ export const KanjiDMAK = ({
   const [retryKey, setRetryKey] = useState(0);
   const [status, setStatus] = useState<SvgLoadStatus>("loading");
   const [svgBaseUri, setSvgBaseUri] = useState<string | null>(null);
+  const [{ showStrokeOrderNumbers }] = useStrokeAnimationSettings();
 
   // Needed: probe local/CDN reachability; no render-time API for this.
   useEffect(() => {
@@ -80,7 +83,10 @@ export const KanjiDMAK = ({
             order: { visible: true },
             attr: { stroke: "random" },
           }
-        : { attr: { stroke: "random" } },
+        : {
+            attr: { stroke: "random" },
+            order: { visible: showStrokeOrderNumbers },
+          },
 
       grid: { show: gridShow },
     });
@@ -91,7 +97,17 @@ export const KanjiDMAK = ({
       document.getElementById(kanjiId)?.replaceChildren();
       // Keep window.Raphael set; other KanjiDMAK instances may still need it.
     };
-  }, [status, svgBaseUri, kanji, kanjiId, step, size, staticMode, gridShow]);
+  }, [
+    status,
+    svgBaseUri,
+    kanji,
+    kanjiId,
+    step,
+    size,
+    staticMode,
+    gridShow,
+    showStrokeOrderNumbers,
+  ]);
 
   if (status === "error") {
     return (
@@ -117,53 +133,69 @@ export const StrokeOrderReplay = ({
   replayClassName,
   buttonRowClassName = "flex justify-center space-x-2",
   buttonClassName,
+  showSettings = false,
 }: {
   kanji: string;
   size: number;
   replayClassName?: string;
   buttonRowClassName?: string;
   buttonClassName?: string;
+  showSettings?: boolean;
 }) => {
   const [key, setKey] = useState(1);
   const [speed, setSpeed] = useState<AnimationSpeed>("fast");
   const [unavailable, setUnavailable] = useState(false);
+  const [settings] = useStrokeAnimationSettings();
   const replay = () => setKey((x) => x + 1);
 
   return (
     <>
-      <div
-        role="button"
-        tabIndex={unavailable ? -1 : 0}
-        title={unavailable ? undefined : "Replay stroke order"}
-        aria-disabled={unavailable || undefined}
-        className={
-          replayClassName
-            ? `${replayClassName} ${unavailable ? "" : "cursor-pointer"}`
-            : unavailable
-              ? undefined
-              : "cursor-pointer"
-        }
-        style={{ height: size }}
-        onClick={unavailable ? undefined : replay}
-        onKeyDown={
-          unavailable
-            ? undefined
-            : (e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  replay();
-                }
-              }
-        }
-      >
-        {/** key needed to redraw on change  */}
-        <div key={`${kanji}-${speed}-${key}`}>
-          <KanjiDMAK
-            kanji={kanji}
-            step={SPEEDS[speed].rate}
-            size={size}
-            onUnavailableChange={setUnavailable}
+      <div className={replayClassName} style={{ height: size }}>
+        {/* Overlay border so dotted stroke doesn't change the box's layout size. */}
+        <div
+          className="relative overflow-hidden rounded-3xl"
+          style={{ width: size, height: size }}
+        >
+          <div
+            role="button"
+            tabIndex={unavailable ? -1 : 0}
+            title={unavailable ? undefined : "Replay stroke order"}
+            aria-disabled={unavailable || undefined}
+            className={unavailable ? undefined : "cursor-pointer"}
+            style={{ width: size, height: size }}
+            onClick={unavailable ? undefined : replay}
+            onKeyDown={
+              unavailable
+                ? undefined
+                : (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      replay();
+                    }
+                  }
+            }
+          >
+            {/** key needed to redraw on change  */}
+            <div
+              key={`${kanji}-${speed}-${key}-${settings.fastSpeed}-${settings.slowSpeed}-${settings.showStrokeOrderNumbers}`}
+            >
+              <KanjiDMAK
+                kanji={kanji}
+                step={dmakStepForSpeed(speed, settings)}
+                size={size}
+                onUnavailableChange={setUnavailable}
+              />
+            </div>
+          </div>
+          <div
+            aria-hidden
+            className="absolute inset-0 border-2 border-dotted pointer-events-none rounded-3xl border-foreground"
           />
+          {showSettings && (
+            <div className="absolute z-10 top-3 left-3">
+              <StrokeAnimationSettingsPopover />
+            </div>
+          )}
         </div>
       </div>
       <div className={buttonRowClassName}>

--- a/src/components/common/RefreshPageBtn.tsx
+++ b/src/components/common/RefreshPageBtn.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useNetworkState } from "@/hooks/use-network-state";
+import { forceHardRefresh } from "@/lib/force-hard-refresh";
 import { cn } from "@/lib/utils";
 import { RefreshCw } from "lucide-react";
 
@@ -26,7 +27,7 @@ export const RefreshPageBtn = ({ cnOverride }: { cnOverride?: string }) => {
             setOfflineHintKey((key) => key + 1);
             return;
           }
-          window.location.reload();
+          void forceHardRefresh();
         }}
         aria-label="Refresh page"
       >

--- a/src/components/common/StrokeAnimationSettingsFields.tsx
+++ b/src/components/common/StrokeAnimationSettingsFields.tsx
@@ -1,0 +1,128 @@
+import { useId, type ReactNode } from "react";
+import { PlayCircle, Snail } from "@/components/icons";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { useStrokeAnimationSettings } from "@/hooks/use-stroke-animation-settings";
+import {
+  DEFAULT_STROKE_ANIMATION_SETTINGS,
+  FAST_SPEED_MAX,
+  FAST_SPEED_MIN,
+  SLOW_SPEED_MAX,
+  SLOW_SPEED_MIN,
+  SPEED_STEP,
+} from "@/lib/stroke-animation-settings";
+import { Button } from "@/components/ui/button";
+
+const formatSpeed = (n: number) => `${n.toFixed(1)}×`;
+
+const SpeedSliderRow = ({
+  id,
+  icon,
+  label,
+  value,
+  min,
+  max,
+  onChange,
+}: {
+  id: string;
+  icon: ReactNode;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (value: number) => void;
+}) => (
+  <div className="space-y-2">
+    <div className="flex items-center justify-between gap-3">
+      <Label
+        htmlFor={id}
+        className="flex items-center gap-1.5 text-xs font-bold"
+      >
+        <span className="flex size-6 items-center justify-center rounded-md bg-secondary text-foreground [&_svg]:size-3.5">
+          {icon}
+        </span>
+        {label}
+      </Label>
+      <span className="text-xs font-bold tabular-nums text-muted-foreground">
+        {formatSpeed(value)}
+      </span>
+    </div>
+    <Slider
+      id={id}
+      min={min}
+      max={max}
+      step={SPEED_STEP}
+      value={[value]}
+      onValueChange={([next]) => {
+        if (next != null) onChange(next);
+      }}
+      aria-label={label}
+    />
+    <div className="flex justify-between text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      <span>{formatSpeed(min)}</span>
+      <span>{formatSpeed(max)}</span>
+    </div>
+  </div>
+);
+
+export const StrokeAnimationSettingsFields = () => {
+  const [settings, setSetting, reset] = useStrokeAnimationSettings();
+  const numbersId = useId();
+  const slowId = useId();
+  const fastId = useId();
+  const isDefault =
+    settings.showStrokeOrderNumbers ===
+      DEFAULT_STROKE_ANIMATION_SETTINGS.showStrokeOrderNumbers &&
+    settings.slowSpeed === DEFAULT_STROKE_ANIMATION_SETTINGS.slowSpeed &&
+    settings.fastSpeed === DEFAULT_STROKE_ANIMATION_SETTINGS.fastSpeed;
+
+  return (
+    <div className="space-y-6 text-left">
+      <div className="flex items-center gap-2">
+        <Switch
+          id={numbersId}
+          checked={settings.showStrokeOrderNumbers}
+          onCheckedChange={(checked) =>
+            setSetting("showStrokeOrderNumbers", checked)
+          }
+        />
+
+        <Label htmlFor={numbersId} className="text-xs font-bold cursor-pointer">
+          Show stroke order numbers
+        </Label>
+      </div>
+
+      <SpeedSliderRow
+        id={slowId}
+        icon={<Snail />}
+        label="Slow Speed"
+        value={settings.slowSpeed}
+        min={SLOW_SPEED_MIN}
+        max={SLOW_SPEED_MAX}
+        onChange={(value) => setSetting("slowSpeed", value)}
+      />
+
+      <SpeedSliderRow
+        id={fastId}
+        icon={<PlayCircle />}
+        label="Default Speed"
+        value={settings.fastSpeed}
+        min={FAST_SPEED_MIN}
+        max={FAST_SPEED_MAX}
+        onChange={(value) => setSetting("fastSpeed", value)}
+      />
+
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        className="w-full text-xs font-bold"
+        disabled={isDefault}
+        onClick={reset}
+      >
+        Reset to defaults
+      </Button>
+    </div>
+  );
+};

--- a/src/components/common/StrokeAnimationSettingsPopover.tsx
+++ b/src/components/common/StrokeAnimationSettingsPopover.tsx
@@ -1,0 +1,31 @@
+import { Settings } from "lucide-react";
+import { GenericPopover } from "@/components/common/GenericPopover";
+import { StrokeAnimationSettingsFields } from "@/components/common/StrokeAnimationSettingsFields";
+import { Button } from "@/components/ui/button";
+
+export const StrokeAnimationSettingsPopover = () => (
+  <GenericPopover
+    modal={true}
+    showArrow
+    contentClassName="z-[60] w-[min(100vw-2rem,20rem)] p-0"
+    trigger={
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="p-4 border-2 border-dashed rounded-xl bg-background"
+        aria-label="Stroke order animation settings"
+      >
+        <Settings className="size-8" />
+      </Button>
+    }
+    content={
+      <div className="p-4 space-y-3">
+        <div className="pb-1 mb-4 text-xs font-extrabold tracking-widest uppercase border-b text-muted-foreground">
+          Stroke animation
+        </div>
+        <StrokeAnimationSettingsFields />
+      </div>
+    }
+  />
+);

--- a/src/components/common/VocabActions.tsx
+++ b/src/components/common/VocabActions.tsx
@@ -30,10 +30,10 @@ export const VocabActions = ({
   return (
     <div className="relative flex flex-wrap items-center justify-center p-2 space-x-1">
       <BugIconErrorBoundary>
-        <JishoBtn word={word} />
+        <JotobaBtn word={word} />
       </BugIconErrorBoundary>
       <BugIconErrorBoundary>
-        <JotobaBtn word={word} />
+        <JishoBtn word={word} />
       </BugIconErrorBoundary>
       <SpeakButton word={word} iconType="volume-2" />
       {kana.length > 0 && <SpeakButton word={kana} iconType={"audio-lines"} />}

--- a/src/components/common/VocabPopoverContent.tsx
+++ b/src/components/common/VocabPopoverContent.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { DottedSeparator } from "@/components/ui/dotted-separator";
 import { ExternalTextLink } from "@/components/common/ExternalTextLink";
 import { SeeMore } from "@/components/common/SeeMore";
@@ -21,6 +21,14 @@ export const VocabPopoverContent = ({
   definition,
   optionalSection,
 }: VocabPopoverContentProps) => {
+  const [showAllLinks, setShowAllLinks] = useState(false);
+  const maxLinks = 6;
+  const canSeeAllLinks = vocabExternalLinks.length <= maxLinks;
+  const visibleLinks =
+    canSeeAllLinks || showAllLinks
+      ? vocabExternalLinks
+      : vocabExternalLinks.slice(0, maxLinks);
+
   return (
     <div className="p-2 w-72">
       {wordKanjis.length > 0 && (
@@ -58,13 +66,23 @@ export const VocabPopoverContent = ({
         🧐 Explore this word further →
       </div>
       <div className="flex flex-wrap justify-center px-2 pb-2 text-xs">
-        {vocabExternalLinks.map((item) => (
+        {visibleLinks.map((item) => (
           <ExternalTextLink
             key={item.name}
             href={item.url(word)}
             text={item.name}
           />
         ))}
+        {!canSeeAllLinks && (
+          <button
+            className="mx-2 my-1 font-bold underline"
+            onClick={() => {
+              setShowAllLinks((prev) => !prev);
+            }}
+          >
+            {showAllLinks ? <>See less</> : <>See more</>}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/common/jlpt/JLPTBadge.tsx
+++ b/src/components/common/jlpt/JLPTBadge.tsx
@@ -1,6 +1,7 @@
 import { JLPTListItems, JLTPTtypes } from "@/lib/jlpt";
 import { GenericPopover } from "../GenericPopover";
 import { ExternalTextLink } from "../ExternalTextLink";
+import { otherOutLinks } from "@/lib/external-links";
 
 export const JLPTBadge = ({ jlpt }: { jlpt: JLTPTtypes }) => {
   return (
@@ -18,7 +19,10 @@ export const JLPTBadge = ({ jlpt }: { jlpt: JLTPTtypes }) => {
           content={
             <div className="w-64 px-4 py-3 text-xs">
               The <strong>Japanese‑Language Proficiency Test</strong>
-              <ExternalTextLink href="https://jlpt.jp" text="(jlpt.jp)" />{" "}
+              <ExternalTextLink
+                href={otherOutLinks.jlpt}
+                text="(jlpt.jp)"
+              />{" "}
               certifies non‑native speakers’ Japanese skills across five levels.{" "}
               <em>(N5 easiest → N1 hardest)</em>
             </div>

--- a/src/components/common/kanji-dmak-speeds.ts
+++ b/src/components/common/kanji-dmak-speeds.ts
@@ -4,3 +4,12 @@ export const SPEEDS: Record<AnimationSpeed, { rate: number }> = {
   fast: { rate: 0.0095 },
   slow: { rate: 0.022 },
 };
+
+/** DMAK `step` — higher is slower. Speed factors divide the base rate. */
+export const dmakStepForSpeed = (
+  speed: AnimationSpeed,
+  settings: { slowSpeed: number; fastSpeed: number }
+) => {
+  const factor = speed === "fast" ? settings.fastSpeed : settings.slowSpeed;
+  return SPEEDS[speed].rate / factor;
+};

--- a/src/components/dependent/DrawingPad.tsx
+++ b/src/components/dependent/DrawingPad.tsx
@@ -26,6 +26,7 @@ export const DrawingPad = ({
   showForgotBtn = false,
   onClickForgot,
   forgotDisabled = false,
+  overlay,
 }: {
   svgSize: number;
   // Optional controlled strokes. When provided, the parent owns the strokes
@@ -43,6 +44,8 @@ export const DrawingPad = ({
   showForgotBtn?: boolean;
   onClickForgot?: () => void;
   forgotDisabled?: boolean;
+  /** Rendered over the pad square (e.g. a short-viewport grade banner). */
+  overlay?: ReactNode;
 }) => {
   const [internalStrokes, setInternalStrokes] = useState<Stroke[]>([]);
   const strokes = controlledStrokes ?? internalStrokes;
@@ -126,6 +129,7 @@ export const DrawingPad = ({
     <div className="flex flex-col items-center gap-2 mx-auto my-2 sm:m-4">
       <div
         ref={wrapperRef}
+        className="relative"
         style={{ touchAction: "none", lineHeight: 0 }}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
@@ -198,6 +202,7 @@ export const DrawingPad = ({
               ) : null;
             })()}
         </svg>
+        {overlay}
       </div>
       <div className="flex justify-center mt-2 space-x-2">
         {showForgotBtn && (

--- a/src/components/dependent/site-wide/KanjiActionBtns.tsx
+++ b/src/components/dependent/site-wide/KanjiActionBtns.tsx
@@ -1,6 +1,7 @@
 import { CopyButton } from "@/components/common/CopyButton";
 import { SpeakButton } from "@/components/common/SpeakButton";
 import { URL_PARAMS } from "@/lib/settings/url-params";
+import { outLinks } from "@/lib/external-links";
 import ChangeFontButton from "./ChangeFontButton";
 import { DotIcon } from "../../icons";
 import { NextPrevLinks } from "../routing/NextPrevLinks";
@@ -15,7 +16,7 @@ export const KanjiActionsBtns = ({ kanji }: { kanji: string }) => {
         </div>
         <DotIcon className="w-3 m-0" />
         <CopyButton
-          textToCopy={`https://kanjiheatmap.com/?${URL_PARAMS.openKanji}=${kanji}`}
+          textToCopy={`${outLinks.site}/?${URL_PARAMS.openKanji}=${kanji}`}
           iconType="link"
         />
         <CopyButton textToCopy={kanji} iconType="clipboard" />

--- a/src/components/dependent/site-wide/SettingsModal.tsx
+++ b/src/components/dependent/site-wide/SettingsModal.tsx
@@ -31,6 +31,7 @@ import { DEFAULT_JP_VOICE_ID, findJpVoice, TTS_DISCLAIMER } from "@/lib/tts";
 import { cn } from "@/lib/utils";
 import { SpeakButton } from "@/components/common/SpeakButton";
 import { Settings } from "lucide-react";
+import { StrokeAnimationSettingsFields } from "@/components/common/StrokeAnimationSettingsFields";
 
 // Names line up with the active `:root` block in src/JFonts.css (jap-font-0..14).
 const FONT_NAMES = [
@@ -52,7 +53,7 @@ const FONT_NAMES = [
 ];
 
 const sectionHeadingCn =
-  "mb-3  border-b-2 border-dotted text-xs font-extrabold uppercase tracking-widest text-muted-foreground text-left";
+  "mb-3 mt-6 border-b-2 border-dotted text-xs font-extrabold uppercase tracking-widest text-muted-foreground text-left";
 
 type PreloadProgress = { done: number; total: number } | null;
 type CancelFn = () => void;
@@ -314,7 +315,7 @@ export const SettingsModal = () => {
       <ScrollableDialogContent
         size="md"
         title="User Preferences"
-        description="Offline data caching and presentation preferences"
+        description="Offline data caching, stroke animation, and presentation preferences"
         titleClassName="text-left"
       >
         <section>
@@ -335,7 +336,7 @@ export const SettingsModal = () => {
           />
         </section>
 
-        <section>
+        <section className="mt-6">
           <h3 className={sectionHeadingCn}>Presentation</h3>
 
           <div className="mb-4 text-left">
@@ -361,6 +362,14 @@ export const SettingsModal = () => {
           </div>
 
           <LightDarkRow />
+
+          <section className="mt-6">
+            <h3 className={sectionHeadingCn}>Stroke order</h3>
+            <p className="mb-3 text-xs text-left text-muted-foreground">
+              Used for kanji details, writing practice, and production practice.
+            </p>
+            <StrokeAnimationSettingsFields />
+          </section>
         </section>
       </ScrollableDialogContent>
     </Dialog>

--- a/src/components/dependent/site-wide/SettingsModal.tsx
+++ b/src/components/dependent/site-wide/SettingsModal.tsx
@@ -1,12 +1,6 @@
 import { useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { Dialog, DialogTrigger } from "@/components/ui/dialog";
+import { ScrollableDialogContent } from "@/components/ui/scrollable-dialog-content";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Progress } from "@/components/ui/progress";
@@ -299,14 +293,12 @@ export const SettingsModal = () => {
           <Settings className="w-[1.2rem] h-[1.2rem]" />
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[90dvh] max-w-md overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="text-left">User Preferences</DialogTitle>
-          <DialogDescription className="sr-only">
-            Offline data caching and presentation preferences
-          </DialogDescription>
-        </DialogHeader>
-
+      <ScrollableDialogContent
+        size="md"
+        title="User Preferences"
+        description="Offline data caching and presentation preferences"
+        titleClassName="text-left"
+      >
         <section>
           <h3 className={sectionHeadingCn}>Data</h3>
           <DataDownloadRow
@@ -354,7 +346,7 @@ export const SettingsModal = () => {
 
           <LightDarkRow />
         </section>
-      </DialogContent>
+      </ScrollableDialogContent>
     </Dialog>
   );
 };

--- a/src/components/dependent/site-wide/SettingsModal.tsx
+++ b/src/components/dependent/site-wide/SettingsModal.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Trash2, Download, Loader2 } from "@/components/icons";
+import { Trash2, Download, Loader2, CircleX } from "@/components/icons";
 import { useLocalStorageFlag } from "@/hooks/use-local-storage";
 import { useTheme } from "@/providers/theme-hooks";
 import { useCurrentFont } from "@/hooks/use-change-font";
@@ -60,14 +60,12 @@ type CancelFn = () => void;
 const DataDownloadRow = ({
   label,
   sizeHint,
-  enabledKey,
   completeKey,
   startPreload,
   clearCache,
 }: {
   label: string;
   sizeHint: string;
-  enabledKey: string;
   completeKey: string;
   startPreload: (onProgress: (done: number, total: number) => void) => {
     promise: Promise<void>;
@@ -75,42 +73,43 @@ const DataDownloadRow = ({
   };
   clearCache: () => Promise<void>;
 }) => {
-  const [enabled, setEnabled] = useLocalStorageFlag(enabledKey);
   const [complete, setComplete] = useLocalStorageFlag(completeKey);
   const [progress, setProgress] = useState<PreloadProgress>(null);
   const [cancelFn, setCancelFn] = useState<CancelFn | null>(null);
 
   const isRunning = progress !== null && !complete;
 
-  const handleToggle = (next: boolean) => {
-    setEnabled(next);
-
-    if (!next) {
-      cancelFn?.();
-      setCancelFn(null);
-      setProgress(null);
-      return;
-    }
-
-    if (complete) return;
+  const handleDownload = () => {
+    if (complete || isRunning) return;
 
     setProgress({ done: 0, total: 0 });
     const { promise, cancel } = startPreload((done, total) =>
       setProgress({ done, total })
     );
-    setCancelFn(() => cancel);
+
+    let cancelled = false;
+    setCancelFn(() => () => {
+      cancelled = true;
+      cancel();
+    });
     promise.then(() => {
+      if (cancelled) return;
       setComplete(true);
       setProgress(null);
       setCancelFn(null);
     });
   };
 
+  const handleCancel = () => {
+    cancelFn?.();
+    setCancelFn(null);
+    setProgress(null);
+  };
+
   const handleClear = async () => {
     cancelFn?.();
     setCancelFn(null);
     setProgress(null);
-    setEnabled(false);
     setComplete(false);
     await clearCache();
   };
@@ -128,20 +127,39 @@ const DataDownloadRow = ({
           <span className="text-xs text-muted-foreground">{sizeHint}</span>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 px-2"
-            onClick={handleClear}
-            aria-label={`Clear ${label} cache`}
-          >
-            <Trash2 className="size-4" />
-          </Button>
-          <Switch
-            checked={enabled}
-            onCheckedChange={handleToggle}
-            aria-label={`Toggle ${label}`}
-          />
+          {complete && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2"
+              onClick={handleClear}
+              aria-label={`Clear ${label} cache`}
+            >
+              <Trash2 className="size-4" />
+            </Button>
+          )}
+          {!complete &&
+            (isRunning ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2"
+                onClick={handleCancel}
+                aria-label={`Cancel ${label}`}
+              >
+                <CircleX className="size-4" />
+              </Button>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2"
+                onClick={handleDownload}
+                aria-label={label}
+              >
+                <Download className="size-4" />
+              </Button>
+            ))}
         </div>
       </div>
 
@@ -304,7 +322,6 @@ export const SettingsModal = () => {
           <DataDownloadRow
             label="Download Kanji SVGs"
             sizeHint="~16 MB · stroke order for ~2000 kanji"
-            enabledKey="svg-preload-enabled"
             completeKey="svg-preload-complete"
             startPreload={preloadKanjiSvgs}
             clearCache={clearKanjiSvgCache}
@@ -312,7 +329,6 @@ export const SettingsModal = () => {
           <DataDownloadRow
             label="Download Katakana Challenges"
             sizeHint="~1 MB · 10,000 speed katakana words"
-            enabledKey="katakana-preload-enabled"
             completeKey="katakana-preload-complete"
             startPreload={preloadKatakanaChallenges}
             clearCache={clearKatakanaCache}

--- a/src/components/error/common.tsx
+++ b/src/components/error/common.tsx
@@ -3,6 +3,7 @@ import { ExternalTextLink } from "@/components/common/ExternalTextLink";
 import { LinksOutItems } from "@/components/common/LinksOutItems";
 import { cnTextLink } from "@/lib/generic-cn";
 import { outLinks } from "@/lib/external-links";
+import { forceHardRefresh } from "@/lib/force-hard-refresh";
 import { cn } from "@/lib/utils";
 import { RefreshPageBtn } from "../common/RefreshPageBtn";
 import { DebugInfo } from "../common/DebugInfo";
@@ -28,7 +29,7 @@ export const SayHiReportOrRefresh = () => {
         type="button"
         className={`${cnTextLink} px-0.5 py-0`}
         onClick={() => {
-          window?.location.reload();
+          void forceHardRefresh();
         }}
       >
         refresh

--- a/src/components/production-practice-v1/ClozeWord.tsx
+++ b/src/components/production-practice-v1/ClozeWord.tsx
@@ -40,7 +40,7 @@ export const ClozeWord = ({
         <span className="mx-0.5">{kanji}</span>
       ) : (
         <span
-          className="inline-flex items-center romaji-font justify-center mx-1 min-w-[1.25em] px-2  border-2 border-dotted rounded-xl border-foreground/70 align-middle"
+          className="inline-flex items-center justify-center mx-1 min-w-[1.25em] pb-4 pt-2 border-2 border-dotted rounded-xl border-foreground/70 align-middle"
           aria-label="missing kanji"
         >
           ?

--- a/src/components/production-practice-v1/ModelErrorNoRecognizer.tsx
+++ b/src/components/production-practice-v1/ModelErrorNoRecognizer.tsx
@@ -12,7 +12,7 @@ export const ModelErrorNoRecognizer = ({
   <ModelErrorShell
     title="Recognition unavailable"
     description="Neither handwriting recognizer could start. You can still practice — pick the correct kanji after each drawing, without stroke grading."
-    continueLabel="Continue without recognition"
+    continueLabel="Continue"
     errorReport={errorReport}
     onContinue={onContinue}
     onCancel={onCancel}

--- a/src/components/production-practice-v1/ModelLoadingScreen.tsx
+++ b/src/components/production-practice-v1/ModelLoadingScreen.tsx
@@ -1,11 +1,11 @@
 export const ModelLoadingScreen = ({
-  message = "Loading handwriting model…",
+  message = "Loading handwriting AI…",
 }: {
   message?: string;
 }) => {
   return (
     <div className="flex flex-col items-center justify-center w-full h-full gap-6 px-6 text-center animate-fade-in">
-      <div className="text-4xl animate-pulse" aria-hidden>
+      <div className="text-4xl animate-bounce" aria-hidden>
         ✍️
       </div>
       <div>

--- a/src/components/production-practice-v1/ProductionPracticeV1.tsx
+++ b/src/components/production-practice-v1/ProductionPracticeV1.tsx
@@ -47,6 +47,109 @@ const FadeIn = ({ children }: { children: ReactNode }) => (
   <div className="h-full animate-fade-in">{children}</div>
 );
 
+type ProductionPracticePhaseProps = {
+  loadPhase: LoadPhase;
+  session: ReturnType<typeof usePracticeSession<SessionResult>>;
+  settings: ProductionPracticeSettings;
+  randomKanjiPool: string[];
+  gradingEnabled: boolean;
+  activeBackend: RecognitionBackend;
+  continueWithChosenBackend: (chosen: RecognitionBackend) => void;
+};
+
+const ProductionPracticePhase = ({
+  loadPhase,
+  session,
+  settings,
+  randomKanjiPool,
+  gradingEnabled,
+  activeBackend,
+  continueWithChosenBackend,
+}: ProductionPracticePhaseProps) => {
+  const { phase } = session;
+
+  if (phase === "initial") {
+    return (
+      <FadeIn>
+        <InitialScreen onStart={session.startGame} />
+      </FadeIn>
+    );
+  }
+
+  if (phase === "loading" && loadPhase.status === "loading-dakanji") {
+    return (
+      <FadeIn>
+        <ModelLoadingScreen message="Loading handwriting model…" />
+      </FadeIn>
+    );
+  }
+
+  if (phase === "loading" && loadPhase.status === "loading-backup") {
+    return (
+      <FadeIn>
+        <ModelLoadingScreen message="Trying a lighter recognizer…" />
+      </FadeIn>
+    );
+  }
+
+  if (phase === "loading" && loadPhase.status === "error-lighter") {
+    return (
+      <FadeIn>
+        <ModelErrorLighterRecognizer
+          errorReport={loadPhase.errorReport}
+          onContinue={() => continueWithChosenBackend("kanjicanvas")}
+          onCancel={session.goToInitial}
+        />
+      </FadeIn>
+    );
+  }
+
+  if (phase === "loading" && loadPhase.status === "error-none") {
+    return (
+      <FadeIn>
+        <ModelErrorNoRecognizer
+          errorReport={loadPhase.errorReport}
+          onContinue={() => continueWithChosenBackend("none")}
+          onCancel={session.goToInitial}
+        />
+      </FadeIn>
+    );
+  }
+
+  if (phase === "playing" && session.sessionItems.length > 0) {
+    return (
+      <FadeIn>
+        <Game
+          sessionItems={session.sessionItems}
+          settings={settings}
+          randomKanjiPool={randomKanjiPool}
+          gradingEnabled={gradingEnabled}
+          recognize={(payload) => recognizeWithBackend(activeBackend, payload)}
+          onProgress={session.setProgress}
+          onComplete={session.finishSession}
+          onEnd={session.goToInitial}
+        />
+      </FadeIn>
+    );
+  }
+
+  if (phase === "ended" && session.results) {
+    return (
+      <FadeIn>
+        <EndSession
+          results={session.hasMore ? session.results : session.runResults}
+          hasMore={session.hasMore}
+          wordsCleared={session.deck.length}
+          onNext={session.startNextSession}
+          onEnd={session.goToInitial}
+        />
+      </FadeIn>
+    );
+  }
+
+  return null;
+};
+
 const ProductionPracticeV1 = () => {
   useHtmlDocumentTitle(productionPracticePageMeta.heading);
 
@@ -74,7 +177,7 @@ const ProductionPracticeV1 = () => {
       void warmThenCommit(commitPlaying);
     },
   });
-  const { phase, results, hasMore } = session;
+  const { phase, hasMore } = session;
 
   const warmThenCommit = async (commitPlaying: () => void) => {
     if (backend != null) {
@@ -131,94 +234,31 @@ const ProductionPracticeV1 = () => {
   const activeBackend = backend ?? "none";
   const gradingEnabled = activeBackend !== "none";
 
-  const renderPhase = (): ReactNode => {
-    if (phase === "initial") {
-      return (
-        <FadeIn key="initial">
-          <InitialScreen onStart={session.startGame} />
-        </FadeIn>
-      );
-    }
-
-    if (phase === "loading" && loadPhase.status === "loading-dakanji") {
-      return (
-        <FadeIn key="loading-dakanji">
-          <ModelLoadingScreen message="Loading handwriting model…" />
-        </FadeIn>
-      );
-    }
-
-    if (phase === "loading" && loadPhase.status === "loading-backup") {
-      return (
-        <FadeIn key="loading-backup">
-          <ModelLoadingScreen message="Trying a lighter recognizer…" />
-        </FadeIn>
-      );
-    }
-
-    if (phase === "loading" && loadPhase.status === "error-lighter") {
-      return (
-        <FadeIn key="error-lighter">
-          <ModelErrorLighterRecognizer
-            errorReport={loadPhase.errorReport}
-            onContinue={() => continueWithChosenBackend("kanjicanvas")}
-            onCancel={session.goToInitial}
-          />
-        </FadeIn>
-      );
-    }
-
-    if (phase === "loading" && loadPhase.status === "error-none") {
-      return (
-        <FadeIn key="error-none">
-          <ModelErrorNoRecognizer
-            errorReport={loadPhase.errorReport}
-            onContinue={() => continueWithChosenBackend("none")}
-            onCancel={session.goToInitial}
-          />
-        </FadeIn>
-      );
-    }
-
-    if (phase === "playing" && session.sessionItems.length > 0) {
-      return (
-        <FadeIn key={`playing-${session.sessionKey}`}>
-          <Game
-            sessionItems={session.sessionItems}
-            settings={settings}
-            randomKanjiPool={randomKanjiPool}
-            gradingEnabled={gradingEnabled}
-            recognize={(payload) =>
-              recognizeWithBackend(activeBackend, payload)
-            }
-            onProgress={session.setProgress}
-            onComplete={session.finishSession}
-            onEnd={session.goToInitial}
-          />
-        </FadeIn>
-      );
-    }
-
-    if (phase === "ended" && results) {
-      return (
-        <FadeIn key={hasMore ? "ended" : "complete"}>
-          <EndSession
-            results={hasMore ? results : session.runResults}
-            hasMore={hasMore}
-            wordsCleared={session.deck.length}
-            onNext={session.startNextSession}
-            onEnd={session.goToInitial}
-          />
-        </FadeIn>
-      );
-    }
-
-    return null;
-  };
+  const phaseKey =
+    phase === "loading"
+      ? loadPhase.status
+      : phase === "playing"
+        ? `playing-${session.sessionKey}`
+        : phase === "ended"
+          ? hasMore
+            ? "ended"
+            : "complete"
+          : phase;
 
   return (
     <>
-      <PracticeShell progress={session.progress}>{renderPhase()}</PracticeShell>
+      <PracticeShell progress={session.progress}>
+        <ProductionPracticePhase
+          key={phaseKey}
+          loadPhase={loadPhase}
+          session={session}
+          settings={settings}
+          randomKanjiPool={randomKanjiPool}
+          gradingEnabled={gradingEnabled}
+          activeBackend={activeBackend}
+          continueWithChosenBackend={continueWithChosenBackend}
+        />
+      </PracticeShell>
 
       {phase === "ended" && <KanjiDrawerGlobal />}
     </>

--- a/src/components/production-practice-v1/StrokeOrderPlayer.tsx
+++ b/src/components/production-practice-v1/StrokeOrderPlayer.tsx
@@ -1,8 +1,9 @@
 import { StrokeOrderReplay } from "@/components/common/KanjiDmak";
+import { SMALL_SVG_SIZE } from "../sections/KanjiDetails/stroke-animation-constants";
 
 export const StrokeOrderPlayer = ({
   kanji,
-  size = 160,
+  size = SMALL_SVG_SIZE,
 }: {
   kanji: string;
   size?: number;

--- a/src/components/production-practice-v1/WritingPracticeModal.tsx
+++ b/src/components/production-practice-v1/WritingPracticeModal.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense } from "react";
 import { Dialog } from "@/components/ui/dialog";
 import { ScrollableDialogContent } from "@/components/ui/scrollable-dialog-content";
 import { ErrorBoundary } from "@/components/error";
-import { StrokeAnimationLoadingScreen } from "@/components/sections/KanjiDetails/StrokeAnimationLoadingScreen";
+import { WritingPracticeLoadingScreen } from "@/components/sections/KanjiDetails/StrokeAnimationLoadingScreen";
 
 const StrokeAnimation = lazy(
   () => import("@/components/sections/KanjiDetails/StrokeAnimation")
@@ -27,7 +27,7 @@ export const WritingPracticeModal = ({
         titleClassName="flex items-center text-center"
       >
         <ErrorBoundary details="StrokeAnimation in WritingPracticeModal">
-          <Suspense fallback={<StrokeAnimationLoadingScreen />}>
+          <Suspense fallback={<WritingPracticeLoadingScreen />}>
             {/* Remount when opened so stroke order restarts from the first stroke. */}
             {open && (
               <StrokeAnimation key={kanji} kanji={kanji} defaultPracticeMode />

--- a/src/components/production-practice-v1/WritingPracticeModal.tsx
+++ b/src/components/production-practice-v1/WritingPracticeModal.tsx
@@ -1,11 +1,6 @@
 import { lazy, Suspense } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog } from "@/components/ui/dialog";
+import { ScrollableDialogContent } from "@/components/ui/scrollable-dialog-content";
 import { ErrorBoundary } from "@/components/error";
 import { StrokeAnimationLoadingScreen } from "@/components/sections/KanjiDetails/StrokeAnimationLoadingScreen";
 
@@ -24,30 +19,22 @@ export const WritingPracticeModal = ({
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[96dvh] max-w-md overflow-hidden px-0 py-0">
-        <div className="min-h-0 overflow-y-auto px-4">
-          <DialogHeader className="px-6 pt-6 pb-0">
-            <DialogTitle className="flex items-center text-center">
-              <span className="text-3xl kanji-font">{kanji}</span>
-            </DialogTitle>
-            <DialogDescription className="sr-only">
-              Practice writing stroke order for {kanji}
-            </DialogDescription>
-          </DialogHeader>
-          <ErrorBoundary details="StrokeAnimation in WritingPracticeModal">
-            <Suspense fallback={<StrokeAnimationLoadingScreen />}>
-              {/* Remount when opened so stroke order restarts from the first stroke. */}
-              {open && (
-                <StrokeAnimation
-                  key={kanji}
-                  kanji={kanji}
-                  defaultPracticeMode
-                />
-              )}
-            </Suspense>
-          </ErrorBoundary>
-        </div>
-      </DialogContent>
+      <ScrollableDialogContent
+        size="md"
+        title={<span className="text-3xl kanji-font">{kanji}</span>}
+        description={`Practice writing stroke order for ${kanji}`}
+        headerClassName="pt-4"
+        titleClassName="flex items-center text-center"
+      >
+        <ErrorBoundary details="StrokeAnimation in WritingPracticeModal">
+          <Suspense fallback={<StrokeAnimationLoadingScreen />}>
+            {/* Remount when opened so stroke order restarts from the first stroke. */}
+            {open && (
+              <StrokeAnimation key={kanji} kanji={kanji} defaultPracticeMode />
+            )}
+          </Suspense>
+        </ErrorBoundary>
+      </ScrollableDialogContent>
     </Dialog>
   );
 };

--- a/src/components/production-practice-v1/drawers/ItemReveal.tsx
+++ b/src/components/production-practice-v1/drawers/ItemReveal.tsx
@@ -2,11 +2,11 @@ import { RomajiBadge } from "@/components/dependent/kana/RomajiBadge";
 import { SpeakButton } from "@/components/common/SpeakButton";
 import type { PracticeItem } from "../types";
 
-/** Kanji · reading badges · speak · gloss — shared across feedback drawers. */
+/** Word · reading badges · speak · gloss — shared across feedback drawers. */
 export const ItemReveal = ({ item }: { item: PracticeItem }) => (
   <div className="flex flex-col items-center gap-1 text-foreground">
     <div className="flex flex-wrap items-center justify-center gap-1">
-      <span className="text-4xl kanji-font">{item.kanji}</span>
+      <span className="text-4xl kanji-font">{item.word}</span>
       <span className="mx-1 text-base font-normal">·</span>
       {item.reading.split("・").map((r) => (
         <RomajiBadge key={r} kana={r} />

--- a/src/components/recognition-practice-v1/Game.tsx
+++ b/src/components/recognition-practice-v1/Game.tsx
@@ -172,7 +172,7 @@ export const Game = ({
               spellCheck={false}
               aria-label='Type the reading or type "forgot"'
               placeholder='Type the reading or type "forgot"'
-              className="relative w-full p-0 mt-2 text-xl text-center border-2 rounded-2xl h-14 focus-visible:ring-offset-0 animate-fade-in"
+              className="relative w-full p-0 px-2 mt-2 text-xl text-center border-2 rounded-2xl h-14 focus-visible:ring-offset-0 animate-fade-in"
               onKeyDown={handleKeyDown}
               {...kanaInput}
             />

--- a/src/components/screens/ListScreen/ControlBar/ControlBarErrorFallback.tsx
+++ b/src/components/screens/ListScreen/ControlBar/ControlBarErrorFallback.tsx
@@ -1,8 +1,7 @@
 import { Flower, Settings2 } from "@/components/icons";
 import { Button } from "@/components/ui/button";
+import { forceHardRefresh } from "@/lib/force-hard-refresh";
 import { SearchInputErrorFallback } from "./SearchInput/SearchInputErrorFallback";
-
-const reloadPage = () => window.location.reload();
 
 export const ControlBarErrorFallback = () => (
   <>
@@ -12,7 +11,7 @@ export const ControlBarErrorFallback = () => (
       variant="outline"
       size="icon"
       className="h-9 w-9 shrink-0 text-muted-foreground opacity-80 transition-opacity hover:opacity-100"
-      onClick={reloadPage}
+      onClick={() => void forceHardRefresh()}
       aria-label="Controls failed to load. Refresh page."
     >
       <Settings2 />
@@ -22,7 +21,7 @@ export const ControlBarErrorFallback = () => (
       variant="outline"
       size="icon"
       className="h-9 w-9 shrink-0 text-muted-foreground opacity-80 transition-opacity hover:opacity-100"
-      onClick={reloadPage}
+      onClick={() => void forceHardRefresh()}
       aria-label="Controls failed to load. Refresh page."
     >
       <Flower />

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/HandwritingControl.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/HandwritingControl.tsx
@@ -9,6 +9,7 @@ import {
   recognizeWithGoogle,
   recognizeWithKanjiCanvas,
 } from "./recognizers";
+import { otherOutLinks } from "@/lib/external-links";
 
 // "google" = online API; "kanjicanvas" / "dakanji" = on-device.
 export type HandwritingVariant = "google" | "kanjicanvas" | "dakanji";
@@ -34,7 +35,7 @@ const VARIANT_CONFIG = {
     errorText: "Google's handwriting API can't be accessed right now.",
     idleContent: (
       <IdleCredit
-        href="https://www.google.com/inputtools/services/features/handwriting.html"
+        href={otherOutLinks.googleHandwriting}
         label="Google Handwriting API"
       />
     ),
@@ -43,10 +44,7 @@ const VARIANT_CONFIG = {
     recognize: recognizeWithDaKanji,
     errorText: "The DaKanji recognizer couldn't be loaded right now.",
     idleContent: (
-      <IdleCredit
-        href="https://github.com/dariyooo/DaKanji-Single-Kanji-Recognition"
-        label="Dariyooo (DaAppLab)"
-      />
+      <IdleCredit href={otherOutLinks.dakanji} label="Dariyooo (DaAppLab)" />
     ),
   },
   kanjicanvas: {
@@ -54,7 +52,7 @@ const VARIANT_CONFIG = {
     errorText: "The handwriting recognizer couldn't be loaded right now.",
     idleContent: (
       <IdleCredit
-        href="https://github.com/asdfjkl/kanjicanvas"
+        href={otherOutLinks.kanjiCanvas}
         label="KanjiCanvas (asdfjkl)"
       />
     ),

--- a/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInputErrorFallback.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SearchInput/SearchInputErrorFallback.tsx
@@ -1,4 +1,5 @@
 import { Search } from "@/components/icons";
+import { forceHardRefresh } from "@/lib/force-hard-refresh";
 import { cn } from "@/lib/utils";
 import { RefreshCw } from "lucide-react";
 
@@ -6,7 +7,7 @@ export const SearchInputErrorFallback = () => (
   <section className="relative flex-1 min-w-0">
     <button
       type="button"
-      onClick={() => window.location.reload()}
+      onClick={() => void forceHardRefresh()}
       aria-label="Search failed to load. Refresh page."
       className={cn(
         "flex w-full items-center rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm",

--- a/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterDialog.tsx
+++ b/src/components/screens/ListScreen/ControlBar/SortAndFilter/SortAndFilterDialog.tsx
@@ -1,14 +1,8 @@
 import { useState } from "react";
 import { SearchSettings } from "@/lib/settings/settings";
 import { ErrorBoundary } from "@/components/error";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { Dialog, DialogTrigger } from "@/components/ui/dialog";
+import { ScrollableDialogContent } from "@/components/ui/scrollable-dialog-content";
 import {
   HoverCard,
   HoverCardContent,
@@ -44,17 +38,15 @@ export const SortAndFilterSettingsDialog = ({
           Sort and Filter Settings
         </HoverCardContent>
       </HoverCard>
-      <DialogContent
-        className={"max-h-svh z-50 flex flex-col min-h-0 px-1 md:px-4 pb-4"}
+      <ScrollableDialogContent
+        title="Sorting and Filtering Settings"
+        description="Manage your Sorting and Filtering Settings"
+        scrollBody={false}
+        className="max-h-svh px-1 pb-4 md:px-4"
+        headerClassName="px-0 pt-0"
+        titleClassName="px-2 text-left"
+        bodyClassName="px-0"
       >
-        <DialogHeader>
-          <DialogTitle className="px-2 m-0 text-left">
-            Sorting and Filtering Settings
-          </DialogTitle>
-          <DialogDescription className="sr-only">
-            Manage your Sorting and Filtering Settings
-          </DialogDescription>
-        </DialogHeader>
         {isOpen && (
           <ErrorBoundary>
             <SortAndFilterSettingsForm
@@ -66,7 +58,7 @@ export const SortAndFilterSettingsDialog = ({
             />
           </ErrorBoundary>
         )}
-      </DialogContent>
+      </ScrollableDialogContent>
     </Dialog>
   );
 };

--- a/src/components/sections/KanjiDetails/Details.tsx
+++ b/src/components/sections/KanjiDetails/Details.tsx
@@ -23,7 +23,7 @@ import { StrokeAnimationLoadingScreen } from "./StrokeAnimationLoadingScreen";
 
 const StudyNotesLoadingFallback = () => (
   <div
-    className="flex w-full h-48 items-center justify-center"
+    className="flex items-center justify-center w-full h-48"
     role="status"
     aria-label="Loading"
   >

--- a/src/components/sections/KanjiDetails/PaginatedVocabulary.tsx
+++ b/src/components/sections/KanjiDetails/PaginatedVocabulary.tsx
@@ -90,8 +90,8 @@ export const PaginatedVocabulary = ({
               Translation
             </TableHead>
             <TableHead className="text-center w-fit">Tags</TableHead>
-            <TableHead className="w-24 text-left">Jisho.org</TableHead>
             <TableHead className="w-24 text-left">Jotoba.de</TableHead>
+            <TableHead className="w-24 text-left">Jisho.org</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/components/sections/KanjiDetails/PaginatedVocabulary.tsx
+++ b/src/components/sections/KanjiDetails/PaginatedVocabulary.tsx
@@ -1,11 +1,5 @@
 import { useMemo } from "react";
-import {
-  Table,
-  TableBody,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { Table, TableBody } from "@/components/ui/table";
 import { Keyboard } from "@/components/icons";
 import { CommonWordEntry, sortWordData } from "@/lib/sample-vocabulary";
 import { Pagination } from "./Pagination";
@@ -14,6 +8,7 @@ import {
   useKeyboardPagination,
   PaginationShortcuts,
 } from "./pagination-hooks";
+import { VocabularyTableHeader } from "./VocabularyTableHeader";
 import { WordRow } from "./WordRow";
 
 const ShortcutKey = ({ label }: { label: string }) => (
@@ -81,19 +76,7 @@ export const PaginatedVocabulary = ({
       </p>
       {pagination}
       <Table className="w-full min-w-[400px] mt-4 animate-fade-in">
-        <TableHeader>
-          <TableRow>
-            <TableHead className="text-left w-fit">Speak</TableHead>
-            <TableHead className="text-center w-fit">Word</TableHead>
-            <TableHead className="text-center w-fit">Reading</TableHead>
-            <TableHead className="text-center min-w-16 max-w-24">
-              Translation
-            </TableHead>
-            <TableHead className="text-center w-fit">Tags</TableHead>
-            <TableHead className="w-24 text-left">Jotoba.de</TableHead>
-            <TableHead className="w-24 text-left">Jisho.org</TableHead>
-          </TableRow>
-        </TableHeader>
+        <VocabularyTableHeader />
         <TableBody>
           {pageData.map((entry) => (
             <WordRow key={entry.w} entry={entry} />

--- a/src/components/sections/KanjiDetails/RepresentativeStudyWord.tsx
+++ b/src/components/sections/KanjiDetails/RepresentativeStudyWord.tsx
@@ -30,7 +30,7 @@ const WhatIsARepresentativeStudyWord = () => {
           </span>
         }
         content={
-          <div className="p-4 text-xs text-left w-96">
+          <div className="p-4 text-xs text-left w-72">
             <p className="py-2">
               An <strong>Anchor Word</strong> is a Japanese word chosen to
               create a strong, memorable connection between a kanji and one of

--- a/src/components/sections/KanjiDetails/SampleVocabulary.tsx
+++ b/src/components/sections/KanjiDetails/SampleVocabulary.tsx
@@ -1,6 +1,7 @@
 import { useJsonFetch } from "@/hooks/use-json";
 import { SAMPLE_VOCAB_PATH } from "@/lib/assets-paths";
 import { PrimaryDataSources } from "@/components/common/PrimaryDataSources";
+import { sampleVocabSourceLinks } from "@/lib/external-links";
 import { CommonWordEntry } from "@/lib/sample-vocabulary";
 import { PaginatedVocabulary } from "./PaginatedVocabulary";
 import { TableSkeleton } from "./TableSkeleton";
@@ -28,14 +29,7 @@ export const SampleVocabulary = ({ kanji }: { kanji: string }) => {
           next: { key: "d", shiftKey: true, label: "Shift + D" },
         }}
       />
-      <PrimaryDataSources
-        links={[
-          {
-            text: "JP Word Ranks Lookup",
-            url: "https://pikapikagems.github.io/japanese-word-ranks/about/",
-          },
-        ]}
-      />
+      <PrimaryDataSources links={sampleVocabSourceLinks} />
     </div>
   );
 };

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -8,6 +8,7 @@ import { recognizeWithDaKanji } from "@/components/screens/ListScreen/ControlBar
 import { gradeMessage, type GradeResult } from "@/lib/dakanji-grade";
 import { useFitPadSize } from "@/hooks/use-fit-pad-size";
 import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
+import { otherOutLinks } from "@/lib/external-links";
 import { Rocket } from "lucide-react";
 
 export const StrokeAnimation = ({ kanji }: { kanji: string }) => (
@@ -60,9 +61,6 @@ const HintSection = ({ kanji }: { kanji: string }) => {
 };
 
 type GradeStatus = "idle" | "loading" | "success" | "error";
-
-const DAKANJI_CREDIT_HREF =
-  "https://github.com/dariyooo/DaKanji-Single-Kanji-Recognition";
 
 const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
   const [strokes, setStrokes] = useState<Stroke[]>([]);
@@ -142,7 +140,7 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
       <p className="max-w-[310px] text-center text-[11px] leading-relaxed opacity-70">
         Grading powered by DaKanji ·{" "}
         <a
-          href={DAKANJI_CREDIT_HREF}
+          href={otherOutLinks.dakanji}
           target="_blank"
           rel="noopener noreferrer"
           className="font-bold underline underline-offset-2 hover:opacity-80"

--- a/src/components/sections/KanjiDetails/StrokeAnimation.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimation.tsx
@@ -7,7 +7,11 @@ import { RecognizingStatus } from "@/components/common/RecognizingStatus";
 import { recognizeWithDaKanji } from "@/components/screens/ListScreen/ControlBar/SearchInput/HandwritingScreen/recognizers";
 import { gradeMessage, type GradeResult } from "@/lib/dakanji-grade";
 import { useFitPadSize } from "@/hooks/use-fit-pad-size";
-import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
+import {
+  CONTAINER_CN,
+  HINT_SVG_SIZE,
+  SVG_SIZE,
+} from "./stroke-animation-constants";
 import { otherOutLinks } from "@/lib/external-links";
 import { Rocket } from "lucide-react";
 
@@ -17,11 +21,10 @@ export const StrokeAnimation = ({ kanji }: { kanji: string }) => (
       kanji={kanji}
       size={SVG_SIZE}
       replayClassName={CONTAINER_CN}
+      showSettings={true}
     />
   </div>
 );
-
-const HINT_SVG_SIZE = 85;
 
 const HintSection = ({ kanji }: { kanji: string }) => {
   const [blurred, setBlurred] = useState(true);
@@ -61,6 +64,57 @@ const HintSection = ({ kanji }: { kanji: string }) => {
 };
 
 type GradeStatus = "idle" | "loading" | "success" | "error";
+
+const GradeStatusCopy = ({
+  status,
+  kanji,
+  result,
+}: {
+  status: GradeStatus;
+  kanji: string;
+  result: GradeResult | null;
+}) => {
+  if (status === "loading") {
+    return (
+      <div className="animate-fade-in opacity-80">
+        <RecognizingStatus label="採点中 · Grading…" />
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="animate-fade-in">
+        すみません 🥺 🙇. The grader {`couldn't`} be loaded right now.
+      </div>
+    );
+  }
+
+  if (status === "success" && result != null) {
+    return (
+      <div className="animate-practice-bounce-soft">
+        {gradeMessage(kanji, result)}
+      </div>
+    );
+  }
+
+  return <div className="font-bold">Draw the kanji, then tap 🚀 to grade.</div>;
+};
+
+const DaKanjiCredit = () => (
+  <p className="max-w-[310px] text-center text-[11px] leading-relaxed opacity-70">
+    Grading powered by DaKanji ·{" "}
+    <a
+      href={otherOutLinks.dakanji}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="font-bold underline underline-offset-2 hover:opacity-80"
+    >
+      Dariyooo (DaAppLab)
+    </a>{" "}
+    💪
+  </p>
+);
 
 const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
   const [strokes, setStrokes] = useState<Stroke[]>([]);
@@ -114,41 +168,24 @@ const WritingPracticeMode = ({ kanji }: { kanji: string }) => {
         submitDisabled={status === "loading"}
         onClickSubmit={onGrade}
         onClickClear={onClear}
+        overlay={
+          status === "idle" ? undefined : (
+            <div className="absolute inset-x-0 top-0 z-10 hidden px-2 pt-2 pointer-events-none [@media(max-height:40rem)]:block">
+              <div className="px-2 py-1.5 text-sm font-bold text-center rounded-2xl bg-background/90">
+                <GradeStatusCopy
+                  status={status}
+                  kanji={kanji}
+                  result={result}
+                />
+              </div>
+            </div>
+          )
+        }
       />
-
-      <div className="w-full max-w-[310px] min-h-10 px-2 text-base font-bold text-center">
-        {status === "loading" && (
-          <div className="animate-fade-in opacity-80">
-            <RecognizingStatus label="採点中 · Grading…" />
-          </div>
-        )}
-        {status === "error" && (
-          <div className="animate-fade-in">
-            すみません 🙇🏽‍♀️ 🙇. The grader {`couldn't`} be loaded right now.
-          </div>
-        )}
-        {status === "success" && result != null && (
-          <div className="animate-practice-bounce-soft">
-            {gradeMessage(kanji, result)}
-          </div>
-        )}
-        {status === "idle" && (
-          <div className="font-bold">Draw the kanji, then tap 🚀 to grade.</div>
-        )}
+      <div className="w-full max-w-[310px] min-h-10 px-2 text-base font-bold text-center [@media(max-height:40rem)]:hidden">
+        <GradeStatusCopy status={status} kanji={kanji} result={result} />
       </div>
-
-      <p className="max-w-[310px] text-center text-[11px] leading-relaxed opacity-70">
-        Grading powered by DaKanji ·{" "}
-        <a
-          href={otherOutLinks.dakanji}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-bold underline underline-offset-2 hover:opacity-80"
-        >
-          Dariyooo (DaAppLab)
-        </a>{" "}
-        💪
-      </p>
+      <DaKanjiCredit />
     </div>
   );
 };

--- a/src/components/sections/KanjiDetails/StrokeAnimationLoadingScreen.tsx
+++ b/src/components/sections/KanjiDetails/StrokeAnimationLoadingScreen.tsx
@@ -1,46 +1,58 @@
-import { CONTAINER_CN, SVG_SIZE } from "./stroke-animation-constants";
+import {
+  CONTAINER_CN,
+  HINT_SVG_SIZE,
+  SVG_SIZE,
+} from "./stroke-animation-constants";
 
-/** Shared Suspense fallback for lazy-loaded StrokeAnimation. */
+const PadGridSkeleton = () => (
+  <div
+    className="relative overflow-hidden rounded-3xl bg-muted animate-pulse"
+    style={{ width: SVG_SIZE, height: SVG_SIZE }}
+  >
+    <svg
+      width={SVG_SIZE}
+      height={SVG_SIZE}
+      className="absolute inset-0 text-foreground opacity-10"
+      aria-hidden
+    >
+      <line
+        x1={SVG_SIZE / 2}
+        y1={0}
+        x2={SVG_SIZE / 2}
+        y2={SVG_SIZE}
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeDasharray="5 5"
+      />
+      <line
+        x1={0}
+        y1={SVG_SIZE / 2}
+        x2={SVG_SIZE}
+        y2={SVG_SIZE / 2}
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeDasharray="5 5"
+      />
+    </svg>
+  </div>
+);
+
+const SwitchRowSkeleton = () => (
+  <div className="flex items-center gap-2">
+    <div className="h-5 rounded-full w-9 bg-muted animate-pulse" />
+    <div className="w-24 h-3 rounded-lg bg-muted animate-pulse" />
+  </div>
+);
+
+/** Suspense fallback for stroke-order replay (kanji details accordion). */
 export const StrokeAnimationLoadingScreen = () => {
   return (
     <div className="p-4">
       <div className="flex px-4 pt-6 pb-3">
-        <div className="flex items-center gap-2">
-          <div className="h-5 rounded-full w-9 bg-muted animate-pulse" />
-          <div className="w-24 h-3 rounded-lg bg-muted animate-pulse" />
-        </div>
+        <SwitchRowSkeleton />
       </div>
       <div className={CONTAINER_CN} style={{ height: SVG_SIZE }}>
-        <div
-          className="relative overflow-hidden rounded-3xl bg-muted animate-pulse"
-          style={{ width: SVG_SIZE, height: SVG_SIZE }}
-        >
-          <svg
-            width={SVG_SIZE}
-            height={SVG_SIZE}
-            className="absolute inset-0 text-foreground opacity-10"
-            aria-hidden
-          >
-            <line
-              x1={SVG_SIZE / 2}
-              y1={0}
-              x2={SVG_SIZE / 2}
-              y2={SVG_SIZE}
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeDasharray="5 5"
-            />
-            <line
-              x1={0}
-              y1={SVG_SIZE / 2}
-              x2={SVG_SIZE}
-              y2={SVG_SIZE / 2}
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeDasharray="5 5"
-            />
-          </svg>
-        </div>
+        <PadGridSkeleton />
       </div>
       <div className="flex justify-center space-x-2">
         <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
@@ -49,3 +61,44 @@ export const StrokeAnimationLoadingScreen = () => {
     </div>
   );
 };
+
+/** Suspense fallback when the writing-practice pad is the first paint. */
+export const WritingPracticeLoadingScreen = () => (
+  <div>
+    <div className="flex px-4 pt-6 pb-3">
+      <div className="relative flex items-center w-full gap-2 mb-4">
+        <SwitchRowSkeleton />
+        <div className="absolute right-0 z-10 px-2 m-4 border border-dashed sm:-right-8 rounded-2xl -top-10 border-foreground bg-background/80">
+          <div
+            className="rounded-xl bg-muted animate-pulse"
+            style={{
+              width: HINT_SVG_SIZE,
+              height: HINT_SVG_SIZE,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+    <div className="min-h-[min(530px,calc(90dvh-11rem))]">
+      <div className="flex flex-col items-center gap-3 px-2 pt-4 pb-6 sm:px-4">
+        <div className="flex flex-col items-center gap-2 mx-auto my-2 sm:m-4">
+          <div className="relative">
+            <PadGridSkeleton />
+            <div className="absolute inset-x-0 top-0 z-10 hidden px-2 pt-2 [@media(max-height:40rem)]:block">
+              <div className="h-8 rounded-2xl bg-muted/80 animate-pulse" />
+            </div>
+          </div>
+          <div className="flex justify-center mt-2 space-x-2">
+            <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
+            <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
+            <div className="rounded-lg w-9 h-9 bg-muted animate-pulse" />
+          </div>
+        </div>
+        <div className="flex items-center justify-center w-full max-w-[310px] min-h-10 px-2 [@media(max-height:40rem)]:hidden">
+          <div className="w-48 h-4 rounded-lg bg-muted animate-pulse" />
+        </div>
+        <div className="w-40 h-3 rounded-lg bg-muted animate-pulse opacity-70" />
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/sections/KanjiDetails/StructureInfo.tsx
+++ b/src/components/sections/KanjiDetails/StructureInfo.tsx
@@ -8,6 +8,10 @@ import {
 } from "@/components/sections/KanjiDetails/StructuralCategory";
 import { ReactNode } from "react";
 import { PrimaryDataSources } from "@/components/common/PrimaryDataSources";
+import {
+  similarKanjiSourceLinks,
+  structureSourceLinks,
+} from "@/lib/external-links";
 import { OriginalKanjiComponentBreakdown } from "./OriginalComponentBreakdown";
 import { useSimilarKanjis } from "@/kanji-worker/kanji-worker-hooks";
 import { dedupe } from "@/lib/utils";
@@ -57,18 +61,7 @@ const SimilarKanjis = ({ kanji }: { kanji: string }) => {
           ))}
         </div>
       </div>
-      <PrimaryDataSources
-        links={[
-          {
-            text: "lennart-finke/kanjidist-visualiser",
-            url: "https://github.com/lennart-finke/kanjidist-visualiser/blob/master/data/dkanjistat.json",
-          },
-          {
-            text: "Yencken, Lars (2010) Orthographic support for passing the reading hurdle in Japanese. PhD Thesis, University of Melbourne, Melbourne, Australia",
-            url: "https://lars.yencken.org/datasets/kanji-confusion/",
-          },
-        ]}
-      />
+      <PrimaryDataSources links={similarKanjiSourceLinks} />
     </>
   );
 };
@@ -118,30 +111,7 @@ export const StructureInfo = ({ kanji }: { kanji: string }) => {
         </TableBody>
       </Table>
 
-      <PrimaryDataSources
-        links={[
-          {
-            text: "mifunetoshiro/kanjium",
-            url: "https://github.com/mifunetoshiro/kanjium/blob/master/data/source_files/kanjidict.txt",
-          },
-          {
-            text: "hlorenzi/jisho-open",
-            url: "https://raw.githubusercontent.com/hlorenzi/jisho-open/main/backend/src/data/kanji_structural_category.ts",
-          },
-          {
-            text: "yagays/kanjivg-radical",
-            url: "https://github.com/yagays/kanjivg-radical/blob/master/data/kanji2radical.json",
-          },
-          {
-            text: "ScottOglesby/kanji-bakuhatsu",
-            url: "https://github.com/ScottOglesby/kanji-bakuhatsu/blob/master/raw/kanji-composition-map.txt",
-          },
-          {
-            text: "scriptin/topokanji",
-            url: "https://github.com/scriptin/topokanji",
-          },
-        ]}
-      />
+      <PrimaryDataSources links={structureSourceLinks} />
 
       <SimilarKanjis kanji={kanji} />
     </>

--- a/src/components/sections/KanjiDetails/TableSkeleton.tsx
+++ b/src/components/sections/KanjiDetails/TableSkeleton.tsx
@@ -34,8 +34,8 @@ export const TableSkeleton = () => {
             <TableHead className="text-center w-fit min-w-16 max-w-24">
               Tags
             </TableHead>
-            <TableHead className="w-24 text-left">Jisho.org</TableHead>
             <TableHead className="w-24 text-left">Jotoba.de</TableHead>
+            <TableHead className="w-24 text-left">Jisho.org</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/components/sections/KanjiDetails/TableSkeleton.tsx
+++ b/src/components/sections/KanjiDetails/TableSkeleton.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useState } from "react";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import { VocabularyTableHeader } from "./VocabularyTableHeader";
 
 /** Placeholder table shown while a vocabulary JSON is loading. */
 export const TableSkeleton = () => {
@@ -25,19 +19,7 @@ export const TableSkeleton = () => {
   return (
     <div className="px-2 mx-2 overflow-x-auto mt-14 animate pulse">
       <Table className="w-full min-w-[400px]">
-        <TableHeader>
-          <TableRow>
-            <TableHead className="text-left w-fit">Speak</TableHead>
-            <TableHead className="text-center w-fit">Word</TableHead>
-            <TableHead className="text-center w-fit">Reading</TableHead>
-            <TableHead className="w-12 text-center">Translation</TableHead>
-            <TableHead className="text-center w-fit min-w-16 max-w-24">
-              Tags
-            </TableHead>
-            <TableHead className="w-24 text-left">Jotoba.de</TableHead>
-            <TableHead className="w-24 text-left">Jisho.org</TableHead>
-          </TableRow>
-        </TableHeader>
+        <VocabularyTableHeader />
         <TableBody>
           {Array.from({ length: 10 }).map((_, i) => (
             <TableRow key={i}>

--- a/src/components/sections/KanjiDetails/TextbookVocabulary.tsx
+++ b/src/components/sections/KanjiDetails/TextbookVocabulary.tsx
@@ -1,6 +1,7 @@
 import { useJsonFetch } from "@/hooks/use-json";
 import { TEXT_BOOK_VOCAB_PATH } from "@/lib/assets-paths";
 import { PrimaryDataSources } from "@/components/common/PrimaryDataSources";
+import { textbookVocabSourceLinks } from "@/lib/external-links";
 import {
   TextbookWordEntry,
   toCommonWordEntries,
@@ -39,30 +40,7 @@ export const TextbookVocabulary = ({ kanji }: { kanji: string }) => {
           next: { key: "d", label: "d" },
         }}
       />
-      <PrimaryDataSources
-        links={[
-          {
-            text: "Anki Deck: 1564742924",
-            url: "https://ankiweb.net/shared/info/1564742924",
-          },
-          {
-            text: "Anki Deck: 779483253",
-            url: "https://ankiweb.net/shared/info/779483253",
-          },
-          {
-            text: "Anki Deck: 2106223612",
-            url: "https://ankiweb.net/shared/info/2106223612",
-          },
-          {
-            text: "Anki Deck: 1468618470",
-            url: "https://ankiweb.net/shared/info/1468618470",
-          },
-          {
-            text: "Kanji Mastery Blog",
-            url: "https://kanjimastery.blogspot.com/",
-          },
-        ]}
-      />
+      <PrimaryDataSources links={textbookVocabSourceLinks} />
     </div>
   );
 };

--- a/src/components/sections/KanjiDetails/VocabularyTableHeader.tsx
+++ b/src/components/sections/KanjiDetails/VocabularyTableHeader.tsx
@@ -1,0 +1,17 @@
+import { TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export const VocabularyTableHeader = () => (
+  <TableHeader>
+    <TableRow>
+      <TableHead className="text-left w-fit">Speak</TableHead>
+      <TableHead className="text-center w-fit">Word</TableHead>
+      <TableHead className="text-center w-fit">Reading</TableHead>
+      <TableHead className="text-center min-w-16 max-w-24">
+        Translation
+      </TableHead>
+      <TableHead className="text-center w-fit">Tags</TableHead>
+      <TableHead className="w-24 text-left">Jotoba.de</TableHead>
+      <TableHead className="w-24 text-left">Jisho.org</TableHead>
+    </TableRow>
+  </TableHeader>
+);

--- a/src/components/sections/KanjiDetails/WordRow.tsx
+++ b/src/components/sections/KanjiDetails/WordRow.tsx
@@ -119,12 +119,12 @@ export const WordRow = ({ entry }: { entry: CommonWordEntry }) => {
         </TableCell>
         <TableCell className="w-12">
           <BugIconErrorBoundary>
-            <JishoBtn word={entry.w} />
+            <JotobaBtn word={entry.w} />
           </BugIconErrorBoundary>
         </TableCell>
         <TableCell className="w-12">
           <BugIconErrorBoundary>
-            <JotobaBtn word={entry.w} />
+            <JishoBtn word={entry.w} />
           </BugIconErrorBoundary>
         </TableCell>
       </TableRow>

--- a/src/components/sections/KanjiDetails/stroke-animation-constants.ts
+++ b/src/components/sections/KanjiDetails/stroke-animation-constants.ts
@@ -1,2 +1,4 @@
 export const SVG_SIZE = 310;
+export const HINT_SVG_SIZE = 85;
+export const SMALL_SVG_SIZE = 160;
 export const CONTAINER_CN = `flex w-full justify-center my-4 h-[${SVG_SIZE}px]`;

--- a/src/components/ui/practice-button-variants.ts
+++ b/src/components/ui/practice-button-variants.ts
@@ -10,7 +10,7 @@ export const practiceButtonVariants = cva(
     "border-2 border-b-[5px]",
     "transition-[transform,border-width,filter] duration-75 ease-out",
     "active:translate-y-[3px] active:border-b-2",
-    "disabled:pointer-events-none disabled:opacity-20",
+    "disabled:pointer-events-none",
     "disabled:active:translate-y-0 disabled:active:border-b-[5px] disabled:cursor-not-allowed",
     "outline-none [-webkit-tap-highlight-color:transparent]",
     "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
@@ -19,14 +19,15 @@ export const practiceButtonVariants = cva(
     variants: {
       variant: {
         primary:
-          "background-theme-color-with-opacity-100 text-white border-theme-color-darker hover:brightness-105",
+          "background-theme-color-with-opacity-100 text-white border-theme-color-darker hover:brightness-105 disabled:opacity-50",
         inverted:
-          "bg-foreground text-background border-neutral-800 dark:border-neutral-400 hover:brightness-105",
-        danger: "bg-rose-500 text-white border-rose-800 hover:brightness-105",
+          "bg-foreground text-background border-neutral-800 dark:border-neutral-400 hover:brightness-105 disabled:opacity-20",
+        danger:
+          "bg-rose-500 text-white border-rose-800 hover:brightness-105 disabled:opacity-20",
         secondary:
-          "bg-background text-foreground border-foreground/30 hover:bg-accent",
+          "bg-background text-foreground border-foreground/30 hover:bg-accent disabled:opacity-20",
         ghost:
-          "bg-transparent text-muted-foreground border-transparent border-b-transparent shadow-none active:translate-y-0 hover:text-foreground",
+          "bg-transparent text-muted-foreground border-transparent border-b-transparent shadow-none active:translate-y-0 hover:text-foreground disabled:opacity-20",
       },
       size: {
         default: "h-12 px-6 text-base",

--- a/src/components/ui/scrollable-dialog-content.tsx
+++ b/src/components/ui/scrollable-dialog-content.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import {
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+type ScrollableDialogContentProps = Omit<
+  React.ComponentPropsWithoutRef<typeof DialogContent>,
+  "title"
+> & {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  headerClassName?: string;
+  titleClassName?: string;
+  bodyClassName?: string;
+  /** Narrow modal (settings, writing practice). Default is full dialog width. */
+  size?: "md" | "default";
+  /**
+   * When false, the body is a flex slot only; children own scrolling
+   * (e.g. Sort and Filter form with a sticky footer).
+   */
+  scrollBody?: boolean;
+};
+
+const shellCn =
+  "flex max-h-[96dvh] min-h-0 flex-col gap-0 overflow-hidden px-0 py-0";
+const headerCn = "shrink-0 px-6 pt-4 pb-2";
+const scrollBodyCn = "min-h-0 flex-1 overflow-y-auto px-4 pb-6";
+const flexBodyCn = "flex min-h-0 flex-1 flex-col";
+
+export const ScrollableDialogContent = ({
+  title,
+  description,
+  children,
+  className,
+  headerClassName,
+  titleClassName,
+  bodyClassName,
+  size = "default",
+  scrollBody = true,
+  ...props
+}: ScrollableDialogContentProps) => (
+  <DialogContent
+    className={cn(shellCn, size === "md" && "max-w-md", className)}
+    {...props}
+  >
+    <DialogHeader className={cn(headerCn, headerClassName)}>
+      <DialogTitle className={cn("m-0", titleClassName)}>{title}</DialogTitle>
+      {description != null && (
+        <DialogDescription className="sr-only">{description}</DialogDescription>
+      )}
+    </DialogHeader>
+    <div className={cn(scrollBody ? scrollBodyCn : flexBodyCn, bodyClassName)}>
+      {children}
+    </div>
+  </DialogContent>
+);

--- a/src/components/ui/scrollable-dialog-content.tsx
+++ b/src/components/ui/scrollable-dialog-content.tsx
@@ -26,12 +26,6 @@ type ScrollableDialogContentProps = Omit<
   scrollBody?: boolean;
 };
 
-const shellCn =
-  "flex max-h-[96dvh] min-h-0 flex-col gap-0 overflow-hidden px-0 py-0";
-const headerCn = "shrink-0 px-6 pt-4 pb-2";
-const scrollBodyCn = "min-h-0 flex-1 overflow-y-auto px-4 pb-6";
-const flexBodyCn = "flex min-h-0 flex-1 flex-col";
-
 export const ScrollableDialogContent = ({
   title,
   description,
@@ -45,16 +39,27 @@ export const ScrollableDialogContent = ({
   ...props
 }: ScrollableDialogContentProps) => (
   <DialogContent
-    className={cn(shellCn, size === "md" && "max-w-md", className)}
+    className={cn(
+      "flex max-h-[96dvh] min-h-0 flex-col gap-0 overflow-hidden px-0 py-0",
+      size === "md" && "max-w-md",
+      className
+    )}
     {...props}
   >
-    <DialogHeader className={cn(headerCn, headerClassName)}>
+    <DialogHeader className={cn("shrink-0 px-6 pt-4 pb-2", headerClassName)}>
       <DialogTitle className={cn("m-0", titleClassName)}>{title}</DialogTitle>
       {description != null && (
         <DialogDescription className="sr-only">{description}</DialogDescription>
       )}
     </DialogHeader>
-    <div className={cn(scrollBody ? scrollBodyCn : flexBodyCn, bodyClassName)}>
+    <div
+      className={cn(
+        scrollBody
+          ? "min-h-0 flex-1 overflow-y-auto px-4 pb-6"
+          : "flex min-h-0 flex-1 flex-col",
+        bodyClassName
+      )}
+    >
       {children}
     </div>
   </DialogContent>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,22 @@
+import type { ComponentProps } from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+
+import { cn } from "@/lib/utils";
+
+export const Slider = ({
+  className,
+  ...props
+}: ComponentProps<typeof SliderPrimitive.Root>) => (
+  <SliderPrimitive.Root
+    className={cn(
+      "relative flex w-full touch-none select-none items-center",
+      className
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+);

--- a/src/hooks/use-debug-info.ts
+++ b/src/hooks/use-debug-info.ts
@@ -1,0 +1,83 @@
+import { useWindowSize } from "@/hooks/use-window-size";
+import { useNetworkState, type NetworkState } from "@/hooks/use-network-state";
+import { getUserAgentData, type UserAgentData } from "@/lib/ua-utils";
+
+declare const __BUILD_TIMESTAMP__: string;
+
+export type DebugInfoSnapshot = {
+  online: boolean;
+  effectiveType?: NetworkState["effectiveType"];
+  saveData?: boolean;
+  version: string;
+  viewportWidth: number;
+  viewportHeight: number;
+  device: UserAgentData | null;
+};
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+const formatGmtOffset = (date: Date) => {
+  const offsetMin = -date.getTimezoneOffset();
+  const sign = offsetMin >= 0 ? "+" : "-";
+  const abs = Math.abs(offsetMin);
+  return `GMT${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`;
+};
+
+export const formatCaptureTimestamp = (date = new Date()) => {
+  const timeZone =
+    Intl.DateTimeFormat().resolvedOptions().timeZone || "Unknown";
+  const local = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+  return `${local} ${formatGmtOffset(date)} (${timeZone})`;
+};
+
+export const formatDebugInfoForClipboard = (
+  info: DebugInfoSnapshot,
+  capturedAt = new Date()
+) => {
+  const network = [
+    info.online ? "online" : "offline",
+    info.effectiveType,
+    info.saveData ? "save-data" : undefined,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const lines = [
+    "Kanji Heatmap debug",
+    `Captured: ${formatCaptureTimestamp(capturedAt)}`,
+    "",
+    `Network: ${network}`,
+    `Version: ${info.version}`,
+    `Viewport: ${info.viewportWidth}×${info.viewportHeight}`,
+  ];
+
+  if (info.device) {
+    const { os, browser, platform } = info.device;
+    lines.push(
+      "",
+      `OS: ${os.name} · ${os.version} · ${platform.platform}`,
+      `Browser: ${browser.name} · ${browser.version}`
+    );
+  }
+
+  return lines.join("\n");
+};
+
+export function useDebugInfo(): DebugInfoSnapshot {
+  const { online, effectiveType, saveData } = useNetworkState();
+  const [viewportWidth, viewportHeight] = useWindowSize(0);
+  const device =
+    typeof navigator !== "undefined" && navigator.userAgent
+      ? getUserAgentData(navigator.userAgent)
+      : null;
+
+  return {
+    online,
+    effectiveType,
+    saveData,
+    version: __BUILD_TIMESTAMP__,
+    viewportWidth,
+    viewportHeight,
+    device,
+  };
+}

--- a/src/hooks/use-stroke-animation-settings.ts
+++ b/src/hooks/use-stroke-animation-settings.ts
@@ -1,0 +1,25 @@
+import { useLocalStorage } from "@/hooks/use-local-storage";
+import { notifyStorage } from "@/lib/storage";
+import {
+  DEFAULT_STROKE_ANIMATION_SETTINGS,
+  STROKE_ANIMATION_SETTINGS_KEY,
+  normalizeStrokeAnimationSettings,
+  type StrokeAnimationSettings,
+} from "@/lib/stroke-animation-settings";
+
+export const useStrokeAnimationSettings = () => {
+  const [raw, setItem] = useLocalStorage<StrokeAnimationSettings>(
+    STROKE_ANIMATION_SETTINGS_KEY,
+    DEFAULT_STROKE_ANIMATION_SETTINGS
+  );
+
+  const reset = () => {
+    localStorage.setItem(
+      STROKE_ANIMATION_SETTINGS_KEY,
+      JSON.stringify(DEFAULT_STROKE_ANIMATION_SETTINGS)
+    );
+    notifyStorage(STROKE_ANIMATION_SETTINGS_KEY);
+  };
+
+  return [normalizeStrokeAnimationSettings(raw), setItem, reset] as const;
+};

--- a/src/lib/cn-fns.ts
+++ b/src/lib/cn-fns.ts
@@ -47,9 +47,6 @@ const ALT_BORDER_CN = [
   "border-theme-color-with-opacity-75",
 ] as const;
 
-const ALT_BIG_TILE_CN = "!border-8 !rounded-xl motion-reduce:transition-none";
-const ALT_SMALL_TILE_CN = "!border-4 !rounded-lg motion-reduce:transition-none";
-
 const cnGradientAlt = () => {
   // Skip 0/100 so tiles stay mid-opacity — pulse reads on every tile.
   const bg = freqCategoryCn[selectRandom([1, 2, 3] as const)] ?? 0;
@@ -58,9 +55,9 @@ const cnGradientAlt = () => {
 };
 
 export const randomCnGradientAlt = () => {
-  return `${cnGradientAlt()} ${ALT_BIG_TILE_CN}`;
+  return `${cnGradientAlt()} !border-8 !rounded-xl motion-reduce:transition-none`;
 };
 
 export const randomCn2GradientAlt = () => {
-  return `${cnGradientAlt()} ${ALT_SMALL_TILE_CN}`;
+  return `${cnGradientAlt()} !border-4 !rounded-lg motion-reduce:transition-none`;
 };

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -195,6 +195,7 @@ export const externalLinks: { name: string; url: (x: string) => string }[] = [
 // https: //www.verbix.com/webverbix/japanese/miru
 
 export const outLinks = {
+  site: "https://kanjiheatmap.com",
   githubIssue: "https://github.com/PikaPikaGems/kanji-heatmap/issues/241",
   githubContentIssue:
     "https://github.com/PikaPikaGems/kanji-heatmap-data/issues/27",
@@ -211,7 +212,94 @@ export const otherOutLinks = {
   webSpeechApi:
     "https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesis",
   jmdictFurigana: "https://github.com/Doublevil/JmdictFurigana",
+  dakanji: "https://github.com/dariyooo/DaKanji-Single-Kanji-Recognition",
+  googleHandwriting:
+    "https://www.google.com/inputtools/services/features/handwriting.html",
+  kanjiCanvas: "https://github.com/asdfjkl/kanjicanvas",
+  jlpt: "https://jlpt.jp",
+  jpWordRanksAbout: "https://pikapikagems.github.io/japanese-word-ranks/about/",
+  kanjidistVisualiser:
+    "https://github.com/lennart-finke/kanjidist-visualiser/blob/master/data/dkanjistat.json",
+  yenckenKanjiConfusion: "https://lars.yencken.org/datasets/kanji-confusion/",
+  kanjium:
+    "https://github.com/mifunetoshiro/kanjium/blob/master/data/source_files/kanjidict.txt",
+  lorenziJishoOpen:
+    "https://raw.githubusercontent.com/hlorenzi/jisho-open/main/backend/src/data/kanji_structural_category.ts",
+  yagaysKanjiVgRadical:
+    "https://github.com/yagays/kanjivg-radical/blob/master/data/kanji2radical.json",
+  scottKanjiBakuhatsu:
+    "https://github.com/ScottOglesby/kanji-bakuhatsu/blob/master/raw/kanji-composition-map.txt",
+  topoKanji: "https://github.com/scriptin/topokanji",
+  ankiDeck1564742924: "https://ankiweb.net/shared/info/1564742924",
+  ankiDeck779483253: "https://ankiweb.net/shared/info/779483253",
+  ankiDeck2106223612: "https://ankiweb.net/shared/info/2106223612",
+  ankiDeck1468618470: "https://ankiweb.net/shared/info/1468618470",
+  kanjiMasteryBlog: "https://kanjimastery.blogspot.com/",
 };
+
+export const similarKanjiSourceLinks = [
+  {
+    text: "lennart-finke/kanjidist-visualiser",
+    url: otherOutLinks.kanjidistVisualiser,
+  },
+  {
+    text: "Yencken, Lars (2010) Orthographic support for passing the reading hurdle in Japanese. PhD Thesis, University of Melbourne, Melbourne, Australia",
+    url: otherOutLinks.yenckenKanjiConfusion,
+  },
+];
+
+export const structureSourceLinks = [
+  {
+    text: "mifunetoshiro/kanjium",
+    url: otherOutLinks.kanjium,
+  },
+  {
+    text: "hlorenzi/jisho-open",
+    url: otherOutLinks.lorenziJishoOpen,
+  },
+  {
+    text: "yagays/kanjivg-radical",
+    url: otherOutLinks.yagaysKanjiVgRadical,
+  },
+  {
+    text: "ScottOglesby/kanji-bakuhatsu",
+    url: otherOutLinks.scottKanjiBakuhatsu,
+  },
+  {
+    text: "scriptin/topokanji",
+    url: otherOutLinks.topoKanji,
+  },
+];
+
+export const textbookVocabSourceLinks = [
+  {
+    text: "Anki Deck: 1564742924",
+    url: otherOutLinks.ankiDeck1564742924,
+  },
+  {
+    text: "Anki Deck: 779483253",
+    url: otherOutLinks.ankiDeck779483253,
+  },
+  {
+    text: "Anki Deck: 2106223612",
+    url: otherOutLinks.ankiDeck2106223612,
+  },
+  {
+    text: "Anki Deck: 1468618470",
+    url: otherOutLinks.ankiDeck1468618470,
+  },
+  {
+    text: "Kanji Mastery Blog",
+    url: otherOutLinks.kanjiMasteryBlog,
+  },
+];
+
+export const sampleVocabSourceLinks = [
+  {
+    text: "JP Word Ranks Lookup",
+    url: otherOutLinks.jpWordRanksAbout,
+  },
+];
 
 export const vocabExternalLinksCore = [
   {

--- a/src/lib/external-links.ts
+++ b/src/lib/external-links.ts
@@ -4,11 +4,6 @@ export const kanshudoFn = (kanji: string) =>
 
 export const jitenMoeFn = (kanji: string) => `https://jiten.moe/kanji/${kanji}`;
 export const externalLinks: { name: string; url: (x: string) => string }[] = [
-  {
-    name: "Kagi Translate",
-    url: (kanji: string) =>
-      `https://translate.kagi.com/?from=ja&to=en&text=${kanji}`,
-  },
   { name: "⭐️ JPDB.io", url: jpdbFn },
   {
     name: "⭐️ Jiten.Moe",
@@ -98,6 +93,10 @@ export const externalLinks: { name: string; url: (x: string) => string }[] = [
   {
     name: "Uchiwakekanji Explosion",
     url: (kanji: string) => `https://uchiwakekanji.github.io/jp/?k=${kanji}`,
+  },
+  {
+    name: "Hanabira",
+    url: (kanji: string) => `https://hanabira.org/kanji/${kanji}`,
   },
   {
     name: "Romaji Desu",
@@ -241,11 +240,6 @@ export const vocabExternalLinksCore = [
     name: "Jiten.Moe",
 
     url: (word: string) => `https://jiten.moe/parse?text=${word}&parsed=true`,
-  },
-  {
-    name: "Kagi Translate",
-    url: (word: string) =>
-      `https://translate.kagi.com/?from=ja&to=en&text=${word}`,
   },
 ];
 

--- a/src/lib/force-hard-refresh.ts
+++ b/src/lib/force-hard-refresh.ts
@@ -1,0 +1,22 @@
+/** Last-resort refresh: new app shell, same URL state, keep runtime caches. */
+export async function forceHardRefresh() {
+  const url = new URL(window.location.href);
+  // Bust HTTP cache of index.html without dropping search params.
+  url.searchParams.set("nocache", String(Date.now()));
+
+  // Stop a stuck SW from serving the old shell on the next navigation.
+  const regs = await navigator.serviceWorker?.getRegistrations?.();
+  if (regs) await Promise.all(regs.map((r) => r.unregister()));
+
+  // Precache is html/js/css only. Leave SVG, JSON, fonts, ONNX, etc.
+  if ("caches" in window) {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys
+        .filter((k) => k.startsWith("workbox-precache"))
+        .map((k) => caches.delete(k))
+    );
+  }
+
+  window.location.replace(url.toString());
+}

--- a/src/lib/stroke-animation-settings.ts
+++ b/src/lib/stroke-animation-settings.ts
@@ -1,0 +1,50 @@
+export const STROKE_ANIMATION_SETTINGS_KEY = "stroke-animation-settings";
+
+export const SLOW_SPEED_MIN = 0.2;
+export const SLOW_SPEED_MAX = 1.0;
+export const FAST_SPEED_MIN = 1.0;
+export const FAST_SPEED_MAX = 5.0;
+export const SPEED_STEP = 0.1;
+
+export type StrokeAnimationSettings = {
+  showStrokeOrderNumbers: boolean;
+  /** Speed factor for the snail button. Lower is slower (0.2–1.0). */
+  slowSpeed: number;
+  /** Speed factor for the play button. Higher is faster (1.0–5.0). */
+  fastSpeed: number;
+};
+
+export const DEFAULT_STROKE_ANIMATION_SETTINGS: StrokeAnimationSettings = {
+  showStrokeOrderNumbers: false,
+  slowSpeed: SLOW_SPEED_MAX,
+  fastSpeed: FAST_SPEED_MIN,
+};
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+const clamp = (n: unknown, min: number, max: number, fallback: number) => {
+  const v = typeof n === "number" ? n : Number(n);
+  if (!Number.isFinite(v)) return fallback;
+  return round1(Math.min(max, Math.max(min, v)));
+};
+
+/** Merge + clamp a stored blob so missing or junk keys don't break replay. */
+export const normalizeStrokeAnimationSettings = (
+  raw: Partial<StrokeAnimationSettings> | null | undefined
+): StrokeAnimationSettings => ({
+  showStrokeOrderNumbers:
+    raw?.showStrokeOrderNumbers ??
+    DEFAULT_STROKE_ANIMATION_SETTINGS.showStrokeOrderNumbers,
+  slowSpeed: clamp(
+    raw?.slowSpeed,
+    SLOW_SPEED_MIN,
+    SLOW_SPEED_MAX,
+    DEFAULT_STROKE_ANIMATION_SETTINGS.slowSpeed
+  ),
+  fastSpeed: clamp(
+    raw?.fastSpeed,
+    FAST_SPEED_MIN,
+    FAST_SPEED_MAX,
+    DEFAULT_STROKE_ANIMATION_SETTINGS.fastSpeed
+  ),
+});


### PR DESCRIPTION
## Summary

- **External links:** Remove Kagi Translate; add Hanabira; reorder Jotoba before Jisho; centralize credit/source URLs in `external-links.ts`.
- **Word popover:** Cap visible links at 6 with a “see more” overflow.
- **Practice UX:** Show the full word (not just kanji) in the production reveal drawer; tighten input layout; fix disabled primary button visibility in light mode; add padding on “Continue without recognition”; refactor production practice to early-return phase routing (no `renderPhase()`).
- **Writing practice:** Bouncing emoji on loading screen; fix `[?]` help padding/font; add a short success animation inside the drawing pad on correct answers (“Awesome · That's 合”).
- **Stroke order:** Persisted settings (speed, show numbers, snail speed) via local storage; shared cog popover for animation controls.
- **Offline cache:** Replace toggle switch with explicit download / cancel / clear actions for SVG cache.
- **Debug info:** Copy-to-clipboard button with capture timestamp.
- **Hard refresh:** Replace `location.reload` with a shell-busting hard refresh helper.
- **Modals & dialogs:** Shared scrollable dialog shell; sticky close button in user-preference modals.
- **Code hygiene:** Inline one-off Tailwind `_CN` constants; dedupe vocabulary table header/skeleton; update Cursor rules (`inline-tailwind-classes`, `react-single-responsibility-screens`, `concise-answers`).

## Test plan

- [ ] Kanji details → word popover: at most 6 links visible; “see more” expands the rest; Jotoba appears before Jisho; Hanabira link present; no Kagi Translate
- [ ] Production practice: reveal drawer shows full word; input layout looks correct; disabled primary button readable in light mode
- [ ] Writing practice: loading screen shows bouncing emoji; `[?]` help readable; correct answer shows pad animation + “Awesome · That's …” copy
- [ ] Stroke animation (details + practice): cog opens speed/numbers settings; preferences persist after reload
- [ ] Settings → offline cache: download / cancel / clear actions work; no switch UI
- [ ] Debug info popover: copy button copies snapshot with timestamp
- [ ] Refresh / error recovery: hard refresh busts app shell (not plain reload)
- [ ] Sort & filter / settings modals: close button stays sticky while scrolling
- [ ] `pnpm run lint && pnpm run typecheck && CF_PAGES=1 pnpm build`
- [ ] `pnpm test:e2e` — practice spec updated for “Continue” button label


Made with [Cursor](https://cursor.com)