### PR TITLE
Polish dashboard activity stats and heatmap layout controls

### DIFF
--- a/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCalendarHeatmap.tsx
@@ -1,4 +1,4 @@
-import { useId } from "react";
+import { CalendarDays } from "lucide-react";
 import {
   ActivityByDay,
   ActivityKindFilters,
@@ -12,9 +12,8 @@ import {
 } from "@/lib/activity";
 import { useActivityData } from "@/hooks/use-activity-data";
 import { useActivityHeatmapSettings } from "@/hooks/use-activity-heatmap-settings";
-import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
 import { SectionHeading } from "./SectionHeading";
+import { ActivityCalendarHeatmapSettingsPopover } from "./ActivityCalendarHeatmapSettingsPopover";
 import { ActivityCountsGrid } from "./ActivityCountsGrid";
 import { ActivityKindFiltersRow } from "./ActivityKindFiltersRow";
 import { DurationNav } from "./DurationNav";
@@ -22,6 +21,8 @@ import { CalendarGrid } from "./CalendarGrid";
 import { VerticalCalendarGrid } from "./VerticalCalendarGrid";
 import { DashboardPanel } from "./DashboardPanel";
 import { GradientLegend } from "@/components/common/GradientLegend";
+import { OverviewCaption } from "./OverviewStat";
+import { formatRawCount } from "@/lib/format-count";
 
 const ActivityHeatmapGrid = ({
   vertical,
@@ -63,7 +64,6 @@ export const ActivityCalendarHeatmap = () => {
   const { byDay } = useActivityData();
   const [{ duration, filters, vertical }, setSetting] =
     useActivityHeatmapSettings();
-  const layoutSwitchId = useId();
 
   const range = getDurationRange(duration);
   const maxN = maxDayTotalInRange(byDay, range, filters);
@@ -71,64 +71,53 @@ export const ActivityCalendarHeatmap = () => {
 
   return (
     <DashboardPanel>
-      <SectionHeading
-        title="Activity Heatmap"
-        description="Daily practice events. Brighter days mean more activity relative to your busiest day in this range."
-      />
+      <div key={vertical ? "compact" : "wide"} className="animate-fade-in">
+        <SectionHeading
+          title="Activity Heatmap"
+          description="Daily practice events. Brighter days mean more activity relative to your busiest day in this range."
+        />
 
-      <DurationNav
-        value={duration}
-        onChange={(next) => setSetting("duration", next)}
-      />
+        <DurationNav
+          value={duration}
+          onChange={(next) => setSetting("duration", next)}
+        />
 
-      <ActivityHeatmapGrid
-        vertical={vertical}
-        range={range}
-        byDay={byDay}
-        filters={filters}
-        maxN={maxN}
-      />
-
-      <div className="mt-2">
-        <ActivityKindFiltersRow
+        <ActivityHeatmapGrid
+          vertical={vertical}
+          range={range}
+          byDay={byDay}
           filters={filters}
-          onChange={(kind, checked) =>
-            setSetting("filters", { ...filters, [kind]: checked })
-          }
+          maxN={maxN}
         />
-      </div>
-      <div className="flex items-center justify-center w-full mt-4">
-        <div>
-          <GradientLegend />
+
+        <div className="mt-2">
+          <ActivityKindFiltersRow
+            filters={filters}
+            onChange={(kind, checked) =>
+              setSetting("filters", { ...filters, [kind]: checked })
+            }
+          />
         </div>
-      </div>
+        <div className="flex items-center justify-center w-full mt-4 mb-4">
+          <div className="flex items-center gap-1">
+            <GradientLegend /> ·
+            <ActivityCalendarHeatmapSettingsPopover />
+          </div>
+        </div>
 
-      <div className="flex items-center justify-center gap-2 mb-4 text-xs text-muted-foreground">
-        <Label
-          htmlFor={layoutSwitchId}
-          className={!vertical ? "text-foreground font-semibold" : undefined}
-        >
-          Wide
-        </Label>
-        <Switch
-          id={layoutSwitchId}
-          checked={vertical}
-          onCheckedChange={(checked) => setSetting("vertical", checked)}
-          aria-label="Toggle compact activity heatmap"
-        />
-        <Label
-          htmlFor={layoutSwitchId}
-          className={vertical ? "text-foreground font-semibold" : undefined}
-        >
-          Compact
-        </Label>
-      </div>
-
-      <div className="mt-6">
-        <p className="mb-3 text-xs tracking-wide text-center text-muted-foreground">
-          In this period
-        </p>
-        <ActivityCountsGrid stats={windowed} />
+        <div className="mt-6">
+          <p className="mb-3 text-xs tracking-wide text-center text-muted-foreground">
+            In this period
+          </p>
+          <ActivityCountsGrid stats={windowed} />
+          <div className="mt-4">
+            <OverviewCaption
+              Icon={CalendarDays}
+              label="Days active"
+              value={formatRawCount(windowed.daysActive)}
+            />
+          </div>
+        </div>
       </div>
     </DashboardPanel>
   );

--- a/src/components/screens/DashboardScreen/ActivityCalendarHeatmapSettingsPopover.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCalendarHeatmapSettingsPopover.tsx
@@ -1,0 +1,58 @@
+import { useId } from "react";
+import { Settings } from "lucide-react";
+import { GenericPopover } from "@/components/common/GenericPopover";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { useActivityHeatmapSettings } from "@/hooks/use-activity-heatmap-settings";
+
+export const ActivityCalendarHeatmapSettingsPopover = () => {
+  const [{ vertical }, setSetting] = useActivityHeatmapSettings();
+  const layoutSwitchId = useId();
+
+  return (
+    <GenericPopover
+      contentClassName="m-0 p-0 max-w-56"
+      trigger={
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="p-2 rounded-xl bg-background"
+          aria-label="Activity heatmap settings bg-red-500"
+        >
+          <Settings className="size-2" />
+        </Button>
+      }
+      content={
+        <div className="p-5 space-y-3 text-left">
+          <div className="text-xs font-extrabold uppercase text-muted-foreground">
+            Layout
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Label
+              htmlFor={layoutSwitchId}
+              className={
+                !vertical ? "text-foreground font-semibold" : undefined
+              }
+            >
+              Wide
+            </Label>
+            <Switch
+              id={layoutSwitchId}
+              checked={vertical}
+              onCheckedChange={(checked) => setSetting("vertical", checked)}
+              aria-label="Toggle compact activity heatmap"
+            />
+            <Label
+              htmlFor={layoutSwitchId}
+              className={vertical ? "text-foreground font-semibold" : undefined}
+            >
+              Compact
+            </Label>
+          </div>
+        </div>
+      }
+    />
+  );
+};

--- a/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
+++ b/src/components/screens/DashboardScreen/ActivityCountsGrid.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, Eye, Keyboard, PenLine } from "lucide-react";
+import { Eye, Keyboard, PenLine } from "lucide-react";
 import {
   productionPracticePageMeta,
   recognitionPracticePageMeta,
@@ -7,7 +7,6 @@ import {
 import { OverviewStat } from "./OverviewStat";
 
 export type ActivityCountsDisplay = {
-  daysActive: number;
   speedKatakanaDays: number;
   productionDays: number;
   recognitionDays: number;
@@ -16,40 +15,40 @@ export type ActivityCountsDisplay = {
   recognitionRounds: number;
 };
 
-/** Day totals (2×2 / 4-up) + session/round totals (3-up centered text / capped row). */
+const COUNTS_ROW_CN =
+  "grid grid-cols-3 gap-2 sm:flex sm:flex-row sm:flex-wrap sm:justify-center sm:gap-3";
+
+/** Day totals + session/round totals (3-up centered text / capped row). */
 export const ActivityCountsGrid = ({
   stats,
 }: {
   stats: ActivityCountsDisplay;
 }) => (
   <div className="flex flex-col gap-2 sm:gap-3">
-    <div className="grid grid-cols-2 gap-2 justify-items-start sm:grid-cols-4 sm:gap-3">
-      <OverviewStat
-        value={stats.daysActive}
-        title="Total"
-        unit="Days"
-        Icon={CalendarDays}
-      />
+    <div className={COUNTS_ROW_CN}>
       <OverviewStat
         value={stats.productionDays}
         title={productionPracticePageMeta.shortLabel}
         unit="Days"
         Icon={PenLine}
+        compact
       />
       <OverviewStat
         value={stats.recognitionDays}
         title={recognitionPracticePageMeta.shortLabel}
         unit="Days"
         Icon={Eye}
+        compact
       />
       <OverviewStat
         value={stats.speedKatakanaDays}
         title={speedKatakanaPageMeta.shortLabel}
         unit="Days"
         Icon={Keyboard}
+        compact
       />
     </div>
-    <div className="grid grid-cols-3 gap-2 sm:flex sm:flex-row sm:flex-wrap sm:justify-center sm:gap-3">
+    <div className={COUNTS_ROW_CN}>
       <OverviewStat
         value={stats.productionRounds}
         title={productionPracticePageMeta.shortLabel}

--- a/src/components/screens/DashboardScreen/OverviewStat.tsx
+++ b/src/components/screens/DashboardScreen/OverviewStat.tsx
@@ -54,6 +54,23 @@ const StatValue = ({
   );
 };
 
+export const OverviewCaption = ({
+  Icon,
+  label,
+  value,
+}: {
+  Icon: LucideIcon;
+  label: string;
+  value: string;
+}) => (
+  <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+    <Icon className="size-4 shrink-0" aria-hidden />
+    <span>
+      {label}: <span className="font-bold text-foreground">{value}</span>
+    </span>
+  </div>
+);
+
 export const OverviewStat = ({
   value,
   title,

--- a/src/components/screens/DashboardScreen/StatsOverview.tsx
+++ b/src/components/screens/DashboardScreen/StatsOverview.tsx
@@ -1,9 +1,11 @@
-import { Cake } from "lucide-react";
+import { Cake, CalendarDays } from "lucide-react";
 import { formatCakeDay } from "@/lib/activity";
 import { useActivityData } from "@/hooks/use-activity-data";
+import { formatRawCount } from "@/lib/format-count";
 import { SectionHeading } from "./SectionHeading";
 import { ActivityCountsGrid } from "./ActivityCountsGrid";
 import { DashboardPanel } from "./DashboardPanel";
+import { OverviewCaption } from "./OverviewStat";
 
 export const StatsOverview = () => {
   const {
@@ -22,7 +24,6 @@ export const StatsOverview = () => {
       />
       <ActivityCountsGrid
         stats={{
-          daysActive,
           speedKatakanaDays,
           productionDays,
           recognitionDays,
@@ -31,14 +32,18 @@ export const StatsOverview = () => {
           recognitionRounds: allTime.recognitionRounds,
         }}
       />
-      <div className="flex items-center justify-center gap-2 mt-4 text-sm text-muted-foreground">
-        <Cake className="size-4 shrink-0" aria-hidden />
-        <span>
-          Cake day:{" "}
-          <span className="font-bold text-foreground">
-            {allTime.cakeDay ? formatCakeDay(allTime.cakeDay) : "Not yet"}
-          </span>
-        </span>
+      <div className="flex flex-col justify-center w-full gap-2 mt-4 sm:flex-row">
+        <OverviewCaption
+          Icon={CalendarDays}
+          label="Days active"
+          value={formatRawCount(daysActive)}
+        />
+        <div className="hidden sm:flex">·</div>
+        <OverviewCaption
+          Icon={Cake}
+          label="Cake day"
+          value={allTime.cakeDay ? formatCakeDay(allTime.cakeDay) : "Not yet"}
+        />
       </div>
     </DashboardPanel>
   );


### PR DESCRIPTION
## Summary
- Move the activity heatmap wide/compact toggle into a settings popover beside the gradient legend
- Simplify the activity counts grid to three practice columns and show days active as a shared caption below stats
- Add a fade-in transition when switching heatmap layout and reuse `OverviewCaption` in both overview and heatmap sections

## Test plan
- [ ] Open Dashboard → All-time Overview: verify three day-count cards and sessions/rounds rows; confirm "Days active" and "Cake day" captions render below
- [ ] Open Activity Heatmap: open settings popover and toggle Wide/Compact; confirm layout updates with fade-in
- [ ] Confirm "In this period" section shows practice counts and a days-active caption for the selected range
- [ ] Check mobile and desktop layouts for the counts grid and captions


Made with [Cursor](https://cursor.com)